### PR TITLE
feat(builders): add logfile and extra to cluster and sentinel closes #26

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -207,6 +207,12 @@ impl RedisServer {
         self
     }
 
+    /// Set the log file path.
+    pub fn logfile(mut self, path: impl Into<String>) -> Self {
+        self.inner = self.inner.logfile(path);
+        self
+    }
+
     /// Set the number of databases.
     pub fn databases(mut self, n: u32) -> Self {
         self.inner = self.inner.databases(n);
@@ -460,6 +466,18 @@ impl RedisClusterBuilder {
         self
     }
 
+    /// Set the log file path for all cluster nodes.
+    pub fn logfile(mut self, path: impl Into<String>) -> Self {
+        self.inner = self.inner.logfile(path);
+        self
+    }
+
+    /// Set an arbitrary config directive for all cluster nodes.
+    pub fn extra(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.inner = self.inner.extra(key, value);
+        self
+    }
+
     /// Set a custom `redis-server` binary path.
     pub fn redis_server_bin(mut self, bin: impl Into<String>) -> Self {
         self.inner = self.inner.redis_server_bin(bin);
@@ -586,6 +604,12 @@ impl RedisSentinelBuilder {
         self
     }
 
+    /// Set the log file path for all processes in the topology.
+    pub fn logfile(mut self, path: impl Into<String>) -> Self {
+        self.inner = self.inner.logfile(path);
+        self
+    }
+
     /// Set down-after-milliseconds for the sentinel.
     pub fn down_after_ms(mut self, ms: u64) -> Self {
         self.inner = self.inner.down_after_ms(ms);
@@ -595,6 +619,12 @@ impl RedisSentinelBuilder {
     /// Set failover-timeout for the sentinel.
     pub fn failover_timeout_ms(mut self, ms: u64) -> Self {
         self.inner = self.inner.failover_timeout_ms(ms);
+        self
+    }
+
+    /// Set an arbitrary config directive for all processes in the topology.
+    pub fn extra(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.inner = self.inner.extra(key, value);
         self
     }
 

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1,5 +1,6 @@
 //! Redis Cluster lifecycle management built on `RedisServer`.
 
+use std::collections::HashMap;
 use std::time::Duration;
 
 use crate::cli::RedisCli;
@@ -32,6 +33,8 @@ pub struct RedisClusterBuilder {
     base_port: u16,
     bind: String,
     password: Option<String>,
+    logfile: Option<String>,
+    extra: HashMap<String, String>,
     redis_server_bin: String,
     redis_cli_bin: String,
 }
@@ -60,6 +63,18 @@ impl RedisClusterBuilder {
     /// Set a `requirepass` password for all cluster nodes.
     pub fn password(mut self, password: impl Into<String>) -> Self {
         self.password = Some(password.into());
+        self
+    }
+
+    /// Set the log file path for all cluster nodes.
+    pub fn logfile(mut self, path: impl Into<String>) -> Self {
+        self.logfile = Some(path.into());
+        self
+    }
+
+    /// Set an arbitrary config directive for all cluster nodes.
+    pub fn extra(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.extra.insert(key.into(), value.into());
         self
     }
 
@@ -103,7 +118,6 @@ impl RedisClusterBuilder {
         for port in self.ports() {
             let node_dir = std::env::temp_dir().join(format!("redis-cluster-wrapper/node-{port}"));
             let _ = std::fs::remove_dir_all(&node_dir);
-
             let mut server = RedisServer::new()
                 .port(port)
                 .bind(&self.bind)
@@ -114,6 +128,12 @@ impl RedisClusterBuilder {
                 .redis_cli_bin(&self.redis_cli_bin);
             if let Some(ref password) = self.password {
                 server = server.password(password).masterauth(password);
+            }
+            if let Some(ref logfile) = self.logfile {
+                server = server.logfile(logfile.clone());
+            }
+            for (key, value) in &self.extra {
+                server = server.extra(key.clone(), value.clone());
             }
             let handle = server.start().await?;
             nodes.push(handle);
@@ -165,6 +185,8 @@ impl RedisCluster {
             base_port: 7000,
             bind: "127.0.0.1".into(),
             password: None,
+            logfile: None,
+            extra: HashMap::new(),
             redis_server_bin: "redis-server".into(),
             redis_cli_bin: "redis-cli".into(),
         }
@@ -255,6 +277,8 @@ mod tests {
         assert_eq!(b.replicas_per_master, 0);
         assert_eq!(b.base_port, 7000);
         assert_eq!(b.password, None);
+        assert!(b.logfile.is_none());
+        assert!(b.extra.is_empty());
         assert_eq!(b.total_nodes(), 3);
     }
 
@@ -270,5 +294,14 @@ mod tests {
     fn builder_password() {
         let b = RedisCluster::builder().password("secret");
         assert_eq!(b.password.as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn builder_logfile_and_extra() {
+        let b = RedisCluster::builder()
+            .logfile("/tmp/cluster.log")
+            .extra("maxmemory", "10mb");
+        assert_eq!(b.logfile.as_deref(), Some("/tmp/cluster.log"));
+        assert_eq!(b.extra.get("maxmemory").map(String::as_str), Some("10mb"));
     }
 }

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -39,8 +39,10 @@ pub struct RedisSentinelBuilder {
     sentinel_base_port: u16,
     quorum: u16,
     bind: String,
+    logfile: Option<String>,
     down_after_ms: u64,
     failover_timeout_ms: u64,
+    extra: HashMap<String, String>,
     redis_server_bin: String,
     redis_cli_bin: String,
 }
@@ -86,6 +88,11 @@ impl RedisSentinelBuilder {
         self
     }
 
+    pub fn logfile(mut self, path: impl Into<String>) -> Self {
+        self.logfile = Some(path.into());
+        self
+    }
+
     pub fn down_after_ms(mut self, ms: u64) -> Self {
         self.down_after_ms = ms;
         self
@@ -93,6 +100,11 @@ impl RedisSentinelBuilder {
 
     pub fn failover_timeout_ms(mut self, ms: u64) -> Self {
         self.failover_timeout_ms = ms;
+        self
+    }
+
+    pub fn extra(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.extra.insert(key.into(), value.into());
         self
     }
 
@@ -143,29 +155,39 @@ impl RedisSentinelBuilder {
         }
 
         // 1. Start master.
-        let master = RedisServer::new()
+        let mut master = RedisServer::new()
             .port(self.master_port)
             .bind(&self.bind)
             .dir(base_dir.join("master"))
             .appendonly(true)
             .redis_server_bin(&self.redis_server_bin)
-            .redis_cli_bin(&self.redis_cli_bin)
-            .start()
-            .await?;
+            .redis_cli_bin(&self.redis_cli_bin);
+        if let Some(ref logfile) = self.logfile {
+            master = master.logfile(logfile.clone());
+        }
+        for (key, value) in &self.extra {
+            master = master.extra(key.clone(), value.clone());
+        }
+        let master = master.start().await?;
 
         // 2. Start replicas.
         let mut replicas = Vec::new();
         for port in self.replica_ports() {
-            let replica = RedisServer::new()
+            let mut replica = RedisServer::new()
                 .port(port)
                 .bind(&self.bind)
                 .dir(base_dir.join(format!("replica-{port}")))
                 .appendonly(true)
-                .extra("replicaof", format!("{} {}", self.bind, self.master_port))
+                .replicaof(self.bind.clone(), self.master_port)
                 .redis_server_bin(&self.redis_server_bin)
-                .redis_cli_bin(&self.redis_cli_bin)
-                .start()
-                .await?;
+                .redis_cli_bin(&self.redis_cli_bin);
+            if let Some(ref logfile) = self.logfile {
+                replica = replica.logfile(logfile.clone());
+            }
+            for (key, value) in &self.extra {
+                replica = replica.extra(key.clone(), value.clone());
+            }
+            let replica = replica.start().await?;
             replicas.push(replica);
         }
 
@@ -178,12 +200,17 @@ impl RedisSentinelBuilder {
             let dir = base_dir.join(format!("sentinel-{port}"));
             fs::create_dir_all(&dir)?;
             let conf_path = dir.join("sentinel.conf");
-            let conf = format!(
+            let logfile = self
+                .logfile
+                .as_deref()
+                .map(str::to_owned)
+                .unwrap_or_else(|| format!("{}/sentinel.log", dir.display()));
+            let mut conf = format!(
                 "port {port}\n\
                  bind {bind}\n\
                  daemonize yes\n\
                  pidfile {dir}/sentinel.pid\n\
-                 logfile {dir}/sentinel.log\n\
+                 logfile {logfile}\n\
                  dir {dir}\n\
                  sentinel monitor {name} {master_host} {master_port} {quorum}\n\
                  sentinel down-after-milliseconds {name} {down_after}\n\
@@ -192,6 +219,7 @@ impl RedisSentinelBuilder {
                 port = port,
                 bind = self.bind,
                 dir = dir.display(),
+                logfile = logfile,
                 name = self.master_name,
                 master_host = self.bind,
                 master_port = self.master_port,
@@ -199,6 +227,9 @@ impl RedisSentinelBuilder {
                 down_after = self.down_after_ms,
                 failover_timeout = self.failover_timeout_ms,
             );
+            for (key, value) in &self.extra {
+                conf.push_str(&format!("{key} {value}\n"));
+            }
             fs::write(&conf_path, conf)?;
 
             let status = Command::new(&self.redis_server_bin)
@@ -274,8 +305,10 @@ impl RedisSentinel {
             sentinel_base_port: 26389,
             quorum: 2,
             bind: "127.0.0.1".into(),
+            logfile: None,
             down_after_ms: 5000,
             failover_timeout_ms: 10000,
+            extra: HashMap::new(),
             redis_server_bin: "redis-server".into(),
             redis_cli_bin: "redis-cli".into(),
         }
@@ -406,6 +439,8 @@ mod tests {
         assert_eq!(b.num_replicas, 2);
         assert_eq!(b.num_sentinels, 3);
         assert_eq!(b.quorum, 2);
+        assert!(b.logfile.is_none());
+        assert!(b.extra.is_empty());
     }
 
     #[test]
@@ -415,12 +450,16 @@ mod tests {
             .master_port(6500)
             .replicas(1)
             .sentinels(5)
-            .quorum(3);
+            .quorum(3)
+            .logfile("/tmp/sentinel.log")
+            .extra("maxmemory", "10mb");
         assert_eq!(b.master_name, "custom");
         assert_eq!(b.master_port, 6500);
         assert_eq!(b.num_replicas, 1);
         assert_eq!(b.num_sentinels, 5);
         assert_eq!(b.quorum, 3);
+        assert_eq!(b.logfile.as_deref(), Some("/tmp/sentinel.log"));
+        assert_eq!(b.extra.get("maxmemory").map(String::as_str), Some("10mb"));
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -52,6 +52,7 @@ pub struct RedisServerConfig {
     // -- general --
     pub daemonize: bool,
     pub dir: PathBuf,
+    pub logfile: Option<String>,
     pub loglevel: LogLevel,
     pub databases: Option<u32>,
 
@@ -131,6 +132,7 @@ impl Default for RedisServerConfig {
             tls_auth_clients: None,
             daemonize: true,
             dir: std::env::temp_dir().join("redis-server-wrapper"),
+            logfile: None,
             loglevel: LogLevel::Notice,
             databases: None,
             maxmemory: None,
@@ -261,6 +263,12 @@ impl RedisServer {
     /// Set the log level (default: [`LogLevel::Notice`]).
     pub fn loglevel(mut self, level: LogLevel) -> Self {
         self.config.loglevel = level;
+        self
+    }
+
+    /// Set the log file path. Defaults to `redis.log` inside the node directory.
+    pub fn logfile(mut self, path: impl Into<String>) -> Self {
+        self.config.logfile = Some(path.into());
         self
     }
 
@@ -471,7 +479,6 @@ impl RedisServer {
              bind {bind}\n\
              daemonize {daemonize}\n\
              pidfile {dir}/redis.pid\n\
-             logfile {dir}/redis.log\n\
              dir {dir}\n\
              loglevel {level}\n\
              protected-mode {protected}\n",
@@ -482,6 +489,14 @@ impl RedisServer {
             level = self.config.loglevel,
             protected = yn(self.config.protected_mode),
         );
+
+        let logfile = self
+            .config
+            .logfile
+            .as_deref()
+            .map(str::to_owned)
+            .unwrap_or_else(|| format!("{}/redis.log", node_dir.display()));
+        conf.push_str(&format!("logfile {logfile}\n"));
 
         // -- network --
         if let Some(backlog) = self.config.tcp_backlog {
@@ -691,6 +706,7 @@ mod tests {
             .save(true)
             .appendonly(true)
             .password("secret")
+            .logfile("/tmp/redis.log")
             .loglevel(LogLevel::Warning)
             .extra("maxmemory", "100mb");
 
@@ -699,6 +715,7 @@ mod tests {
         assert!(s.config.save);
         assert!(s.config.appendonly);
         assert_eq!(s.config.password.as_deref(), Some("secret"));
+        assert_eq!(s.config.logfile.as_deref(), Some("/tmp/redis.log"));
         assert_eq!(s.config.extra.get("maxmemory").unwrap(), "100mb");
     }
 

--- a/tests/cluster.rs
+++ b/tests/cluster.rs
@@ -1,11 +1,21 @@
 use redis_server_wrapper::RedisCluster;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[tokio::test]
 async fn cluster_start_and_health() {
+    let log_path = std::env::temp_dir().join(format!(
+        "redis-cluster-{}.log",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos()
+    ));
     let cluster = RedisCluster::builder()
         .masters(3)
         .replicas_per_master(0)
         .base_port(17000)
+        .logfile(log_path.display().to_string())
+        .extra("maxmemory", "10mb")
         .start()
         .await
         .expect("failed to start redis cluster");
@@ -16,6 +26,18 @@ async fn cluster_start_and_health() {
         .await
         .expect("cluster did not become healthy");
     assert!(cluster.is_healthy().await);
+    let maxmemory = cluster
+        .cli()
+        .run(&["CONFIG", "GET", "maxmemory"])
+        .await
+        .expect("failed to query cluster config");
+    assert!(maxmemory.contains("10485760") || maxmemory.contains("10mb"));
+    let logfile = cluster
+        .cli()
+        .run(&["CONFIG", "GET", "logfile"])
+        .await
+        .expect("failed to query cluster logfile");
+    assert!(logfile.contains(&log_path.display().to_string()));
     assert_eq!(cluster.node_addrs().len(), 3);
     assert_eq!(cluster.addr(), "127.0.0.1:17000");
 }

--- a/tests/sentinel.rs
+++ b/tests/sentinel.rs
@@ -1,13 +1,23 @@
-use redis_server_wrapper::RedisSentinel;
+use redis_server_wrapper::{RedisCli, RedisSentinel};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[tokio::test]
 async fn sentinel_start_and_health() {
+    let log_path = std::env::temp_dir().join(format!(
+        "redis-sentinel-{}.log",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos()
+    ));
     let sentinel = RedisSentinel::builder()
         .master_port(16390)
         .replicas(1)
         .replica_base_port(16391)
         .sentinels(3)
         .sentinel_base_port(26490)
+        .logfile(log_path.display().to_string())
+        .extra("maxmemory", "10mb")
         .start()
         .await
         .expect("failed to start sentinel topology");
@@ -16,6 +26,17 @@ async fn sentinel_start_and_health() {
         .wait_for_healthy(std::time::Duration::from_secs(30))
         .await
         .expect("sentinel topology did not become healthy");
+    let master_cli = RedisCli::new().host("127.0.0.1").port(16390);
+    let maxmemory = master_cli
+        .run(&["CONFIG", "GET", "maxmemory"])
+        .await
+        .expect("failed to query master config");
+    assert!(maxmemory.contains("10485760") || maxmemory.contains("10mb"));
+    let logfile = master_cli
+        .run(&["CONFIG", "GET", "logfile"])
+        .await
+        .expect("failed to query master logfile");
+    assert!(logfile.contains(&log_path.display().to_string()));
     assert!(sentinel.is_healthy().await);
     assert_eq!(sentinel.master_name(), "mymaster");
     assert_eq!(sentinel.master_addr(), "127.0.0.1:16390");


### PR DESCRIPTION
## Summary
- Add `logfile` and `extra` builder options to cluster and sentinel builders, including the blocking wrappers.
- Thread those options through process startup so cluster nodes, sentinel masters, replicas, and sentinel config files receive the configured directives.
- Add explicit `RedisServer` logfile support while preserving the existing default log path when no override is provided.
- Extend unit and integration coverage to verify the new builder state and runtime config behavior.

## Files changed
- `src/blocking.rs`: expose the new builder methods on the blocking wrappers for server, cluster, and sentinel types.
- `src/cluster.rs`: store cluster-wide logfile and extra config, apply them to each node, and add builder tests.
- `src/sentinel.rs`: store sentinel-topology logfile and extra config, apply them to master and replicas, append extra directives to sentinel config, and add builder tests.
- `src/server.rs`: add logfile to `RedisServerConfig`, expose a builder setter, and emit either the custom or default logfile path in generated config.
- `tests/cluster.rs`: verify a started cluster honors configured `maxmemory` and logfile settings.
- `tests/sentinel.rs`: verify a started sentinel topology honors configured `maxmemory` and logfile settings on the master.

## Test plan
- `cargo test`

Closes #26