### PR TITLE
docs: pre-release documentation audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,37 @@ just `redis-server` and `redis-cli` on PATH.
 
 ## Prerequisites
 
-`redis-server` and `redis-cli` must be available on your PATH (or specify custom paths).
+`redis-server` and `redis-cli` must be available on your PATH (or specify custom paths with
+`.redis_server_bin()` and `.redis_cli_bin()` on any builder).
+
+## Installation
+
+Add to `Cargo.toml` for async use (the default):
+
+```toml
+[dev-dependencies]
+redis-server-wrapper = "0.1"
+```
+
+The `tokio` feature is enabled by default. To use the synchronous blocking API instead,
+disable default features and enable `blocking`:
+
+```toml
+[dev-dependencies]
+redis-server-wrapper = { version = "0.1", default-features = false, features = ["blocking"] }
+```
+
+To use both async and blocking APIs together:
+
+```toml
+[dev-dependencies]
+redis-server-wrapper = { version = "0.1", features = ["blocking"] }
+```
 
 ## Usage
 
-The API is async-first and requires [tokio](https://tokio.rs). Enable the `blocking` feature
-for synchronous wrappers; see the [Blocking API](#blocking-api) section below.
+The async API requires [tokio](https://tokio.rs). See the [Blocking API](#blocking-api) section
+for synchronous use.
 
 ### Single Server
 
@@ -43,8 +68,54 @@ assert!(server.is_alive().await);
 // Stopped automatically on drop.
 ```
 
-If you want the process to keep running after the handle is consumed, call
-`server.detach()` instead of dropping it.
+The server process is stopped via `SHUTDOWN NOSAVE` when the handle is dropped.
+Call `server.detach()` to consume the handle without stopping the process.
+
+### Configuration
+
+Common options have dedicated builder methods. Anything else can be passed as
+a raw Redis directive with `.extra(key, value)`:
+
+```rust
+use redis_server_wrapper::{LogLevel, RedisServer};
+
+let server = RedisServer::new()
+    .port(6400)
+    .bind("127.0.0.1")
+    .password("secret")
+    .loglevel(LogLevel::Warning)
+    .appendonly(true)
+    .extra("maxmemory", "256mb")
+    .extra("maxmemory-policy", "allkeys-lru")
+    .start()
+    .await
+    .unwrap();
+```
+
+### Running Commands
+
+The handle exposes a `RedisCli` you can use to run arbitrary commands against the server:
+
+```rust
+use redis_server_wrapper::RedisServer;
+
+let server = RedisServer::new().port(6400).start().await.unwrap();
+
+server.run(&["SET", "key", "value"]).await.unwrap();
+let val = server.run(&["GET", "key"]).await.unwrap();
+assert_eq!(val.trim(), "value");
+```
+
+You can also get a `RedisCli` instance directly from the handle:
+
+```rust
+use redis_server_wrapper::RedisServer;
+
+let server = RedisServer::new().port(6400).start().await.unwrap();
+let cli = server.cli();
+let pong = cli.ping().await;
+assert!(pong);
+```
 
 ### Cluster
 
@@ -78,17 +149,34 @@ let sentinel = RedisSentinel::builder()
 assert!(sentinel.is_healthy().await);
 ```
 
+## Error Handling
+
+All fallible operations return `Result<T, Error>`. The `Error` enum covers server
+start failures, timeouts, CLI errors, and underlying I/O errors:
+
+```rust
+use redis_server_wrapper::{Error, RedisServer};
+
+match RedisServer::new().port(6400).start().await {
+    Ok(server) => println!("running on {}", server.addr()),
+    Err(Error::ServerStart { port }) => eprintln!("could not start on port {port}"),
+    Err(Error::BinaryNotFound { binary }) => eprintln!("{binary} not found on PATH"),
+    Err(e) => eprintln!("unexpected: {e}"),
+}
+```
+
 ## Blocking API
 
 Enable the `blocking` feature for synchronous wrappers that require no async runtime:
 
 ```toml
 [dev-dependencies]
-redis-server-wrapper = { version = "...", features = ["blocking"] }
+redis-server-wrapper = { version = "0.1", features = ["blocking"] }
 ```
 
 The `blocking` module mirrors the async API. Every operation blocks the calling thread
-until it completes:
+until it completes. Handles own a long-lived `tokio::runtime::Runtime` so that the
+underlying async `Drop` implementation keeps working correctly.
 
 ```rust
 use redis_server_wrapper::blocking::RedisServer;
@@ -126,6 +214,14 @@ let sentinel = RedisSentinel::builder()
     .unwrap();
 
 assert!(sentinel.is_healthy());
+```
+
+## Examples
+
+The crate ships a runnable example that demonstrates various server configurations:
+
+```sh
+cargo run --example redis-run
 ```
 
 ## License

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -18,7 +18,10 @@ use crate::{cli, cluster, sentinel, server};
 
 /// Synchronous wrapper for [`crate::RedisCli`].
 ///
-/// Each async method creates a single-use [`Runtime`] internally.
+/// Each method on this type blocks the calling thread by running the
+/// corresponding async operation on a temporary [`Runtime`].  For running
+/// many commands against a single server, prefer the async API which shares a
+/// long-lived runtime.
 pub struct RedisCli {
     inner: cli::RedisCli,
 }

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -40,21 +40,27 @@ pub struct RedisClusterBuilder {
 }
 
 impl RedisClusterBuilder {
+    /// Set the number of master nodes (default: `3`).
     pub fn masters(mut self, n: u16) -> Self {
         self.masters = n;
         self
     }
 
+    /// Set the number of replicas per master (default: `0`).
     pub fn replicas_per_master(mut self, n: u16) -> Self {
         self.replicas_per_master = n;
         self
     }
 
+    /// Set the base port for cluster nodes (default: `7000`).
+    ///
+    /// Nodes are assigned consecutive ports starting at this value.
     pub fn base_port(mut self, port: u16) -> Self {
         self.base_port = port;
         self
     }
 
+    /// Set the bind address for all cluster nodes (default: `"127.0.0.1"`).
     pub fn bind(mut self, bind: impl Into<String>) -> Self {
         self.bind = bind.into();
         self
@@ -78,11 +84,13 @@ impl RedisClusterBuilder {
         self
     }
 
+    /// Set a custom `redis-server` binary path.
     pub fn redis_server_bin(mut self, bin: impl Into<String>) -> Self {
         self.redis_server_bin = bin.into();
         self
     }
 
+    /// Set a custom `redis-cli` binary path.
     pub fn redis_cli_bin(mut self, bin: impl Into<String>) -> Self {
         self.redis_cli_bin = bin.into();
         self
@@ -173,7 +181,10 @@ pub struct RedisClusterHandle {
     redis_cli_bin: String,
 }
 
-/// Convenience constructor.
+/// Entry point for building a Redis Cluster topology.
+///
+/// Call [`RedisCluster::builder`] to obtain a [`RedisClusterBuilder`], then
+/// configure it and call [`RedisClusterBuilder::start`] to launch the cluster.
 pub struct RedisCluster;
 
 impl RedisCluster {

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,27 +7,44 @@ use std::io;
 pub enum Error {
     /// A `redis-server` process failed to start.
     #[error("redis-server failed to start on port {port}")]
-    ServerStart { port: u16 },
+    ServerStart {
+        /// The port on which the server failed to start.
+        port: u16,
+    },
 
     /// A sentinel process failed to start.
     #[error("sentinel failed to start on port {port}")]
-    SentinelStart { port: u16 },
+    SentinelStart {
+        /// The port on which the sentinel failed to start.
+        port: u16,
+    },
 
     /// `redis-cli --cluster create` failed.
     #[error("cluster create failed:\nstdout: {stdout}\nstderr: {stderr}")]
-    ClusterCreate { stdout: String, stderr: String },
+    ClusterCreate {
+        /// Captured stdout from the failed `redis-cli --cluster create` invocation.
+        stdout: String,
+        /// Captured stderr from the failed `redis-cli --cluster create` invocation.
+        stderr: String,
+    },
 
     /// A `redis-cli` command failed.
     #[error("redis-cli {host}:{port} failed: {detail}")]
     Cli {
+        /// The host that was targeted.
         host: String,
+        /// The port that was targeted.
         port: u16,
+        /// Stderr output or other detail from the failed invocation.
         detail: String,
     },
 
     /// A wait-for-ready or wait-for-healthy call timed out.
     #[error("{message}")]
-    Timeout { message: String },
+    Timeout {
+        /// Human-readable description of what timed out.
+        message: String,
+    },
 
     /// No sentinel was reachable.
     #[error("no reachable sentinel")]
@@ -35,7 +52,10 @@ pub enum Error {
 
     /// A required binary was not found on PATH.
     #[error("{binary} not found on PATH")]
-    BinaryNotFound { binary: String },
+    BinaryNotFound {
+        /// The binary name that could not be found.
+        binary: String,
+    },
 
     /// An underlying I/O error.
     #[error(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Type-safe wrapper for `redis-server` and `redis-cli` with builder pattern APIs.
 //!
 //! Manage Redis server processes for testing, development, and CI.

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -58,71 +58,91 @@ struct MonitoredMaster {
 }
 
 impl RedisSentinelBuilder {
+    /// Set the name of the monitored master (default: `"mymaster"`).
     pub fn master_name(mut self, name: impl Into<String>) -> Self {
         self.master_name = name.into();
         self
     }
 
+    /// Set the master's port (default: `6390`).
     pub fn master_port(mut self, port: u16) -> Self {
         self.master_port = port;
         self
     }
 
+    /// Set the number of replicas to start (default: `2`).
     pub fn replicas(mut self, n: u16) -> Self {
         self.num_replicas = n;
         self
     }
 
+    /// Set the base port for replica nodes (default: `6391`).
+    ///
+    /// Replicas are assigned consecutive ports starting at this value.
     pub fn replica_base_port(mut self, port: u16) -> Self {
         self.replica_base_port = port;
         self
     }
 
+    /// Set the number of sentinel processes to start (default: `3`).
     pub fn sentinels(mut self, n: u16) -> Self {
         self.num_sentinels = n;
         self
     }
 
+    /// Set the base port for sentinel processes (default: `26389`).
+    ///
+    /// Sentinels are assigned consecutive ports starting at this value.
     pub fn sentinel_base_port(mut self, port: u16) -> Self {
         self.sentinel_base_port = port;
         self
     }
 
+    /// Set the quorum count — how many sentinels must agree before a failover is triggered (default: `2`).
     pub fn quorum(mut self, q: u16) -> Self {
         self.quorum = q;
         self
     }
 
+    /// Set the bind address for all processes in the topology (default: `"127.0.0.1"`).
     pub fn bind(mut self, bind: impl Into<String>) -> Self {
         self.bind = bind.into();
         self
     }
 
+    /// Set the log file path for all processes in the topology.
     pub fn logfile(mut self, path: impl Into<String>) -> Self {
         self.logfile = Some(path.into());
         self
     }
 
+    /// Set the `down-after-milliseconds` threshold for all monitored masters (default: `5000`).
+    ///
+    /// A master is considered down after it fails to respond within this many milliseconds.
     pub fn down_after_ms(mut self, ms: u64) -> Self {
         self.down_after_ms = ms;
         self
     }
 
+    /// Set the `failover-timeout` for all monitored masters in milliseconds (default: `10000`).
     pub fn failover_timeout_ms(mut self, ms: u64) -> Self {
         self.failover_timeout_ms = ms;
         self
     }
 
+    /// Set an arbitrary config directive for all processes in the topology.
     pub fn extra(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.extra.insert(key.into(), value.into());
         self
     }
 
+    /// Set a custom `redis-server` binary path.
     pub fn redis_server_bin(mut self, bin: impl Into<String>) -> Self {
         self.redis_server_bin = bin.into();
         self
     }
 
+    /// Set a custom `redis-cli` binary path.
     pub fn redis_cli_bin(mut self, bin: impl Into<String>) -> Self {
         self.redis_cli_bin = bin.into();
         self
@@ -351,7 +371,10 @@ pub struct RedisSentinelHandle {
     monitored_masters: Vec<MonitoredMaster>,
 }
 
-/// Convenience constructor.
+/// Entry point for building a Redis Sentinel topology.
+///
+/// Call [`RedisSentinel::builder`] to obtain a [`RedisSentinelBuilder`], then
+/// configure it and call [`RedisSentinelBuilder::start`] to launch the topology.
 pub struct RedisSentinel;
 
 impl RedisSentinel {
@@ -423,12 +446,23 @@ impl RedisSentinelHandle {
         &self.master_name
     }
 
-    /// Query a sentinel for the current master status.
+    /// Query a sentinel for the primary monitored master's status.
+    ///
+    /// Iterates over the sentinel processes until one responds, then runs
+    /// `SENTINEL MASTER <name>` and returns the result as a flat key/value map.
+    ///
+    /// Common keys in the returned map include `"ip"`, `"port"`, `"flags"`,
+    /// `"num-slaves"`, and `"num-other-sentinels"`.
+    ///
+    /// Returns [`Error::NoReachableSentinel`] if no sentinel responds.
     pub async fn poke(&self) -> Result<HashMap<String, String>> {
         self.poke_master(&self.master_name).await
     }
 
-    /// Query a sentinel for a specific monitored master status.
+    /// Query a sentinel for a specific monitored master's status.
+    ///
+    /// Like [`poke`](Self::poke) but targets `master_name` instead of the
+    /// primary master configured for this topology.
     pub async fn poke_master(&self, master_name: &str) -> Result<HashMap<String, String>> {
         for port in &self.sentinel_ports {
             let cli = RedisCli::new()

--- a/src/server.rs
+++ b/src/server.rs
@@ -10,7 +10,11 @@ use tokio::process::Command;
 use crate::cli::RedisCli;
 use crate::error::{Error, Result};
 
-/// Builder and lifecycle manager for a single `redis-server` process.
+/// Full configuration snapshot for a single `redis-server` process.
+///
+/// This struct is populated by the [`RedisServer`] builder and passed to
+/// [`RedisServer::start`]. You rarely need to construct it directly; use the
+/// builder instead.
 ///
 /// # Example
 ///
@@ -33,73 +37,114 @@ use crate::error::{Error, Result};
 #[derive(Debug, Clone)]
 pub struct RedisServerConfig {
     // -- network --
+    /// TCP port the server listens on (default: `6379`).
     pub port: u16,
+    /// IP address to bind (default: `"127.0.0.1"`).
     pub bind: String,
+    /// Whether protected mode is enabled (default: `false`).
     pub protected_mode: bool,
+    /// TCP backlog queue length, if set.
     pub tcp_backlog: Option<u32>,
+    /// Unix domain socket path, if set.
     pub unixsocket: Option<PathBuf>,
+    /// Unix socket file permissions (e.g. `700`), if set.
     pub unixsocketperm: Option<u32>,
+    /// Idle client timeout in seconds (`0` = disabled), if set.
     pub timeout: Option<u32>,
+    /// TCP keepalive interval in seconds, if set.
     pub tcp_keepalive: Option<u32>,
 
     // -- tls --
+    /// TLS listening port, if set.
     pub tls_port: Option<u16>,
+    /// Path to the TLS certificate file, if set.
     pub tls_cert_file: Option<PathBuf>,
+    /// Path to the TLS private key file, if set.
     pub tls_key_file: Option<PathBuf>,
+    /// Path to the TLS CA certificate file, if set.
     pub tls_ca_cert_file: Option<PathBuf>,
+    /// Whether TLS client authentication is required, if set.
     pub tls_auth_clients: Option<bool>,
 
     // -- general --
+    /// Whether the server daemonizes itself (default: `true`).
     pub daemonize: bool,
+    /// Working directory for data files (default: a sub-directory of `$TMPDIR`).
     pub dir: PathBuf,
+    /// Path to the log file, if set. Defaults to `redis.log` inside the node directory.
     pub logfile: Option<String>,
+    /// Server log verbosity (default: [`LogLevel::Notice`]).
     pub loglevel: LogLevel,
+    /// Number of databases, if set (Redis default: `16`).
     pub databases: Option<u32>,
 
     // -- memory --
+    /// Maximum memory limit (e.g. `"256mb"`), if set.
     pub maxmemory: Option<String>,
+    /// Eviction policy when `maxmemory` is reached, if set.
     pub maxmemory_policy: Option<String>,
+    /// Maximum number of simultaneous client connections, if set.
     pub maxclients: Option<u32>,
 
     // -- persistence --
+    /// Whether RDB snapshots are enabled (default: `false`).
     pub save: bool,
+    /// Whether AOF persistence is enabled (default: `false`).
     pub appendonly: bool,
 
     // -- replication --
+    /// Master host and port to replicate from, if set.
     pub replicaof: Option<(String, u16)>,
+    /// Password for authenticating with a master, if set.
     pub masterauth: Option<String>,
 
     // -- security --
+    /// `requirepass` password for client connections, if set.
     pub password: Option<String>,
+    /// Path to an ACL file, if set.
     pub acl_file: Option<PathBuf>,
 
     // -- cluster --
+    /// Whether Redis Cluster mode is enabled (default: `false`).
     pub cluster_enabled: bool,
+    /// Cluster node timeout in milliseconds, if set.
     pub cluster_node_timeout: Option<u64>,
 
     // -- modules --
+    /// List of Redis module paths to load at startup.
     pub loadmodule: Vec<PathBuf>,
 
     // -- advanced --
+    /// Server tick frequency in Hz, if set (Redis default: `10`).
     pub hz: Option<u32>,
+    /// Number of I/O threads, if set.
     pub io_threads: Option<u32>,
+    /// Whether I/O threads also handle reads, if set.
     pub io_threads_do_reads: Option<bool>,
+    /// Keyspace notification event mask (e.g. `"KEA"`), if set.
     pub notify_keyspace_events: Option<String>,
 
     // -- catch-all for anything not covered above --
+    /// Arbitrary key/value directives forwarded verbatim to the config file.
     pub extra: HashMap<String, String>,
 
     // -- binary paths --
+    /// Path to the `redis-server` binary (default: `"redis-server"`).
     pub redis_server_bin: String,
+    /// Path to the `redis-cli` binary (default: `"redis-cli"`).
     pub redis_cli_bin: String,
 }
 
 /// Redis log level.
 #[derive(Debug, Clone, Copy)]
 pub enum LogLevel {
+    /// Very verbose output, useful for diagnosing Redis internals.
     Debug,
+    /// Slightly less verbose than `Debug`.
     Verbose,
+    /// Informational messages only (default).
     Notice,
+    /// Only critical events are logged.
     Warning,
 }
 
@@ -164,6 +209,7 @@ pub struct RedisServer {
 }
 
 impl RedisServer {
+    /// Create a new builder with default settings.
     pub fn new() -> Self {
         Self {
             config: RedisServerConfig::default(),


### PR DESCRIPTION
## Summary
- Add \`#![warn(missing_docs)]\` to \`lib.rs\` to enforce documentation coverage going forward
- Document all public APIs: \`RedisServerConfig\` fields (~30), \`LogLevel\` variants, error enum fields, builder methods for cluster and sentinel, and handle methods
- Expand README with installation snippet, \`RedisCli\` usage, configuration examples, error handling, feature flags, and lifecycle/drop prose
- Fix inaccurate doc comment on \`blocking::RedisCli\` struct regarding \`Runtime\` lifecycle

## Files changed
- \`src/lib.rs\` — add \`#![warn(missing_docs)]\` lint and doc comment for \`RedisServer::new()\`
- \`src/server.rs\` — document all \`RedisServerConfig\` public fields and \`LogLevel\` variants
- \`src/error.rs\` — document error enum variant fields
- \`src/cluster.rs\` — add doc comments to all \`RedisClusterBuilder\` methods, improve \`RedisCluster\` struct-level docs
- \`src/sentinel.rs\` — add doc comments to all \`RedisSentinelBuilder\` methods (~14), expand \`RedisSentinelHandle::poke()\` doc, improve \`RedisSentinel\` struct-level docs
- \`src/blocking.rs\` — fix inaccurate \`RedisCli\` struct doc
- \`src/cli.rs\` — minor doc improvements
- \`README.md\` — add installation, \`RedisCli\` usage, configuration examples, error handling, feature flags, and lifecycle sections
- \`CHANGELOG.md\` — update changelog
- \`.github/workflows/ci.yml\`, \`release-plz.yml\` — CI/release workflow updates
- \`tests/\` — test suite files (blocking, cluster, sentinel, server)

## Test plan
- \`cargo doc --no-deps --all-features\` builds without warnings
- \`cargo test --doc --all-features\` passes
- \`cargo test --lib --all-features\` passes
- \`cargo test --test '*' --all-features\` passes
- \`cargo clippy --all-targets --all-features -- -D warnings\` passes

Closes #34