### PR TITLE
feat(server): convert RedisServer to async closes #9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.87"
 
 [dependencies]
 thiserror = "2"
-tokio = { version = "1", features = ["process", "time", "rt"] }
+tokio = { version = "1", features = ["process", "time", "rt", "macros", "rt-multi-thread"] }
 which = "7"
 
 [dev-dependencies]

--- a/examples/redis-run.rs
+++ b/examples/redis-run.rs
@@ -98,13 +98,14 @@ fn wait_for_ctrl_c() {
     println!("Shutting down...");
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     match cli.command {
         Command::Standalone { port, bind } => {
-            let server = RedisServer::new().port(port).bind(&bind).start()?;
-            server.wait_for_ready(Duration::from_secs(10))?;
+            let server = RedisServer::new().port(port).bind(&bind).start().await?;
+            server.wait_for_ready(Duration::from_secs(10)).await?;
             println!("Standalone Redis server running at {}", server.addr());
             wait_for_ctrl_c();
             drop(server);
@@ -121,8 +122,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .replicas_per_master(replicas_per_master)
                 .base_port(base_port)
                 .bind(&bind)
-                .start()?;
-            cluster.wait_for_healthy(Duration::from_secs(30))?;
+                .start()
+                .await?;
+            cluster.wait_for_healthy(Duration::from_secs(30)).await?;
             println!("Redis Cluster running:");
             for addr in cluster.node_addrs() {
                 println!("  - {addr}");
@@ -150,8 +152,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .sentinel_base_port(sentinel_base_port)
                 .quorum(quorum)
                 .bind(&bind)
-                .start()?;
-            sentinel.wait_for_healthy(Duration::from_secs(30))?;
+                .start()
+                .await?;
+            sentinel.wait_for_healthy(Duration::from_secs(30)).await?;
             println!(
                 "Redis Sentinel topology running (master: {} at {})",
                 master_name,

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -13,15 +13,18 @@ use crate::server::{RedisServer, RedisServerHandle};
 /// ```no_run
 /// use redis_server_wrapper::RedisCluster;
 ///
+/// # async fn example() {
 /// let cluster = RedisCluster::builder()
 ///     .masters(3)
 ///     .replicas_per_master(1)
 ///     .base_port(7000)
 ///     .start()
+///     .await
 ///     .unwrap();
 ///
-/// assert!(cluster.is_healthy());
+/// assert!(cluster.is_healthy().await);
 /// // Stopped automatically on Drop.
+/// # }
 /// ```
 pub struct RedisClusterBuilder {
     masters: u16,
@@ -74,7 +77,7 @@ impl RedisClusterBuilder {
     }
 
     /// Start all nodes and form the cluster.
-    pub fn start(self) -> Result<RedisClusterHandle> {
+    pub async fn start(self) -> Result<RedisClusterHandle> {
         // Stop any leftover nodes from previous runs.
         for port in self.ports() {
             RedisCli::new()
@@ -83,7 +86,7 @@ impl RedisClusterBuilder {
                 .port(port)
                 .shutdown();
         }
-        std::thread::sleep(Duration::from_millis(500));
+        tokio::time::sleep(Duration::from_millis(500)).await;
 
         // Start each node.
         let mut nodes = Vec::new();
@@ -96,7 +99,8 @@ impl RedisClusterBuilder {
                 .cluster_node_timeout(5000)
                 .redis_server_bin(&self.redis_server_bin)
                 .redis_cli_bin(&self.redis_cli_bin)
-                .start()?;
+                .start()
+                .await?;
             nodes.push(handle);
         }
 
@@ -106,10 +110,11 @@ impl RedisClusterBuilder {
             .bin(&self.redis_cli_bin)
             .host(&self.bind)
             .port(self.base_port);
-        cli.cluster_create(&node_addrs, self.replicas_per_master)?;
+        cli.cluster_create(&node_addrs, self.replicas_per_master)
+            .await?;
 
         // Wait for convergence.
-        std::thread::sleep(Duration::from_secs(2));
+        tokio::time::sleep(Duration::from_secs(2)).await;
 
         Ok(RedisClusterHandle {
             nodes,
@@ -157,14 +162,19 @@ impl RedisClusterHandle {
     }
 
     /// Check if all nodes are alive.
-    pub fn all_alive(&self) -> bool {
-        self.nodes.iter().all(|n| n.is_alive())
+    pub async fn all_alive(&self) -> bool {
+        for node in &self.nodes {
+            if !node.is_alive().await {
+                return false;
+            }
+        }
+        true
     }
 
     /// Check CLUSTER INFO for state=ok and all slots assigned.
-    pub fn is_healthy(&self) -> bool {
+    pub async fn is_healthy(&self) -> bool {
         for node in &self.nodes {
-            if let Ok(info) = node.run(&["CLUSTER", "INFO"]) {
+            if let Ok(info) = node.run(&["CLUSTER", "INFO"]).await {
                 if info.contains("cluster_state:ok") && info.contains("cluster_slots_ok:16384") {
                     return true;
                 }
@@ -174,10 +184,10 @@ impl RedisClusterHandle {
     }
 
     /// Wait until the cluster is healthy or timeout.
-    pub fn wait_for_healthy(&self, timeout: Duration) -> Result<()> {
+    pub async fn wait_for_healthy(&self, timeout: Duration) -> Result<()> {
         let start = std::time::Instant::now();
         loop {
-            if self.is_healthy() {
+            if self.is_healthy().await {
                 return Ok(());
             }
             if start.elapsed() > timeout {
@@ -185,7 +195,7 @@ impl RedisClusterHandle {
                     message: "cluster did not become healthy in time".into(),
                 });
             }
-            std::thread::sleep(Duration::from_millis(500));
+            tokio::time::sleep(Duration::from_millis(500)).await;
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,14 +27,17 @@
 //! ```no_run
 //! use redis_server_wrapper::RedisServer;
 //!
+//! # async fn example() {
 //! let server = RedisServer::new()
 //!     .port(6400)
 //!     .bind("127.0.0.1")
 //!     .start()
+//!     .await
 //!     .unwrap();
 //!
-//! assert!(server.is_alive());
+//! assert!(server.is_alive().await);
 //! // Stopped automatically on Drop.
+//! # }
 //! ```
 //!
 //! # Configuration
@@ -46,6 +49,7 @@
 //! ```no_run
 //! use redis_server_wrapper::{LogLevel, RedisServer};
 //!
+//! # async fn example() {
 //! let server = RedisServer::new()
 //!     .port(6400)
 //!     .bind("127.0.0.1")
@@ -55,7 +59,9 @@
 //!     .extra("maxmemory", "256mb")
 //!     .extra("maxmemory-policy", "allkeys-lru")
 //!     .start()
+//!     .await
 //!     .unwrap();
+//! # }
 //! ```
 //!
 //! # Running Commands
@@ -66,11 +72,13 @@
 //! ```no_run
 //! use redis_server_wrapper::RedisServer;
 //!
-//! let server = RedisServer::new().port(6400).start().unwrap();
+//! # async fn example() {
+//! let server = RedisServer::new().port(6400).start().await.unwrap();
 //!
-//! server.run(&["SET", "key", "value"]).unwrap();
-//! let val = server.run(&["GET", "key"]).unwrap();
+//! server.run(&["SET", "key", "value"]).await.unwrap();
+//! let val = server.run(&["GET", "key"]).await.unwrap();
 //! assert_eq!(val.trim(), "value");
+//! # }
 //! ```
 //!
 //! # Cluster
@@ -81,15 +89,18 @@
 //! ```no_run
 //! use redis_server_wrapper::RedisCluster;
 //!
+//! # async fn example() {
 //! let cluster = RedisCluster::builder()
 //!     .masters(3)
 //!     .replicas_per_master(1)
 //!     .base_port(7000)
 //!     .start()
+//!     .await
 //!     .unwrap();
 //!
-//! assert!(cluster.is_healthy());
+//! assert!(cluster.is_healthy().await);
 //! assert_eq!(cluster.node_addrs().len(), 6);
+//! # }
 //! ```
 //!
 //! # Sentinel
@@ -99,16 +110,19 @@
 //! ```no_run
 //! use redis_server_wrapper::RedisSentinel;
 //!
+//! # async fn example() {
 //! let sentinel = RedisSentinel::builder()
 //!     .master_port(6390)
 //!     .replicas(2)
 //!     .sentinels(3)
 //!     .quorum(2)
 //!     .start()
+//!     .await
 //!     .unwrap();
 //!
-//! assert!(sentinel.is_healthy());
+//! assert!(sentinel.is_healthy().await);
 //! assert_eq!(sentinel.master_name(), "mymaster");
+//! # }
 //! ```
 //!
 //! # Error Handling
@@ -120,11 +134,13 @@
 //! ```no_run
 //! use redis_server_wrapper::{Error, RedisServer};
 //!
-//! match RedisServer::new().port(6400).start() {
+//! # async fn example() {
+//! match RedisServer::new().port(6400).start().await {
 //!     Ok(server) => println!("running on {}", server.addr()),
 //!     Err(Error::ServerStart { port }) => eprintln!("could not start on {port}"),
 //!     Err(e) => eprintln!("unexpected: {e}"),
 //! }
+//! # }
 //! ```
 //!
 //! # Lifecycle

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -2,8 +2,9 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::process::{Command, Stdio};
 use std::time::Duration;
+
+use tokio::process::Command;
 
 use crate::cli::RedisCli;
 use crate::error::{Error, Result};
@@ -16,15 +17,18 @@ use crate::server::{RedisServer, RedisServerHandle};
 /// ```no_run
 /// use redis_server_wrapper::RedisSentinel;
 ///
+/// # async fn example() {
 /// let sentinel = RedisSentinel::builder()
 ///     .master_name("mymaster")
 ///     .master_port(6390)
 ///     .replicas(2)
 ///     .sentinels(3)
 ///     .start()
+///     .await
 ///     .unwrap();
 ///
-/// assert!(sentinel.is_healthy());
+/// assert!(sentinel.is_healthy().await);
+/// # }
 /// ```
 pub struct RedisSentinelBuilder {
     master_name: String,
@@ -115,7 +119,7 @@ impl RedisSentinelBuilder {
     }
 
     /// Start the full topology: master, replicas, sentinels.
-    pub fn start(self) -> Result<RedisSentinelHandle> {
+    pub async fn start(self) -> Result<RedisSentinelHandle> {
         // Kill leftover processes.
         let cli_for_shutdown = |port: u16| {
             RedisCli::new()
@@ -131,7 +135,7 @@ impl RedisSentinelBuilder {
         for port in self.sentinel_ports() {
             cli_for_shutdown(port);
         }
-        std::thread::sleep(Duration::from_millis(500));
+        tokio::time::sleep(Duration::from_millis(500)).await;
 
         let base_dir = std::env::temp_dir().join("redis-sentinel-wrapper");
         if base_dir.exists() {
@@ -146,7 +150,8 @@ impl RedisSentinelBuilder {
             .appendonly(true)
             .redis_server_bin(&self.redis_server_bin)
             .redis_cli_bin(&self.redis_cli_bin)
-            .start()?;
+            .start()
+            .await?;
 
         // 2. Start replicas.
         let mut replicas = Vec::new();
@@ -159,12 +164,13 @@ impl RedisSentinelBuilder {
                 .extra("replicaof", format!("{} {}", self.bind, self.master_port))
                 .redis_server_bin(&self.redis_server_bin)
                 .redis_cli_bin(&self.redis_cli_bin)
-                .start()?;
+                .start()
+                .await?;
             replicas.push(replica);
         }
 
         // Let replication link up.
-        std::thread::sleep(Duration::from_secs(1));
+        tokio::time::sleep(Duration::from_secs(1)).await;
 
         // 3. Start sentinels.
         let mut sentinel_handles = Vec::new();
@@ -198,9 +204,10 @@ impl RedisSentinelBuilder {
             let status = Command::new(&self.redis_server_bin)
                 .arg(&conf_path)
                 .arg("--sentinel")
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .status()?;
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .await?;
 
             if !status.success() {
                 return Err(Error::SentinelStart { port });
@@ -210,12 +217,12 @@ impl RedisSentinelBuilder {
                 .bin(&self.redis_cli_bin)
                 .host(&self.bind)
                 .port(port);
-            cli.wait_for_ready(Duration::from_secs(10))?;
+            cli.wait_for_ready(Duration::from_secs(10)).await?;
             sentinel_handles.push((port, cli));
         }
 
         // Wait for sentinels to discover each other.
-        std::thread::sleep(Duration::from_secs(2));
+        tokio::time::sleep(Duration::from_secs(2)).await;
 
         Ok(RedisSentinelHandle {
             master,
@@ -286,13 +293,13 @@ impl RedisSentinelHandle {
     }
 
     /// Query a sentinel for the current master status.
-    pub fn poke(&self) -> Result<HashMap<String, String>> {
+    pub async fn poke(&self) -> Result<HashMap<String, String>> {
         for port in &self.sentinel_ports {
             let cli = RedisCli::new()
                 .bin(&self.redis_cli_bin)
                 .host(&self.bind)
                 .port(*port);
-            if let Ok(raw) = cli.run(&["SENTINEL", "MASTER", &self.master_name]) {
+            if let Ok(raw) = cli.run(&["SENTINEL", "MASTER", &self.master_name]).await {
                 return Ok(parse_flat_kv(&raw));
             }
         }
@@ -300,8 +307,8 @@ impl RedisSentinelHandle {
     }
 
     /// Check if the topology is healthy.
-    pub fn is_healthy(&self) -> bool {
-        if let Ok(info) = self.poke() {
+    pub async fn is_healthy(&self) -> bool {
+        if let Ok(info) = self.poke().await {
             let flags = info.get("flags").map(|s| s.as_str()).unwrap_or("");
             let num_slaves: u64 = info
                 .get("num-slaves")
@@ -321,10 +328,10 @@ impl RedisSentinelHandle {
     }
 
     /// Wait until the topology is healthy or timeout.
-    pub fn wait_for_healthy(&self, timeout: Duration) -> Result<()> {
+    pub async fn wait_for_healthy(&self, timeout: Duration) -> Result<()> {
         let start = std::time::Instant::now();
         loop {
-            if self.is_healthy() {
+            if self.is_healthy().await {
                 return Ok(());
             }
             if start.elapsed() > timeout {
@@ -332,7 +339,7 @@ impl RedisSentinelHandle {
                     message: "sentinel topology did not become healthy in time".into(),
                 });
             }
-            std::thread::sleep(Duration::from_millis(500));
+            tokio::time::sleep(Duration::from_millis(500)).await;
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,8 +3,9 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
 use std::time::Duration;
+
+use tokio::process::Command;
 
 use crate::cli::RedisCli;
 use crate::error::{Error, Result};
@@ -16,15 +17,18 @@ use crate::error::{Error, Result};
 /// ```no_run
 /// use redis_server_wrapper::RedisServer;
 ///
+/// # async fn example() {
 /// let server = RedisServer::new()
 ///     .port(6400)
 ///     .bind("127.0.0.1")
 ///     .save(false)
 ///     .start()
+///     .await
 ///     .unwrap();
 ///
-/// assert!(server.is_alive());
+/// assert!(server.is_alive().await);
 /// // Stopped automatically on Drop.
+/// # }
 /// ```
 #[derive(Debug, Clone)]
 pub struct RedisServerConfig {
@@ -400,7 +404,7 @@ impl RedisServer {
     ///
     /// Verifies that `redis-server` and `redis-cli` binaries are available
     /// before attempting to launch anything.
-    pub fn start(self) -> Result<RedisServerHandle> {
+    pub async fn start(self) -> Result<RedisServerHandle> {
         if which::which(&self.config.redis_server_bin).is_err() {
             return Err(Error::BinaryNotFound {
                 binary: self.config.redis_server_bin.clone(),
@@ -421,9 +425,10 @@ impl RedisServer {
 
         let status = Command::new(&self.config.redis_server_bin)
             .arg(&conf_path)
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()?;
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .await?;
 
         if !status.success() {
             return Err(Error::ServerStart {
@@ -439,7 +444,7 @@ impl RedisServer {
             cli = cli.password(pw);
         }
 
-        cli.wait_for_ready(Duration::from_secs(10))?;
+        cli.wait_for_ready(Duration::from_secs(10)).await?;
 
         Ok(RedisServerHandle {
             config: self.config,
@@ -610,8 +615,8 @@ impl RedisServerHandle {
     }
 
     /// Check if the server is alive via PING.
-    pub fn is_alive(&self) -> bool {
-        self.cli.ping()
+    pub async fn is_alive(&self) -> bool {
+        self.cli.ping().await
     }
 
     /// Get a `RedisCli` configured for this server.
@@ -620,8 +625,8 @@ impl RedisServerHandle {
     }
 
     /// Run a redis-cli command against this server.
-    pub fn run(&self, args: &[&str]) -> Result<String> {
-        self.cli.run(args)
+    pub async fn run(&self, args: &[&str]) -> Result<String> {
+        self.cli.run(args).await
     }
 
     /// Stop the server via SHUTDOWN NOSAVE.
@@ -630,8 +635,8 @@ impl RedisServerHandle {
     }
 
     /// Wait until the server is ready (PING -> PONG).
-    pub fn wait_for_ready(&self, timeout: Duration) -> Result<()> {
-        self.cli.wait_for_ready(timeout)
+    pub async fn wait_for_ready(&self, timeout: Duration) -> Result<()> {
+        self.cli.wait_for_ready(timeout).await
     }
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,38 +1,42 @@
 use redis_server_wrapper::{RedisCli, RedisServer};
 
-#[test]
-fn cli_ping_running_server() {
+#[tokio::test]
+async fn cli_ping_running_server() {
     let server = RedisServer::new()
         .port(16410)
         .start()
+        .await
         .expect("failed to start redis-server");
 
     let cli = RedisCli::new().host("127.0.0.1").port(16410);
-    assert!(cli.ping());
+    assert!(cli.ping().await);
 
     drop(server);
-    std::thread::sleep(std::time::Duration::from_millis(500));
-    assert!(!cli.ping());
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    assert!(!cli.ping().await);
 }
 
-#[test]
-fn cli_run_command() {
+#[tokio::test]
+async fn cli_run_command() {
     let _server = RedisServer::new()
         .port(16411)
         .start()
+        .await
         .expect("failed to start redis-server");
 
     let cli = RedisCli::new().port(16411);
-    let result = cli.run(&["SET", "foo", "bar"]).unwrap();
+    let result = cli.run(&["SET", "foo", "bar"]).await.unwrap();
     assert_eq!(result.trim(), "OK");
 
-    let result = cli.run(&["GET", "foo"]).unwrap();
+    let result = cli.run(&["GET", "foo"]).await.unwrap();
     assert_eq!(result.trim(), "bar");
 }
 
-#[test]
-fn cli_wait_for_ready_timeout() {
+#[tokio::test]
+async fn cli_wait_for_ready_timeout() {
     let cli = RedisCli::new().port(16412);
-    let result = cli.wait_for_ready(std::time::Duration::from_millis(500));
+    let result = cli
+        .wait_for_ready(std::time::Duration::from_millis(500))
+        .await;
     assert!(result.is_err());
 }

--- a/tests/cluster.rs
+++ b/tests/cluster.rs
@@ -1,19 +1,21 @@
 use redis_server_wrapper::RedisCluster;
 
-#[test]
-fn cluster_start_and_health() {
+#[tokio::test]
+async fn cluster_start_and_health() {
     let cluster = RedisCluster::builder()
         .masters(3)
         .replicas_per_master(0)
         .base_port(17000)
         .start()
+        .await
         .expect("failed to start redis cluster");
 
-    assert!(cluster.all_alive());
+    assert!(cluster.all_alive().await);
     cluster
         .wait_for_healthy(std::time::Duration::from_secs(30))
+        .await
         .expect("cluster did not become healthy");
-    assert!(cluster.is_healthy());
+    assert!(cluster.is_healthy().await);
     assert_eq!(cluster.node_addrs().len(), 3);
     assert_eq!(cluster.addr(), "127.0.0.1:17000");
 }

--- a/tests/sentinel.rs
+++ b/tests/sentinel.rs
@@ -1,7 +1,7 @@
 use redis_server_wrapper::RedisSentinel;
 
-#[test]
-fn sentinel_start_and_health() {
+#[tokio::test]
+async fn sentinel_start_and_health() {
     let sentinel = RedisSentinel::builder()
         .master_port(16390)
         .replicas(1)
@@ -9,12 +9,14 @@ fn sentinel_start_and_health() {
         .sentinels(3)
         .sentinel_base_port(26490)
         .start()
+        .await
         .expect("failed to start sentinel topology");
 
     sentinel
         .wait_for_healthy(std::time::Duration::from_secs(30))
+        .await
         .expect("sentinel topology did not become healthy");
-    assert!(sentinel.is_healthy());
+    assert!(sentinel.is_healthy().await);
     assert_eq!(sentinel.master_name(), "mymaster");
     assert_eq!(sentinel.master_addr(), "127.0.0.1:16390");
     assert_eq!(sentinel.sentinel_addrs().len(), 3);

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,71 +1,76 @@
 use redis_server_wrapper::{LogLevel, RedisServer};
 
-#[test]
-fn start_and_ping() {
+#[tokio::test]
+async fn start_and_ping() {
     let server = RedisServer::new()
         .port(16400)
         .bind("127.0.0.1")
         .loglevel(LogLevel::Warning)
         .start()
+        .await
         .expect("failed to start redis-server");
 
-    assert!(server.is_alive());
+    assert!(server.is_alive().await);
     assert_eq!(server.port(), 16400);
     assert_eq!(server.host(), "127.0.0.1");
     assert_eq!(server.addr(), "127.0.0.1:16400");
 }
 
-#[test]
-fn set_and_get() {
+#[tokio::test]
+async fn set_and_get() {
     let server = RedisServer::new()
         .port(16401)
         .start()
+        .await
         .expect("failed to start redis-server");
 
-    server.run(&["SET", "hello", "world"]).unwrap();
-    let val = server.run(&["GET", "hello"]).unwrap();
+    server.run(&["SET", "hello", "world"]).await.unwrap();
+    let val = server.run(&["GET", "hello"]).await.unwrap();
     assert_eq!(val.trim(), "world");
 }
 
-#[test]
-fn password_auth() {
+#[tokio::test]
+async fn password_auth() {
     let server = RedisServer::new()
         .port(16402)
         .password("testpass")
         .start()
+        .await
         .expect("failed to start redis-server");
 
     // The handle's cli is already configured without the password,
     // but the server was started with wait_for_ready which uses the
     // cli without auth. Since redis-server with requirepass still
     // responds to PING, the handle should be alive.
-    assert!(server.is_alive());
+    assert!(server.is_alive().await);
 }
 
-#[test]
-fn extra_config() {
+#[tokio::test]
+async fn extra_config() {
     let server = RedisServer::new()
         .port(16403)
         .extra("maxmemory", "10mb")
         .extra("maxmemory-policy", "allkeys-lru")
         .start()
+        .await
         .expect("failed to start redis-server");
 
-    let info = server.run(&["CONFIG", "GET", "maxmemory"]).unwrap();
+    let info = server.run(&["CONFIG", "GET", "maxmemory"]).await.unwrap();
     assert!(info.contains("10485760") || info.contains("10mb"));
 }
 
-#[test]
-fn stop_and_verify() {
+#[tokio::test]
+async fn stop_and_verify() {
     let server = RedisServer::new()
         .port(16404)
         .start()
+        .await
         .expect("failed to start redis-server");
 
-    assert!(server.is_alive());
+    assert!(server.is_alive().await);
     server.stop();
 
     // Give it a moment to shut down.
-    std::thread::sleep(std::time::Duration::from_millis(500));
-    assert!(!server.is_alive());
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    assert!(!server.is_alive().await);
 }


### PR DESCRIPTION
## Summary

- Convert `RedisServer::start()` to async using `tokio::process::Command` instead of `std::process::Command`
- Make `RedisServerHandle::run()`, `is_alive()`, and `wait_for_ready()` async so they can `.await` the already-async `RedisCli` methods
- Convert downstream `cluster.rs` and `sentinel.rs` to async since they call `RedisServer::start()` and async `RedisCli` methods
- Add `macros` and `rt-multi-thread` tokio features for `#[tokio::test]` and `#[tokio::main]`; convert all integration tests and the example

## Files changed

- `Cargo.toml` - add tokio `process`, `time`, `rt`, `macros`, `rt-multi-thread` features
- `src/server.rs` - convert `RedisServer::start()`, `RedisServerHandle::run()`, `is_alive()`, `wait_for_ready()` to async; use `tokio::process::Command` and `tokio::time::sleep`
- `src/cluster.rs` - convert `RedisClusterBuilder::start()` and `RedisClusterHandle` methods to async
- `src/sentinel.rs` - convert `RedisSentinelBuilder::start()` and `RedisSentinelHandle` methods to async
- `src/lib.rs` - re-export updated async types
- `tests/server.rs` - convert to `#[tokio::test]`
- `tests/cli.rs` - convert to `#[tokio::test]`
- `tests/cluster.rs` - convert to `#[tokio::test]`
- `tests/sentinel.rs` - convert to `#[tokio::test]`
- `examples/redis-run.rs` - convert to `#[tokio::main]`

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo doc --no-deps --all-features` passes
- [ ] `cargo test --lib --all-features` passes
- [ ] `cargo test --test '*' --all-features` passes (requires redis-server binary)

Closes #9