### PR TITLE
feat: add pid() method to RedisServerHandle and pids() to cluster/sentinel handles

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -379,6 +379,11 @@ impl RedisServerHandle {
         self.inner.host()
     }
 
+    /// The PID of the `redis-server` process.
+    pub fn pid(&self) -> u32 {
+        self.inner.pid()
+    }
+
     /// Check if the server is alive via PING.
     pub fn is_alive(&self) -> bool {
         self.rt.block_on(self.inner.is_alive())
@@ -479,6 +484,11 @@ impl RedisClusterHandle {
     /// All node addresses.
     pub fn node_addrs(&self) -> Vec<String> {
         self.inner.node_addrs()
+    }
+
+    /// The PIDs of all `redis-server` processes in the cluster.
+    pub fn pids(&self) -> Vec<u32> {
+        self.inner.pids()
     }
 
     /// Check if all nodes are alive.
@@ -612,6 +622,11 @@ impl RedisSentinelHandle {
     /// All sentinel addresses.
     pub fn sentinel_addrs(&self) -> Vec<String> {
         self.inner.sentinel_addrs()
+    }
+
+    /// The PIDs of all processes in the topology (master, replicas, sentinels).
+    pub fn pids(&self) -> Vec<u32> {
+        self.inner.pids()
     }
 
     /// The monitored master name.

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -161,6 +161,11 @@ impl RedisClusterHandle {
         self.nodes.iter().map(|n| n.addr()).collect()
     }
 
+    /// The PIDs of all `redis-server` processes in the cluster.
+    pub fn pids(&self) -> Vec<u32> {
+        self.nodes.iter().map(|n| n.pid()).collect()
+    }
+
     /// Check if all nodes are alive.
     pub async fn all_alive(&self) -> bool {
         for node in &self.nodes {

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -218,7 +218,14 @@ impl RedisSentinelBuilder {
                 .host(&self.bind)
                 .port(port);
             cli.wait_for_ready(Duration::from_secs(10)).await?;
-            sentinel_handles.push((port, cli));
+
+            let pid_path = dir.join("sentinel.pid");
+            let pid: u32 = fs::read_to_string(&pid_path)?
+                .trim()
+                .parse()
+                .map_err(|_| Error::SentinelStart { port })?;
+
+            sentinel_handles.push((port, pid, cli));
         }
 
         // Wait for sentinels to discover each other.
@@ -227,7 +234,8 @@ impl RedisSentinelBuilder {
         Ok(RedisSentinelHandle {
             master,
             replicas,
-            sentinel_ports: sentinel_handles.iter().map(|(p, _)| *p).collect(),
+            sentinel_ports: sentinel_handles.iter().map(|(p, _, _)| *p).collect(),
+            sentinel_pids: sentinel_handles.iter().map(|(_, pid, _)| *pid).collect(),
             master_name: self.master_name,
             bind: self.bind,
             redis_cli_bin: self.redis_cli_bin,
@@ -243,6 +251,7 @@ pub struct RedisSentinelHandle {
     #[allow(dead_code)] // Kept alive for Drop cleanup
     replicas: Vec<RedisServerHandle>,
     sentinel_ports: Vec<u16>,
+    sentinel_pids: Vec<u32>,
     master_name: String,
     bind: String,
     redis_cli_bin: String,
@@ -277,6 +286,17 @@ impl RedisSentinelHandle {
     /// The master's address.
     pub fn master_addr(&self) -> String {
         self.master.addr()
+    }
+
+    /// The PIDs of all processes in the topology (master, replicas, sentinels).
+    pub fn pids(&self) -> Vec<u32> {
+        let mut pids = Vec::with_capacity(1 + self.replicas.len() + self.sentinel_pids.len());
+        pids.push(self.master.pid());
+        for replica in &self.replicas {
+            pids.push(replica.pid());
+        }
+        pids.extend_from_slice(&self.sentinel_pids);
+        pids
     }
 
     /// All sentinel addresses.

--- a/src/server.rs
+++ b/src/server.rs
@@ -446,9 +446,19 @@ impl RedisServer {
 
         cli.wait_for_ready(Duration::from_secs(10)).await?;
 
+        let pid_path = node_dir.join("redis.pid");
+        let pid: u32 = fs::read_to_string(&pid_path)
+            .map_err(Error::Io)?
+            .trim()
+            .parse()
+            .map_err(|_| Error::ServerStart {
+                port: self.config.port,
+            })?;
+
         Ok(RedisServerHandle {
             config: self.config,
             cli,
+            pid,
         })
     }
 
@@ -596,6 +606,7 @@ impl Default for RedisServer {
 pub struct RedisServerHandle {
     config: RedisServerConfig,
     cli: RedisCli,
+    pid: u32,
 }
 
 impl RedisServerHandle {
@@ -612,6 +623,11 @@ impl RedisServerHandle {
     /// The server's bind address.
     pub fn host(&self) -> &str {
         &self.config.bind
+    }
+
+    /// The PID of the `redis-server` process.
+    pub fn pid(&self) -> u32 {
+        self.pid
     }
 
     /// Check if the server is alive via PING.


### PR DESCRIPTION
## Summary
- Add `pid()` method to `RedisServerHandle` (async and blocking) to expose the redis-server process ID
- Add `pids()` method to `RedisClusterHandle` to return PIDs of all cluster nodes
- Add `pids()` method to `RedisSentinelHandle` to return PIDs of all processes in the topology (master, replicas, sentinels)
- PIDs are read from pidfiles written by redis-server at startup

## Files changed
- `src/server.rs` - Read PID from pidfile after server start; add `pid()` accessor to `RedisServerHandle`
- `src/cluster.rs` - Add `pids()` method to `RedisClusterHandle` that collects PIDs from all nodes
- `src/sentinel.rs` - Read sentinel PIDs from pidfiles; store in handle; add `pids()` method combining master, replica, and sentinel PIDs
- `src/blocking.rs` - Add `pid()` to blocking `RedisServerHandle` and `pids()` to blocking cluster/sentinel handles

## Test plan
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --lib --all-features` passes
- [ ] `cargo test --test '*' --all-features` passes

Closes #23