### PR TITLE
feat(cluster): add password support to RedisClusterBuilder closes #25

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -454,6 +454,12 @@ impl RedisClusterBuilder {
         self
     }
 
+    /// Set a `requirepass` password for all cluster nodes.
+    pub fn password(mut self, password: impl Into<String>) -> Self {
+        self.inner = self.inner.password(password);
+        self
+    }
+
     /// Set a custom `redis-server` binary path.
     pub fn redis_server_bin(mut self, bin: impl Into<String>) -> Self {
         self.inner = self.inner.redis_server_bin(bin);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -234,7 +234,9 @@ impl RedisCli {
         node_addrs: &[String],
         replicas_per_master: u16,
     ) -> Result<()> {
-        let mut args: Vec<String> = vec!["--cluster".into(), "create".into()];
+        let mut args = self.base_args();
+        args.push("--cluster".into());
+        args.push("create".into());
         args.extend(node_addrs.iter().cloned());
         if replicas_per_master > 0 {
             args.push("--cluster-replicas".into());

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -31,6 +31,7 @@ pub struct RedisClusterBuilder {
     replicas_per_master: u16,
     base_port: u16,
     bind: String,
+    password: Option<String>,
     redis_server_bin: String,
     redis_cli_bin: String,
 }
@@ -53,6 +54,12 @@ impl RedisClusterBuilder {
 
     pub fn bind(mut self, bind: impl Into<String>) -> Self {
         self.bind = bind.into();
+        self
+    }
+
+    /// Set a `requirepass` password for all cluster nodes.
+    pub fn password(mut self, password: impl Into<String>) -> Self {
+        self.password = Some(password.into());
         self
     }
 
@@ -80,11 +87,14 @@ impl RedisClusterBuilder {
     pub async fn start(self) -> Result<RedisClusterHandle> {
         // Stop any leftover nodes from previous runs.
         for port in self.ports() {
-            RedisCli::new()
+            let mut cli = RedisCli::new()
                 .bin(&self.redis_cli_bin)
                 .host(&self.bind)
-                .port(port)
-                .shutdown();
+                .port(port);
+            if let Some(ref password) = self.password {
+                cli = cli.password(password);
+            }
+            cli.shutdown();
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -93,25 +103,31 @@ impl RedisClusterBuilder {
         for port in self.ports() {
             let node_dir = std::env::temp_dir().join(format!("redis-cluster-wrapper/node-{port}"));
             let _ = std::fs::remove_dir_all(&node_dir);
-            let handle = RedisServer::new()
+
+            let mut server = RedisServer::new()
                 .port(port)
                 .bind(&self.bind)
                 .dir(node_dir)
                 .cluster_enabled(true)
                 .cluster_node_timeout(5000)
                 .redis_server_bin(&self.redis_server_bin)
-                .redis_cli_bin(&self.redis_cli_bin)
-                .start()
-                .await?;
+                .redis_cli_bin(&self.redis_cli_bin);
+            if let Some(ref password) = self.password {
+                server = server.password(password).masterauth(password);
+            }
+            let handle = server.start().await?;
             nodes.push(handle);
         }
 
         // Form the cluster.
         let node_addrs: Vec<String> = nodes.iter().map(|n| n.addr()).collect();
-        let cli = RedisCli::new()
+        let mut cli = RedisCli::new()
             .bin(&self.redis_cli_bin)
             .host(&self.bind)
             .port(self.base_port);
+        if let Some(ref password) = self.password {
+            cli = cli.password(password);
+        }
         cli.cluster_create(&node_addrs, self.replicas_per_master)
             .await?;
 
@@ -122,6 +138,7 @@ impl RedisClusterBuilder {
             nodes,
             bind: self.bind,
             base_port: self.base_port,
+            password: self.password,
             redis_cli_bin: self.redis_cli_bin,
         })
     }
@@ -132,6 +149,7 @@ pub struct RedisClusterHandle {
     nodes: Vec<RedisServerHandle>,
     bind: String,
     base_port: u16,
+    password: Option<String>,
     redis_cli_bin: String,
 }
 
@@ -146,6 +164,7 @@ impl RedisCluster {
             replicas_per_master: 0,
             base_port: 7000,
             bind: "127.0.0.1".into(),
+            password: None,
             redis_server_bin: "redis-server".into(),
             redis_cli_bin: "redis-cli".into(),
         }
@@ -208,10 +227,14 @@ impl RedisClusterHandle {
 
     /// Get a `RedisCli` for the seed node.
     pub fn cli(&self) -> RedisCli {
-        RedisCli::new()
+        let mut cli = RedisCli::new()
             .bin(&self.redis_cli_bin)
             .host(&self.bind)
-            .port(self.base_port)
+            .port(self.base_port);
+        if let Some(ref password) = self.password {
+            cli = cli.password(password);
+        }
+        cli
     }
 }
 
@@ -231,6 +254,7 @@ mod tests {
         assert_eq!(b.masters, 3);
         assert_eq!(b.replicas_per_master, 0);
         assert_eq!(b.base_port, 7000);
+        assert_eq!(b.password, None);
         assert_eq!(b.total_nodes(), 3);
     }
 
@@ -240,5 +264,11 @@ mod tests {
         assert_eq!(b.total_nodes(), 6);
         let ports: Vec<u16> = b.ports().collect();
         assert_eq!(ports, vec![7000, 7001, 7002, 7003, 7004, 7005]);
+    }
+
+    #[test]
+    fn builder_password() {
+        let b = RedisCluster::builder().password("secret");
+        assert_eq!(b.password.as_deref(), Some("secret"));
     }
 }

--- a/tests/cluster.rs
+++ b/tests/cluster.rs
@@ -19,3 +19,23 @@ async fn cluster_start_and_health() {
     assert_eq!(cluster.node_addrs().len(), 3);
     assert_eq!(cluster.addr(), "127.0.0.1:17000");
 }
+
+#[tokio::test]
+async fn cluster_password_auth() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(0)
+        .base_port(17010)
+        .password("testpass")
+        .start()
+        .await
+        .expect("failed to start password-protected redis cluster");
+
+    cluster
+        .wait_for_healthy(std::time::Duration::from_secs(30))
+        .await
+        .expect("password-protected cluster did not become healthy");
+
+    let pong = cluster.cli().run(&["PING"]).await.unwrap();
+    assert_eq!(pong.trim(), "PONG");
+}


### PR DESCRIPTION
## Summary
- Add password configuration to `RedisClusterBuilder` in both async and blocking APIs so cluster nodes can be started with `requirepass`.
- Pass the configured password through cluster startup, shutdown, and seed-node CLI interactions, including `redis-cli --cluster create`.
- Clear stale node directories before startup so password-protected cluster nodes come up from a clean state.
- Add regression coverage for builder password storage and authenticated cluster `PING` health.

## Files changed
- `src/cluster.rs`: add cluster-builder password support, propagate authentication to node startup and CLI usage, and reset node directories before launch.
- `src/blocking.rs`: expose the blocking `RedisClusterBuilder::password` wrapper.
- `src/cli.rs`: ensure cluster creation commands include the base CLI auth arguments.
- `tests/cluster.rs`: verify a password-protected cluster becomes healthy and responds to authenticated commands.

## Test plan
- `cargo test cluster_password_auth`
- `cargo test builder_password`

Closes #25