### PR TITLE
feat(cluster): add per-node access and CONFIG SET helpers

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1724,6 +1724,31 @@ impl RedisClusterHandle {
         self.inner.pids()
     }
 
+    /// The number of master nodes in the cluster.
+    pub fn num_masters(&self) -> u16 {
+        self.inner.num_masters()
+    }
+
+    /// Run a command against a specific node by index.
+    pub fn node_run(&self, index: usize, args: &[&str]) -> Result<String> {
+        self.rt.block_on(self.inner.node(index).run(args))
+    }
+
+    /// Run `CONFIG SET` on all nodes.
+    pub fn config_set_all(&self, key: &str, value: &str) -> Result<()> {
+        self.rt.block_on(self.inner.config_set_all(key, value))
+    }
+
+    /// Run `CONFIG SET` on master nodes only (initial topology).
+    pub fn config_set_masters(&self, key: &str, value: &str) -> Result<()> {
+        self.rt.block_on(self.inner.config_set_masters(key, value))
+    }
+
+    /// Run `CONFIG SET` on replica nodes only (initial topology).
+    pub fn config_set_replicas(&self, key: &str, value: &str) -> Result<()> {
+        self.rt.block_on(self.inner.config_set_replicas(key, value))
+    }
+
     /// Check if all nodes are alive.
     pub fn all_alive(&self) -> bool {
         self.rt.block_on(self.inner.all_alive())

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -494,6 +494,7 @@ impl RedisClusterBuilder {
 
         Ok(RedisClusterHandle {
             nodes,
+            num_masters: self.masters,
             bind: self.bind,
             base_port: self.base_port,
             password: self.password,
@@ -505,6 +506,7 @@ impl RedisClusterBuilder {
 /// A running Redis Cluster. Stops all nodes on Drop.
 pub struct RedisClusterHandle {
     nodes: Vec<RedisServerHandle>,
+    num_masters: u16,
     bind: String,
     base_port: u16,
     password: Option<String>,
@@ -615,6 +617,68 @@ impl RedisClusterHandle {
             }
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
+    }
+
+    /// Access a specific node by index.
+    ///
+    /// Nodes are ordered by port: masters first (indices `0..masters`),
+    /// then replicas (indices `masters..total`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index >= total_nodes`.
+    pub fn node(&self, index: usize) -> &RedisServerHandle {
+        &self.nodes[index]
+    }
+
+    /// All node handles.
+    pub fn nodes(&self) -> &[RedisServerHandle] {
+        &self.nodes
+    }
+
+    /// The number of master nodes in the cluster.
+    pub fn num_masters(&self) -> u16 {
+        self.num_masters
+    }
+
+    /// Handles for the master nodes (the first `masters` nodes by port order).
+    ///
+    /// Note: this reflects the *initial* topology. After a failover, the actual
+    /// roles may differ from the startup ordering.
+    pub fn master_nodes(&self) -> &[RedisServerHandle] {
+        &self.nodes[..self.num_masters as usize]
+    }
+
+    /// Handles for the replica nodes (all nodes after the masters by port order).
+    ///
+    /// Note: this reflects the *initial* topology. After a failover, the actual
+    /// roles may differ from the startup ordering.
+    pub fn replica_nodes(&self) -> &[RedisServerHandle] {
+        &self.nodes[self.num_masters as usize..]
+    }
+
+    /// Run `CONFIG SET` on all nodes.
+    pub async fn config_set_all(&self, key: &str, value: &str) -> Result<()> {
+        for node in &self.nodes {
+            node.run(&["CONFIG", "SET", key, value]).await?;
+        }
+        Ok(())
+    }
+
+    /// Run `CONFIG SET` on master nodes only (initial topology).
+    pub async fn config_set_masters(&self, key: &str, value: &str) -> Result<()> {
+        for node in self.master_nodes() {
+            node.run(&["CONFIG", "SET", key, value]).await?;
+        }
+        Ok(())
+    }
+
+    /// Run `CONFIG SET` on replica nodes only (initial topology).
+    pub async fn config_set_replicas(&self, key: &str, value: &str) -> Result<()> {
+        for node in self.replica_nodes() {
+            node.run(&["CONFIG", "SET", key, value]).await?;
+        }
+        Ok(())
     }
 
     /// Get a `RedisCli` for the seed node.

--- a/tests/cluster.rs
+++ b/tests/cluster.rs
@@ -61,3 +61,65 @@ async fn cluster_password_auth() {
     let pong = cluster.cli().run(&["PING"]).await.unwrap();
     assert_eq!(pong.trim(), "PONG");
 }
+
+#[tokio::test]
+async fn cluster_node_access_and_config_set() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(1)
+        .base_port(17020)
+        .start()
+        .await
+        .expect("failed to start cluster");
+
+    cluster
+        .wait_for_healthy(std::time::Duration::from_secs(30))
+        .await
+        .expect("cluster did not become healthy");
+
+    // Verify topology counts.
+    assert_eq!(cluster.nodes().len(), 6);
+    assert_eq!(cluster.num_masters(), 3);
+    assert_eq!(cluster.master_nodes().len(), 3);
+    assert_eq!(cluster.replica_nodes().len(), 3);
+
+    // Access individual node by index.
+    let node0 = cluster.node(0);
+    assert!(node0.is_alive().await);
+
+    // CONFIG SET on all nodes.
+    cluster
+        .config_set_all("hz", "20")
+        .await
+        .expect("config_set_all failed");
+    for node in cluster.nodes() {
+        let val = node.run(&["CONFIG", "GET", "hz"]).await.unwrap();
+        assert!(val.contains("20"));
+    }
+
+    // CONFIG SET on masters only.
+    cluster
+        .config_set_masters("slowlog-log-slower-than", "5000")
+        .await
+        .expect("config_set_masters failed");
+    for node in cluster.master_nodes() {
+        let val = node
+            .run(&["CONFIG", "GET", "slowlog-log-slower-than"])
+            .await
+            .unwrap();
+        assert!(val.contains("5000"));
+    }
+
+    // CONFIG SET on replicas only.
+    cluster
+        .config_set_replicas("slowlog-max-len", "256")
+        .await
+        .expect("config_set_replicas failed");
+    for node in cluster.replica_nodes() {
+        let val = node
+            .run(&["CONFIG", "GET", "slowlog-max-len"])
+            .await
+            .unwrap();
+        assert!(val.contains("256"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `node(index)`, `nodes()`, `master_nodes()`, `replica_nodes()`, and `num_masters()` accessors on `RedisClusterHandle` for direct per-node interaction
- Add `config_set_all()`, `config_set_masters()`, and `config_set_replicas()` for targeted runtime CONFIG SET across node roles
- Store master count in the handle to distinguish masters from replicas by initial topology order
- Blocking wrappers: `node_run(index, args)`, `config_set_all/masters/replicas`, `num_masters()`
- Integration test exercising node access, per-role CONFIG SET, and topology counts

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] All 41 tests pass (20 unit + 21 integration)
- [x] New integration test: `cluster_node_access_and_config_set` (3 masters + 3 replicas, verifies node access, config_set_all, config_set_masters, config_set_replicas)