### PR TITLE
docs(readme,cargo): add badges and verify crates.io readiness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ documentation = "https://docs.rs/redis-server-wrapper"
 homepage = "https://github.com/joshrotenberg/redis-server-wrapper"
 keywords = ["redis", "testing", "wrapper", "server"]
 categories = ["development-tools::testing", "database"]
+readme = "README.md"
 rust-version = "1.87"
+exclude = [".github/", "tests/", "examples/"]
 
 [features]
 default = ["tokio"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # redis-server-wrapper
 
+[![Crates.io](https://img.shields.io/crates/v/redis-server-wrapper)](https://crates.io/crates/redis-server-wrapper)
+[![docs.rs](https://img.shields.io/docsrs/redis-server-wrapper)](https://docs.rs/redis-server-wrapper)
+[![CI](https://github.com/joshrotenberg/redis-server-wrapper/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/redis-server-wrapper/actions/workflows/ci.yml)
+[![License](https://img.shields.io/crates/l/redis-server-wrapper)](https://github.com/joshrotenberg/redis-server-wrapper#license)
+
 Type-safe Rust wrapper for `redis-server` and `redis-cli` with builder pattern APIs.
 
 Manage Redis server processes for testing, development, and CI without Docker --


### PR DESCRIPTION
## Summary

- Add four badges to README.md: crates.io version, docs.rs documentation, GitHub Actions CI status, and license
- Add `readme = "README.md"` to Cargo.toml so crates.io renders the README
- Add `exclude` list to Cargo.toml to keep the published crate lean (excludes `.github/`, `tests/`, `examples/`)

## Files changed

- `README.md` -- badge block added below the heading
- `Cargo.toml` -- added `readme` field and `exclude` list under `[package]`

## Test plan

- [x] Verify badge URLs resolve correctly for crate name `redis-server-wrapper`
- [x] `cargo publish --dry-run` succeeds cleanly
- [x] No test changes needed (documentation-only)

Closes #19