### PR TITLE
feat: add redis-run example CLI for standalone, cluster, and sentinel topologies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,12 @@ rust-version = "1.87"
 thiserror = "2"
 which = "7"
 
+[dev-dependencies]
+clap = { version = "4", features = ["derive"] }
+ctrlc = "3"
+
+[[example]]
+name = "redis-run"
+path = "examples/redis-run.rs"
+
 [workspace]

--- a/examples/redis-run.rs
+++ b/examples/redis-run.rs
@@ -1,0 +1,170 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use clap::{Parser, Subcommand};
+use redis_server_wrapper::{RedisCluster, RedisSentinel, RedisServer};
+
+#[derive(Parser)]
+#[command(
+    name = "redis-run",
+    about = "Run Redis standalone, cluster, or sentinel topologies"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Start a standalone Redis server
+    Standalone {
+        /// Port to listen on
+        #[arg(short, long, default_value_t = 6379)]
+        port: u16,
+
+        /// Address to bind to
+        #[arg(short, long, default_value = "127.0.0.1")]
+        bind: String,
+    },
+
+    /// Start a Redis Cluster
+    Cluster {
+        /// Number of master nodes
+        #[arg(short, long, default_value_t = 3)]
+        masters: u16,
+
+        /// Number of replicas per master
+        #[arg(short, long, default_value_t = 0)]
+        replicas_per_master: u16,
+
+        /// Starting port for cluster nodes
+        #[arg(long, default_value_t = 7000)]
+        base_port: u16,
+
+        /// Address to bind to
+        #[arg(short, long, default_value = "127.0.0.1")]
+        bind: String,
+    },
+
+    /// Start a Redis Sentinel topology
+    Sentinel {
+        /// Name for the monitored master
+        #[arg(long, default_value = "mymaster")]
+        master_name: String,
+
+        /// Port for the master node
+        #[arg(long, default_value_t = 6390)]
+        master_port: u16,
+
+        /// Number of replica nodes
+        #[arg(short, long, default_value_t = 2)]
+        replicas: u16,
+
+        /// Starting port for replicas
+        #[arg(long, default_value_t = 6391)]
+        replica_base_port: u16,
+
+        /// Number of sentinel processes
+        #[arg(short, long, default_value_t = 3)]
+        sentinels: u16,
+
+        /// Starting port for sentinels
+        #[arg(long, default_value_t = 26389)]
+        sentinel_base_port: u16,
+
+        /// Quorum count for failover decisions
+        #[arg(short, long, default_value_t = 2)]
+        quorum: u16,
+
+        /// Address to bind to
+        #[arg(short, long, default_value = "127.0.0.1")]
+        bind: String,
+    },
+}
+
+fn wait_for_ctrl_c() {
+    let running = Arc::new(AtomicBool::new(true));
+    let r = running.clone();
+    ctrlc::set_handler(move || {
+        r.store(false, Ordering::SeqCst);
+    })
+    .expect("failed to set ctrl-c handler");
+
+    println!("Press Ctrl-C to shut down...");
+    while running.load(Ordering::SeqCst) {
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    println!("Shutting down...");
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Command::Standalone { port, bind } => {
+            let server = RedisServer::new().port(port).bind(&bind).start()?;
+            server.wait_for_ready(Duration::from_secs(10))?;
+            println!("Standalone Redis server running at {}", server.addr());
+            wait_for_ctrl_c();
+            drop(server);
+        }
+
+        Command::Cluster {
+            masters,
+            replicas_per_master,
+            base_port,
+            bind,
+        } => {
+            let cluster = RedisCluster::builder()
+                .masters(masters)
+                .replicas_per_master(replicas_per_master)
+                .base_port(base_port)
+                .bind(&bind)
+                .start()?;
+            cluster.wait_for_healthy(Duration::from_secs(30))?;
+            println!("Redis Cluster running:");
+            for addr in cluster.node_addrs() {
+                println!("  - {addr}");
+            }
+            wait_for_ctrl_c();
+            drop(cluster);
+        }
+
+        Command::Sentinel {
+            master_name,
+            master_port,
+            replicas,
+            replica_base_port,
+            sentinels,
+            sentinel_base_port,
+            quorum,
+            bind,
+        } => {
+            let sentinel = RedisSentinel::builder()
+                .master_name(&master_name)
+                .master_port(master_port)
+                .replicas(replicas)
+                .replica_base_port(replica_base_port)
+                .sentinels(sentinels)
+                .sentinel_base_port(sentinel_base_port)
+                .quorum(quorum)
+                .bind(&bind)
+                .start()?;
+            sentinel.wait_for_healthy(Duration::from_secs(30))?;
+            println!(
+                "Redis Sentinel topology running (master: {} at {})",
+                master_name,
+                sentinel.master_addr()
+            );
+            println!("Sentinels:");
+            for addr in sentinel.sentinel_addrs() {
+                println!("  - {addr}");
+            }
+            wait_for_ctrl_c();
+            drop(sentinel);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Added `examples/redis-run.rs` CLI example using `clap` with subcommands for standalone, cluster, and sentinel Redis topologies
- Each subcommand exposes key configuration options (port, bind, masters, replicas, quorum, etc.) with sensible defaults
- The tool starts the topology, prints connection info, and blocks on ctrl-c before graceful shutdown
- Added `clap` and `ctrlc` as dev-dependencies in `Cargo.toml`

## Files changed

- `Cargo.toml` -- added `clap` and `ctrlc` dev-dependencies and `[[example]]` entry for `redis-run`
- `examples/redis-run.rs` -- new CLI example with standalone, cluster, and sentinel subcommands

## Test plan

- [x] `cargo check --example redis-run` compiles cleanly
- [x] `cargo clippy --example redis-run --all-features -- -D warnings` passes with no warnings
- [x] `cargo fmt --all -- --check` passes
- [ ] Manual: `cargo run --example redis-run -- standalone` starts a Redis server and shuts down on ctrl-c
- [ ] Manual: `cargo run --example redis-run -- cluster` starts a Redis cluster
- [ ] Manual: `cargo run --example redis-run -- sentinel` starts a Redis sentinel topology

Closes #1