### PR TITLE
fix(cluster): clear stale node dirs closes #24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   workflow_call:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - "src/**"
       - "tests/**"
@@ -12,7 +12,7 @@ on:
       - "Cargo.lock"
       - ".github/workflows/ci.yml"
   pull_request:
-    branches: [master]
+    branches: [main]
     paths:
       - "src/**"
       - "tests/**"

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   release-plz:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(server)* add `detach()` to async and blocking server handles so they can be consumed without shutting down the Redis process closes #24
+
 ## [0.1.0](https://github.com/joshrotenberg/redis-server-wrapper/releases/tag/v0.1.0) - 2026-03-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ assert!(server.is_alive().await);
 // Stopped automatically on drop.
 ```
 
+If you want the process to keep running after the handle is consumed, call
+`server.detach()` instead of dropping it.
+
 ### Cluster
 
 ```rust
@@ -99,6 +102,8 @@ let server = RedisServer::new()
 assert!(server.is_alive());
 // Stopped automatically on drop.
 ```
+
+Use `server.detach()` in the blocking API for the same keep-running behavior.
 
 Cluster and Sentinel work the same way:
 

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -394,6 +394,11 @@ impl RedisServerHandle {
         self.rt.block_on(self.inner.run(args))
     }
 
+    /// Consume the handle without stopping the server.
+    pub fn detach(self) {
+        self.inner.detach();
+    }
+
     /// Stop the server via SHUTDOWN NOSAVE.
     pub fn stop(&self) {
         self.inner.stop();

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -91,10 +91,12 @@ impl RedisClusterBuilder {
         // Start each node.
         let mut nodes = Vec::new();
         for port in self.ports() {
+            let node_dir = std::env::temp_dir().join(format!("redis-cluster-wrapper/node-{port}"));
+            let _ = std::fs::remove_dir_all(&node_dir);
             let handle = RedisServer::new()
                 .port(port)
                 .bind(&self.bind)
-                .dir(std::env::temp_dir().join(format!("redis-cluster-wrapper/node-{port}")))
+                .dir(node_dir)
                 .cluster_enabled(true)
                 .cluster_node_timeout(5000)
                 .redis_server_bin(&self.redis_server_bin)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,8 @@
 //! topologies, sentinels are shut down first, then replicas and master (via
 //! their own handle drops).
 //!
-//! You can also call `.stop()` explicitly on any handle to shut down early.
+//! You can also call `.stop()` explicitly on any handle to shut down early, or
+//! `.detach()` on a server handle to consume it without stopping the process.
 
 #[cfg(feature = "tokio")]
 pub mod cli;

--- a/src/server.rs
+++ b/src/server.rs
@@ -459,6 +459,7 @@ impl RedisServer {
             config: self.config,
             cli,
             pid,
+            detached: false,
         })
     }
 
@@ -607,6 +608,7 @@ pub struct RedisServerHandle {
     config: RedisServerConfig,
     cli: RedisCli,
     pid: u32,
+    detached: bool,
 }
 
 impl RedisServerHandle {
@@ -645,6 +647,11 @@ impl RedisServerHandle {
         self.cli.run(args).await
     }
 
+    /// Consume the handle without stopping the server.
+    pub fn detach(mut self) {
+        self.detached = true;
+    }
+
     /// Stop the server via SHUTDOWN NOSAVE.
     pub fn stop(&self) {
         self.cli.shutdown();
@@ -658,7 +665,9 @@ impl RedisServerHandle {
 
 impl Drop for RedisServerHandle {
     fn drop(&mut self) {
-        self.stop();
+        if !self.detached {
+            self.stop();
+        }
     }
 }
 

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -43,6 +43,27 @@ fn blocking_server_stop_and_verify() {
 }
 
 #[test]
+fn blocking_server_detach_leaves_server_running() {
+    let server = RedisServer::new()
+        .port(16503)
+        .start()
+        .expect("failed to start redis-server");
+
+    let cli = redis_server_wrapper::blocking::RedisCli::new()
+        .host("127.0.0.1")
+        .port(16503);
+    server.detach();
+
+    cli.wait_for_ready(std::time::Duration::from_secs(2))
+        .expect("detached server should still be reachable");
+    assert!(cli.ping());
+
+    cli.run(&["SHUTDOWN", "NOSAVE"]).unwrap_or_default();
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    assert!(!cli.ping());
+}
+
+#[test]
 fn blocking_cluster_start_and_health() {
     let cluster = RedisCluster::builder()
         .masters(3)

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -74,3 +74,24 @@ async fn stop_and_verify() {
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     assert!(!server.is_alive().await);
 }
+
+#[tokio::test]
+async fn detach_leaves_server_running() {
+    let server = RedisServer::new()
+        .port(16405)
+        .start()
+        .await
+        .expect("failed to start redis-server");
+
+    let cli = server.cli().clone();
+    server.detach();
+
+    cli.wait_for_ready(std::time::Duration::from_secs(2))
+        .await
+        .expect("detached server should still be reachable");
+    assert!(cli.ping().await);
+
+    cli.shutdown();
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    assert!(!cli.ping().await);
+}


### PR DESCRIPTION
## Summary
- add `detach()` to async and blocking `RedisServerHandle` so a handle can be consumed without shutting down the Redis process
- guard server-handle drop shutdown behind the new detached state and document the lifecycle behavior in the crate docs and README
- clear stale cluster node directories before starting ports again so repeated cluster runs do not reuse old on-disk state
- cover the new detach behavior with async and blocking integration tests and record the change in the changelog

## Files changed
- `src/server.rs`: track detached server handles and skip shutdown on drop after `detach()`
- `src/blocking.rs`: expose `detach()` on the blocking server handle wrapper
- `src/cluster.rs`: remove stale per-port cluster temp directories before node startup
- `src/lib.rs`: document `detach()` in the crate-level lifecycle docs
- `README.md`: describe detach behavior for async and blocking server usage
- `CHANGELOG.md`: add the unreleased entry for issue #24
- `tests/server.rs`: verify async `detach()` leaves the server running until explicit shutdown
- `tests/blocking.rs`: verify blocking `detach()` leaves the server running until explicit shutdown

## Test plan
- `cargo test --test server --test blocking`
- `cargo test --features blocking --test blocking`

Closes #24