### PR TITLE
docs(readme,tests): update README to async API and add blocking tests closes #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ just `redis-server` and `redis-cli` on PATH.
 
 ## Usage
 
+The API is async-first and requires [tokio](https://tokio.rs). Enable the `blocking` feature
+for synchronous wrappers; see the [Blocking API](#blocking-api) section below.
+
 ### Single Server
 
 ```rust
@@ -28,9 +31,10 @@ let server = RedisServer::new()
     .port(6400)
     .bind("127.0.0.1")
     .start()
+    .await
     .unwrap();
 
-assert!(server.is_alive());
+assert!(server.is_alive().await);
 // Stopped automatically on drop.
 ```
 
@@ -44,15 +48,65 @@ let cluster = RedisCluster::builder()
     .replicas_per_master(1)
     .base_port(7000)
     .start()
+    .await
     .unwrap();
 
-assert!(cluster.is_healthy());
+assert!(cluster.is_healthy().await);
 ```
 
 ### Sentinel
 
 ```rust
 use redis_server_wrapper::RedisSentinel;
+
+let sentinel = RedisSentinel::builder()
+    .master_port(6390)
+    .replicas(2)
+    .sentinels(3)
+    .start()
+    .await
+    .unwrap();
+
+assert!(sentinel.is_healthy().await);
+```
+
+## Blocking API
+
+Enable the `blocking` feature for synchronous wrappers that require no async runtime:
+
+```toml
+[dev-dependencies]
+redis-server-wrapper = { version = "...", features = ["blocking"] }
+```
+
+The `blocking` module mirrors the async API. Every operation blocks the calling thread
+until it completes:
+
+```rust
+use redis_server_wrapper::blocking::RedisServer;
+
+let server = RedisServer::new()
+    .port(6400)
+    .bind("127.0.0.1")
+    .start()
+    .unwrap();
+
+assert!(server.is_alive());
+// Stopped automatically on drop.
+```
+
+Cluster and Sentinel work the same way:
+
+```rust
+use redis_server_wrapper::blocking::{RedisCluster, RedisSentinel};
+
+let cluster = RedisCluster::builder()
+    .masters(3)
+    .base_port(7000)
+    .start()
+    .unwrap();
+
+assert!(cluster.is_healthy());
 
 let sentinel = RedisSentinel::builder()
     .master_port(6390)

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -1,0 +1,80 @@
+#![cfg(feature = "blocking")]
+
+use redis_server_wrapper::blocking::{RedisCluster, RedisSentinel, RedisServer};
+
+#[test]
+fn blocking_server_start_and_ping() {
+    let server = RedisServer::new()
+        .port(16500)
+        .bind("127.0.0.1")
+        .start()
+        .expect("failed to start redis-server");
+
+    assert!(server.is_alive());
+    assert_eq!(server.port(), 16500);
+    assert_eq!(server.host(), "127.0.0.1");
+    assert_eq!(server.addr(), "127.0.0.1:16500");
+}
+
+#[test]
+fn blocking_server_set_and_get() {
+    let server = RedisServer::new()
+        .port(16501)
+        .start()
+        .expect("failed to start redis-server");
+
+    server.run(&["SET", "hello", "world"]).unwrap();
+    let val = server.run(&["GET", "hello"]).unwrap();
+    assert_eq!(val.trim(), "world");
+}
+
+#[test]
+fn blocking_server_stop_and_verify() {
+    let server = RedisServer::new()
+        .port(16502)
+        .start()
+        .expect("failed to start redis-server");
+
+    assert!(server.is_alive());
+    server.stop();
+
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    assert!(!server.is_alive());
+}
+
+#[test]
+fn blocking_cluster_start_and_health() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(0)
+        .base_port(17100)
+        .start()
+        .expect("failed to start redis cluster");
+
+    cluster
+        .wait_for_healthy(std::time::Duration::from_secs(30))
+        .expect("cluster did not become healthy");
+    assert!(cluster.is_healthy());
+    assert_eq!(cluster.node_addrs().len(), 3);
+    assert_eq!(cluster.addr(), "127.0.0.1:17100");
+}
+
+#[test]
+fn blocking_sentinel_start_and_health() {
+    let sentinel = RedisSentinel::builder()
+        .master_port(16590)
+        .replicas(1)
+        .replica_base_port(16591)
+        .sentinels(3)
+        .sentinel_base_port(26590)
+        .start()
+        .expect("failed to start sentinel topology");
+
+    sentinel
+        .wait_for_healthy(std::time::Duration::from_secs(30))
+        .expect("sentinel topology did not become healthy");
+    assert!(sentinel.is_healthy());
+    assert_eq!(sentinel.master_name(), "mymaster");
+    assert_eq!(sentinel.master_addr(), "127.0.0.1:16590");
+    assert_eq!(sentinel.sentinel_addrs().len(), 3);
+}


### PR DESCRIPTION
## Summary
- Updated README.md code snippets to use async API with `.await` on `start()` and health-check calls
- Added a "Blocking API" section and migration note to README.md
- Added `tests/blocking.rs` with 5 tests covering `blocking::RedisServer`, `blocking::RedisCluster`, and `blocking::RedisSentinel`
- Fixed `src/cluster.rs` to use `tokio::time::sleep(...).await` instead of `std::thread::sleep`

## Files changed
- `README.md` — updated three code snippets to async API; added Blocking API section
- `tests/blocking.rs` — new file with blocking feature tests (gated on `#[cfg(feature = "blocking")]`)
- `src/cluster.rs` — converted `start()`, `all_alive()`, `is_healthy()`, and `wait_for_healthy()` to async; replaced `std::thread::sleep` with `tokio::time::sleep(...).await`

## Test plan
- `cargo test --lib --all-features` passes
- `cargo test --test '*' --all-features` passes (including new `tests/blocking.rs`)
- `cargo clippy --all-features` clean
- `cargo doc --no-deps --all-features` clean

Closes #12