### PR TITLE
feat(cli): add advanced TLS and connection arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ Cargo.lock
 *.swo
 *~
 CLAUDE.md
+# forza internal files
+.plan_breadcrumb.md
+.review_breadcrumb.md
+.forza/

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -70,6 +70,132 @@ impl RedisCli {
         self
     }
 
+    /// Connect via a Unix socket instead of TCP.
+    pub fn unixsocket(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.unixsocket(path);
+        self
+    }
+
+    /// Enable TLS for the connection.
+    pub fn tls(mut self, enable: bool) -> Self {
+        self.inner = self.inner.tls(enable);
+        self
+    }
+
+    /// Set the SNI hostname for TLS.
+    pub fn sni(mut self, hostname: impl Into<String>) -> Self {
+        self.inner = self.inner.sni(hostname);
+        self
+    }
+
+    /// Set the CA certificate file for TLS verification.
+    pub fn cacert(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.cacert(path);
+        self
+    }
+
+    /// Set the CA certificate directory for TLS verification.
+    pub fn cacertdir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.cacertdir(path);
+        self
+    }
+
+    /// Set the client certificate file for TLS.
+    pub fn cert(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.cert(path);
+        self
+    }
+
+    /// Set the client private key file for TLS.
+    pub fn key(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.key(path);
+        self
+    }
+
+    /// Skip TLS certificate verification (`--insecure`).
+    pub fn insecure(mut self, enable: bool) -> Self {
+        self.inner = self.inner.insecure(enable);
+        self
+    }
+
+    /// Set the allowed TLS 1.2 ciphers (`--tls-ciphers`).
+    pub fn tls_ciphers(mut self, ciphers: impl Into<String>) -> Self {
+        self.inner = self.inner.tls_ciphers(ciphers);
+        self
+    }
+
+    /// Set the allowed TLS 1.3 ciphersuites (`--tls-ciphersuites`).
+    pub fn tls_ciphersuites(mut self, ciphersuites: impl Into<String>) -> Self {
+        self.inner = self.inner.tls_ciphersuites(ciphersuites);
+        self
+    }
+
+    /// Set the RESP protocol version.
+    pub fn resp(mut self, protocol: cli::RespProtocol) -> Self {
+        self.inner = self.inner.resp(protocol);
+        self
+    }
+
+    /// Enable cluster mode (`-c` flag) for following redirects.
+    pub fn cluster_mode(mut self, enable: bool) -> Self {
+        self.inner = self.inner.cluster_mode(enable);
+        self
+    }
+
+    /// Set the output format.
+    pub fn output_format(mut self, format: cli::OutputFormat) -> Self {
+        self.inner = self.inner.output_format(format);
+        self
+    }
+
+    /// Suppress the AUTH password warning.
+    pub fn no_auth_warning(mut self, suppress: bool) -> Self {
+        self.inner = self.inner.no_auth_warning(suppress);
+        self
+    }
+
+    /// Set the server URI (`-u`), e.g. `redis://user:pass@host:port/db`.
+    pub fn uri(mut self, uri: impl Into<String>) -> Self {
+        self.inner = self.inner.uri(uri);
+        self
+    }
+
+    /// Set the connection timeout in seconds (`-t`).
+    pub fn timeout(mut self, seconds: f64) -> Self {
+        self.inner = self.inner.timeout(seconds);
+        self
+    }
+
+    /// Prompt for password from stdin (`--askpass`).
+    pub fn askpass(mut self, enable: bool) -> Self {
+        self.inner = self.inner.askpass(enable);
+        self
+    }
+
+    /// Set the client connection name (`--name`).
+    pub fn client_name(mut self, name: impl Into<String>) -> Self {
+        self.inner = self.inner.client_name(name);
+        self
+    }
+
+    /// Set IP version preference for connections.
+    pub fn ip_preference(mut self, preference: cli::IpPreference) -> Self {
+        self.inner = self.inner.ip_preference(preference);
+        self
+    }
+
+    /// Execute the command N times (`-r`).
+    pub fn repeat(mut self, count: u32) -> Self {
+        self.inner = self.inner.repeat(count);
+        self
+    }
+
+    /// Set interval in seconds between repeated commands (`-i`).
+    pub fn interval(mut self, seconds: f64) -> Self {
+        self.inner = self.inner.interval(seconds);
+        self
+    }
+
     /// Run a command and return stdout on success.
     pub fn run(&self, args: &[&str]) -> Result<String> {
         Runtime::new()?.block_on(self.inner.run(args))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,18 @@ pub enum RespProtocol {
     Resp3,
 }
 
+/// IP version preference for connections.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum IpPreference {
+    /// Use the system default.
+    #[default]
+    Default,
+    /// Prefer IPv4 (`-4`).
+    Ipv4,
+    /// Prefer IPv6 (`-6`).
+    Ipv6,
+}
+
 /// Output format for `redis-cli` commands.
 #[derive(Debug, Clone, Copy)]
 pub enum OutputFormat {
@@ -44,12 +56,23 @@ pub struct RedisCli {
     tls: bool,
     sni: Option<String>,
     cacert: Option<PathBuf>,
+    cacertdir: Option<PathBuf>,
     cert: Option<PathBuf>,
     key: Option<PathBuf>,
+    insecure: bool,
+    tls_ciphers: Option<String>,
+    tls_ciphersuites: Option<String>,
     resp: Option<RespProtocol>,
     cluster_mode: bool,
     output_format: OutputFormat,
     no_auth_warning: bool,
+    uri: Option<String>,
+    timeout: Option<f64>,
+    askpass: bool,
+    client_name: Option<String>,
+    ip_preference: IpPreference,
+    repeat: Option<u32>,
+    interval: Option<f64>,
 }
 
 impl RedisCli {
@@ -66,12 +89,23 @@ impl RedisCli {
             tls: false,
             sni: None,
             cacert: None,
+            cacertdir: None,
             cert: None,
             key: None,
+            insecure: false,
+            tls_ciphers: None,
+            tls_ciphersuites: None,
             resp: None,
             cluster_mode: false,
             output_format: OutputFormat::Default,
             no_auth_warning: false,
+            uri: None,
+            timeout: None,
+            askpass: false,
+            client_name: None,
+            ip_preference: IpPreference::Default,
+            repeat: None,
+            interval: None,
         }
     }
 
@@ -144,6 +178,72 @@ impl RedisCli {
     /// Set the client private key file for TLS.
     pub fn key(mut self, path: impl Into<PathBuf>) -> Self {
         self.key = Some(path.into());
+        self
+    }
+
+    /// Set the CA certificate directory for TLS verification.
+    pub fn cacertdir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.cacertdir = Some(path.into());
+        self
+    }
+
+    /// Skip TLS certificate verification (`--insecure`).
+    pub fn insecure(mut self, enable: bool) -> Self {
+        self.insecure = enable;
+        self
+    }
+
+    /// Set the allowed TLS 1.2 ciphers (`--tls-ciphers`).
+    pub fn tls_ciphers(mut self, ciphers: impl Into<String>) -> Self {
+        self.tls_ciphers = Some(ciphers.into());
+        self
+    }
+
+    /// Set the allowed TLS 1.3 ciphersuites (`--tls-ciphersuites`).
+    pub fn tls_ciphersuites(mut self, ciphersuites: impl Into<String>) -> Self {
+        self.tls_ciphersuites = Some(ciphersuites.into());
+        self
+    }
+
+    /// Set the server URI (`-u`), e.g. `redis://user:pass@host:port/db`.
+    pub fn uri(mut self, uri: impl Into<String>) -> Self {
+        self.uri = Some(uri.into());
+        self
+    }
+
+    /// Set the connection timeout in seconds (`-t`).
+    pub fn timeout(mut self, seconds: f64) -> Self {
+        self.timeout = Some(seconds);
+        self
+    }
+
+    /// Prompt for password from stdin (`--askpass`).
+    pub fn askpass(mut self, enable: bool) -> Self {
+        self.askpass = enable;
+        self
+    }
+
+    /// Set the client connection name (`--name`).
+    pub fn client_name(mut self, name: impl Into<String>) -> Self {
+        self.client_name = Some(name.into());
+        self
+    }
+
+    /// Set IP version preference for connections.
+    pub fn ip_preference(mut self, preference: IpPreference) -> Self {
+        self.ip_preference = preference;
+        self
+    }
+
+    /// Execute the command N times (`-r`).
+    pub fn repeat(mut self, count: u32) -> Self {
+        self.repeat = Some(count);
+        self
+    }
+
+    /// Set interval in seconds between repeated commands (`-i`).
+    pub fn interval(mut self, seconds: f64) -> Self {
+        self.interval = Some(seconds);
         self
     }
 
@@ -263,7 +363,11 @@ impl RedisCli {
     fn base_args(&self) -> Vec<String> {
         let mut args = Vec::new();
 
-        if let Some(ref path) = self.unixsocket {
+        // Connection
+        if let Some(ref uri) = self.uri {
+            args.push("-u".to_string());
+            args.push(uri.clone());
+        } else if let Some(ref path) = self.unixsocket {
             args.push("-s".to_string());
             args.push(path.display().to_string());
         } else {
@@ -273,6 +377,7 @@ impl RedisCli {
             args.push(self.port.to_string());
         }
 
+        // Auth
         if let Some(ref user) = self.user {
             args.push("--user".to_string());
             args.push(user.clone());
@@ -281,9 +386,41 @@ impl RedisCli {
             args.push("-a".to_string());
             args.push(pw.clone());
         }
+        if self.askpass {
+            args.push("--askpass".to_string());
+        }
         if let Some(db) = self.db {
             args.push("-n".to_string());
             args.push(db.to_string());
+        }
+
+        // Client name
+        if let Some(ref name) = self.client_name {
+            args.push("--name".to_string());
+            args.push(name.clone());
+        }
+
+        // IP preference
+        match self.ip_preference {
+            IpPreference::Default => {}
+            IpPreference::Ipv4 => args.push("-4".to_string()),
+            IpPreference::Ipv6 => args.push("-6".to_string()),
+        }
+
+        // Timeout
+        if let Some(t) = self.timeout {
+            args.push("-t".to_string());
+            args.push(t.to_string());
+        }
+
+        // Repeat / interval
+        if let Some(r) = self.repeat {
+            args.push("-r".to_string());
+            args.push(r.to_string());
+        }
+        if let Some(i) = self.interval {
+            args.push("-i".to_string());
+            args.push(i.to_string());
         }
 
         // TLS
@@ -298,6 +435,10 @@ impl RedisCli {
             args.push("--cacert".to_string());
             args.push(path.display().to_string());
         }
+        if let Some(ref path) = self.cacertdir {
+            args.push("--cacertdir".to_string());
+            args.push(path.display().to_string());
+        }
         if let Some(ref path) = self.cert {
             args.push("--cert".to_string());
             args.push(path.display().to_string());
@@ -305,6 +446,17 @@ impl RedisCli {
         if let Some(ref path) = self.key {
             args.push("--key".to_string());
             args.push(path.display().to_string());
+        }
+        if self.insecure {
+            args.push("--insecure".to_string());
+        }
+        if let Some(ref ciphers) = self.tls_ciphers {
+            args.push("--tls-ciphers".to_string());
+            args.push(ciphers.clone());
+        }
+        if let Some(ref suites) = self.tls_ciphersuites {
+            args.push("--tls-ciphersuites".to_string());
+            args.push(suites.clone());
         }
 
         // Protocol

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ pub mod server;
 pub mod blocking;
 
 #[cfg(feature = "tokio")]
-pub use cli::{OutputFormat, RedisCli, RespProtocol};
+pub use cli::{IpPreference, OutputFormat, RedisCli, RespProtocol};
 #[cfg(feature = "tokio")]
 pub use cluster::{RedisCluster, RedisClusterBuilder, RedisClusterHandle};
 pub use error::{Error, Result};


### PR DESCRIPTION
## Summary
- Added advanced TLS arguments to `RedisCli`: `cacertdir`, `insecure`, `tls_ciphers`, `tls_ciphersuites`
- Added connection arguments: `uri`, `timeout`, `askpass`, `client_name`, `ip_preference`, `repeat`, `interval`
- New public `IpPreference` enum exported from `lib.rs`
- All new options correctly serialized to CLI flags in `base_args()` for both async and blocking wrappers

## Files changed
- `src/cli.rs` - Added new builder fields, methods, and `base_args()` serialization for TLS and connection arguments
- `src/blocking.rs` - Added blocking wrapper delegation methods for all new builder options
- `src/lib.rs` - Exported new `IpPreference` enum

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --lib --all-features` passes (12/12)
- [x] `cargo doc --no-deps --all-features` builds without warnings
- [ ] Consider adding unit tests for new builder methods and `base_args()` serialization of new flags

Closes #47