### PR TITLE
feat(cluster): add per-node configuration callback

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -7,6 +7,44 @@ use crate::cli::RedisCli;
 use crate::error::{Error, Result};
 use crate::server::{RedisServer, RedisServerHandle, SavePolicy};
 
+/// Context passed to the per-node configuration callback.
+///
+/// Provides information about the node being configured so the callback
+/// can make per-node decisions (e.g., different config for masters vs. replicas,
+/// or for a specific node index).
+pub struct NodeContext {
+    /// The pre-configured [`RedisServer`] builder for this node.
+    ///
+    /// All uniform cluster-level settings have already been applied.
+    /// The callback should modify and return this builder.
+    pub server: RedisServer,
+    /// Zero-based index of this node in the cluster.
+    ///
+    /// Nodes are ordered by port: masters occupy indices `0..masters`,
+    /// replicas occupy indices `masters..total`.
+    pub index: usize,
+    /// The port assigned to this node.
+    pub port: u16,
+    /// Total number of nodes in the cluster.
+    pub total_nodes: u16,
+    /// Number of master nodes.
+    pub masters: u16,
+    /// Number of replicas per master.
+    pub replicas_per_master: u16,
+}
+
+impl NodeContext {
+    /// Whether this node is a master (by initial topology order).
+    pub fn is_master(&self) -> bool {
+        self.index < self.masters as usize
+    }
+
+    /// Whether this node is a replica (by initial topology order).
+    pub fn is_replica(&self) -> bool {
+        !self.is_master()
+    }
+}
+
 /// Builder for a Redis Cluster.
 ///
 /// # Example
@@ -66,6 +104,7 @@ pub struct RedisClusterBuilder {
     extra: HashMap<String, String>,
     redis_server_bin: String,
     redis_cli_bin: String,
+    node_config_fn: Option<Box<dyn FnMut(NodeContext) -> RedisServer + Send>>,
 }
 
 impl RedisClusterBuilder {
@@ -318,6 +357,48 @@ impl RedisClusterBuilder {
         self
     }
 
+    /// Set a per-node configuration callback.
+    ///
+    /// The callback receives a [`NodeContext`] containing the pre-configured
+    /// [`RedisServer`] builder (with all uniform settings already applied) and
+    /// metadata about the node's position in the cluster. It must return the
+    /// (possibly modified) `RedisServer` builder.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use redis_server_wrapper::RedisCluster;
+    ///
+    /// # async fn example() {
+    /// let cluster = RedisCluster::builder()
+    ///     .masters(3)
+    ///     .replicas_per_master(1)
+    ///     .base_port(7000)
+    ///     .with_node_config(|ctx| {
+    ///         let is_replica = ctx.is_replica();
+    ///         let index = ctx.index;
+    ///         let mut server = ctx.server;
+    ///         if is_replica {
+    ///             server = server.cluster_replica_no_failover(true);
+    ///         }
+    ///         if index == 0 {
+    ///             server = server.maxmemory("512mb");
+    ///         }
+    ///         server
+    ///     })
+    ///     .start()
+    ///     .await
+    ///     .unwrap();
+    /// # }
+    /// ```
+    pub fn with_node_config(
+        mut self,
+        f: impl FnMut(NodeContext) -> RedisServer + Send + 'static,
+    ) -> Self {
+        self.node_config_fn = Some(Box::new(f));
+        self
+    }
+
     /// Set an arbitrary config directive for all cluster nodes.
     pub fn extra(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.extra.insert(key.into(), value.into());
@@ -347,7 +428,7 @@ impl RedisClusterBuilder {
     }
 
     /// Start all nodes and form the cluster.
-    pub async fn start(self) -> Result<RedisClusterHandle> {
+    pub async fn start(mut self) -> Result<RedisClusterHandle> {
         // Stop any leftover nodes from previous runs.
         for port in self.ports() {
             let mut cli = RedisCli::new()
@@ -362,8 +443,10 @@ impl RedisClusterBuilder {
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         // Start each node.
+        let total_nodes = self.total_nodes();
+        let ports: Vec<u16> = self.ports().collect();
         let mut nodes = Vec::new();
-        for port in self.ports() {
+        for (index, port) in ports.into_iter().enumerate() {
             let node_dir = std::env::temp_dir().join(format!("redis-cluster-wrapper/node-{port}"));
             let _ = std::fs::remove_dir_all(&node_dir);
             let mut server = RedisServer::new()
@@ -473,6 +556,17 @@ impl RedisClusterBuilder {
             for (key, value) in &self.extra {
                 server = server.extra(key.clone(), value.clone());
             }
+            // Apply per-node customization if configured.
+            if let Some(ref mut f) = self.node_config_fn {
+                server = f(NodeContext {
+                    server,
+                    index,
+                    port,
+                    total_nodes,
+                    masters: self.masters,
+                    replicas_per_master: self.replicas_per_master,
+                });
+            }
             let handle = server.start().await?;
             nodes.push(handle);
         }
@@ -559,6 +653,7 @@ impl RedisCluster {
             extra: HashMap::new(),
             redis_server_bin: "redis-server".into(),
             redis_cli_bin: "redis-cli".into(),
+            node_config_fn: None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ pub mod blocking;
 #[cfg(feature = "tokio")]
 pub use cli::{IpPreference, OutputFormat, RedisCli, RespProtocol};
 #[cfg(feature = "tokio")]
-pub use cluster::{RedisCluster, RedisClusterBuilder, RedisClusterHandle};
+pub use cluster::{NodeContext, RedisCluster, RedisClusterBuilder, RedisClusterHandle};
 pub use error::{Error, Result};
 #[cfg(feature = "tokio")]
 pub use sentinel::{RedisSentinel, RedisSentinelBuilder, RedisSentinelHandle};

--- a/tests/cluster.rs
+++ b/tests/cluster.rs
@@ -61,3 +61,64 @@ async fn cluster_password_auth() {
     let pong = cluster.cli().run(&["PING"]).await.unwrap();
     assert_eq!(pong.trim(), "PONG");
 }
+
+#[tokio::test]
+async fn cluster_with_node_config() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(1)
+        .base_port(17020)
+        .with_node_config(|ctx| {
+            let is_master = ctx.is_master();
+            let index = ctx.index;
+            let mut server = ctx.server;
+            if is_master {
+                server = server.maxmemory("20mb");
+            } else {
+                server = server.maxmemory("10mb");
+            }
+            if index == 0 {
+                server = server.slowlog_max_len(512);
+            }
+            server
+        })
+        .start()
+        .await
+        .expect("failed to start cluster with node config");
+
+    cluster
+        .wait_for_healthy(std::time::Duration::from_secs(30))
+        .await
+        .expect("cluster did not become healthy");
+
+    // Verify master nodes got 20mb.
+    for port in [17020, 17021, 17022] {
+        let cli = redis_server_wrapper::RedisCli::new().port(port);
+        let val = cli.run(&["CONFIG", "GET", "maxmemory"]).await.unwrap();
+        assert!(
+            val.contains("20971520") || val.contains("20mb"),
+            "master on port {port} should have 20mb, got: {val}"
+        );
+    }
+
+    // Verify replica nodes got 10mb.
+    for port in [17023, 17024, 17025] {
+        let cli = redis_server_wrapper::RedisCli::new().port(port);
+        let val = cli.run(&["CONFIG", "GET", "maxmemory"]).await.unwrap();
+        assert!(
+            val.contains("10485760") || val.contains("10mb"),
+            "replica on port {port} should have 10mb, got: {val}"
+        );
+    }
+
+    // Verify node 0 got the custom slowlog setting.
+    let cli = redis_server_wrapper::RedisCli::new().port(17020);
+    let val = cli
+        .run(&["CONFIG", "GET", "slowlog-max-len"])
+        .await
+        .unwrap();
+    assert!(
+        val.contains("512"),
+        "node 0 should have slowlog-max-len 512, got: {val}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `with_node_config()` to `RedisClusterBuilder`, accepting a closure that receives a `NodeContext` and returns a customized `RedisServer` builder
- `NodeContext` provides the pre-configured server builder plus node metadata: index, port, total_nodes, masters, replicas_per_master
- `NodeContext::is_master()` / `is_replica()` helpers for role-based decisions without manual index math
- Export `NodeContext` from the crate root

This enables per-node configuration at startup time, e.g. different maxmemory for masters vs replicas, or disabling failover on specific replica nodes.

## Example

```rust
let cluster = RedisCluster::builder()
    .masters(3)
    .replicas_per_master(1)
    .with_node_config(|ctx| {
        let is_replica = ctx.is_replica();
        let mut server = ctx.server;
        if is_replica {
            server = server.cluster_replica_no_failover(true);
        }
        server
    })
    .start()
    .await?;
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] All 41 tests pass (20 unit + 21 integration)
- [x] New integration test: `cluster_with_node_config` (3 masters + 3 replicas, verifies per-role maxmemory and per-node slowlog-max-len)