### PR TITLE
feat: TLS cert generation and internal CLI wiring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,13 @@ exclude = [".github/", "tests/", "examples/"]
 default = ["tokio"]
 tokio = ["dep:tokio"]
 blocking = ["tokio"]
+test-tls = ["dep:rcgen"]
 
 [dependencies]
 thiserror = "2"
 tokio = { version = "1", features = ["process", "time", "rt", "macros", "rt-multi-thread"], optional = true }
 which = "7"
+rcgen = { version = "0.13", optional = true }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1676,6 +1676,56 @@ impl RedisClusterBuilder {
         self
     }
 
+    // -- TLS directives --
+
+    /// Set the TLS listening port for all cluster nodes.
+    pub fn tls_port(mut self, port: u16) -> Self {
+        self.inner = self.inner.tls_port(port);
+        self
+    }
+
+    /// Set the TLS certificate file path for all cluster nodes.
+    pub fn tls_cert_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.tls_cert_file(path);
+        self
+    }
+
+    /// Set the TLS private key file path for all cluster nodes.
+    pub fn tls_key_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.tls_key_file(path);
+        self
+    }
+
+    /// Set the TLS CA certificate file path for all cluster nodes.
+    pub fn tls_ca_cert_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.tls_ca_cert_file(path);
+        self
+    }
+
+    /// Set the TLS CA certificate directory for all cluster nodes.
+    pub fn tls_ca_cert_dir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.tls_ca_cert_dir(path);
+        self
+    }
+
+    /// Require TLS client authentication for all cluster nodes.
+    pub fn tls_auth_clients(mut self, auth: bool) -> Self {
+        self.inner = self.inner.tls_auth_clients(auth);
+        self
+    }
+
+    /// Use TLS for replication traffic between cluster nodes.
+    pub fn tls_replication(mut self, enable: bool) -> Self {
+        self.inner = self.inner.tls_replication(enable);
+        self
+    }
+
+    /// Use TLS for cluster bus communication between nodes.
+    pub fn tls_cluster(mut self, enable: bool) -> Self {
+        self.inner = self.inner.tls_cluster(enable);
+        self
+    }
+
     /// Set an arbitrary config directive for all cluster nodes.
     pub fn extra(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.inner = self.inner.extra(key, value);
@@ -1886,6 +1936,50 @@ impl RedisSentinelBuilder {
     /// Enable or disable AOF persistence for all data-bearing processes in the topology.
     pub fn appendonly(mut self, appendonly: bool) -> Self {
         self.inner = self.inner.appendonly(appendonly);
+        self
+    }
+
+    // -- TLS directives --
+
+    /// Set the TLS listening port for all nodes.
+    pub fn tls_port(mut self, port: u16) -> Self {
+        self.inner = self.inner.tls_port(port);
+        self
+    }
+
+    /// Set the TLS certificate file path for all nodes.
+    pub fn tls_cert_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.tls_cert_file(path);
+        self
+    }
+
+    /// Set the TLS private key file path for all nodes.
+    pub fn tls_key_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.tls_key_file(path);
+        self
+    }
+
+    /// Set the TLS CA certificate file path for all nodes.
+    pub fn tls_ca_cert_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.tls_ca_cert_file(path);
+        self
+    }
+
+    /// Set the TLS CA certificate directory for all nodes.
+    pub fn tls_ca_cert_dir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.tls_ca_cert_dir(path);
+        self
+    }
+
+    /// Require TLS client authentication for all nodes.
+    pub fn tls_auth_clients(mut self, auth: bool) -> Self {
+        self.inner = self.inner.tls_auth_clients(auth);
+        self
+    }
+
+    /// Use TLS for replication traffic between nodes.
+    pub fn tls_replication(mut self, enable: bool) -> Self {
+        self.inner = self.inner.tls_replication(enable);
         self
     }
 

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1,6 +1,7 @@
 //! Redis Cluster lifecycle management built on `RedisServer`.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::cli::RedisCli;
@@ -101,6 +102,14 @@ pub struct RedisClusterBuilder {
     repl_diskless_sync_delay: Option<u32>,
     repl_ping_replica_period: Option<u32>,
     repl_timeout: Option<u32>,
+    tls_port: Option<u16>,
+    tls_cert_file: Option<PathBuf>,
+    tls_key_file: Option<PathBuf>,
+    tls_ca_cert_file: Option<PathBuf>,
+    tls_ca_cert_dir: Option<PathBuf>,
+    tls_auth_clients: Option<bool>,
+    tls_replication: Option<bool>,
+    tls_cluster: Option<bool>,
     extra: HashMap<String, String>,
     redis_server_bin: String,
     redis_cli_bin: String,
@@ -357,6 +366,56 @@ impl RedisClusterBuilder {
         self
     }
 
+    // -- TLS directives --
+
+    /// Set the TLS listening port for all cluster nodes.
+    pub fn tls_port(mut self, port: u16) -> Self {
+        self.tls_port = Some(port);
+        self
+    }
+
+    /// Set the TLS certificate file path for all cluster nodes.
+    pub fn tls_cert_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.tls_cert_file = Some(path.into());
+        self
+    }
+
+    /// Set the TLS private key file path for all cluster nodes.
+    pub fn tls_key_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.tls_key_file = Some(path.into());
+        self
+    }
+
+    /// Set the TLS CA certificate file path for all cluster nodes.
+    pub fn tls_ca_cert_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.tls_ca_cert_file = Some(path.into());
+        self
+    }
+
+    /// Set the TLS CA certificate directory for all cluster nodes.
+    pub fn tls_ca_cert_dir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.tls_ca_cert_dir = Some(path.into());
+        self
+    }
+
+    /// Require TLS client authentication for all cluster nodes.
+    pub fn tls_auth_clients(mut self, auth: bool) -> Self {
+        self.tls_auth_clients = Some(auth);
+        self
+    }
+
+    /// Use TLS for replication traffic between cluster nodes.
+    pub fn tls_replication(mut self, enable: bool) -> Self {
+        self.tls_replication = Some(enable);
+        self
+    }
+
+    /// Use TLS for cluster bus communication between nodes.
+    pub fn tls_cluster(mut self, enable: bool) -> Self {
+        self.tls_cluster = Some(enable);
+        self
+    }
+
     /// Set a per-node configuration callback.
     ///
     /// The callback receives a [`NodeContext`] containing the pre-configured
@@ -427,6 +486,30 @@ impl RedisClusterBuilder {
         (0..total).map(move |i| base + i)
     }
 
+    /// Whether TLS is configured (cert + key present).
+    fn has_tls(&self) -> bool {
+        self.tls_cert_file.is_some() && self.tls_key_file.is_some()
+    }
+
+    /// Apply TLS flags to a CLI instance based on builder config.
+    fn apply_tls_to_cli(&self, mut cli: RedisCli) -> RedisCli {
+        if self.has_tls() {
+            cli = cli.tls(true);
+            if let Some(ref ca) = self.tls_ca_cert_file {
+                cli = cli.cacert(ca);
+            } else {
+                cli = cli.insecure(true);
+            }
+            if let Some(ref cert) = self.tls_cert_file {
+                cli = cli.cert(cert);
+            }
+            if let Some(ref key) = self.tls_key_file {
+                cli = cli.key(key);
+            }
+        }
+        cli
+    }
+
     /// Start all nodes and form the cluster.
     pub async fn start(mut self) -> Result<RedisClusterHandle> {
         // Stop any leftover nodes from previous runs.
@@ -438,6 +521,7 @@ impl RedisClusterBuilder {
             if let Some(ref password) = self.password {
                 cli = cli.password(password);
             }
+            cli = self.apply_tls_to_cli(cli);
             cli.shutdown();
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -553,6 +637,31 @@ impl RedisClusterBuilder {
             if let Some(appendonly) = self.appendonly {
                 server = server.appendonly(appendonly);
             }
+            // TLS directives.
+            if let Some(port) = self.tls_port {
+                server = server.tls_port(port + index as u16);
+            }
+            if let Some(ref path) = self.tls_cert_file {
+                server = server.tls_cert_file(path);
+            }
+            if let Some(ref path) = self.tls_key_file {
+                server = server.tls_key_file(path);
+            }
+            if let Some(ref path) = self.tls_ca_cert_file {
+                server = server.tls_ca_cert_file(path);
+            }
+            if let Some(ref path) = self.tls_ca_cert_dir {
+                server = server.tls_ca_cert_dir(path);
+            }
+            if let Some(v) = self.tls_auth_clients {
+                server = server.tls_auth_clients(v);
+            }
+            if let Some(v) = self.tls_replication {
+                server = server.tls_replication(v);
+            }
+            if let Some(v) = self.tls_cluster {
+                server = server.tls_cluster(v);
+            }
             for (key, value) in &self.extra {
                 server = server.extra(key.clone(), value.clone());
             }
@@ -580,6 +689,7 @@ impl RedisClusterBuilder {
         if let Some(ref password) = self.password {
             cli = cli.password(password);
         }
+        cli = self.apply_tls_to_cli(cli);
         cli.cluster_create(&node_addrs, self.replicas_per_master)
             .await?;
 
@@ -593,7 +703,44 @@ impl RedisClusterBuilder {
             base_port: self.base_port,
             password: self.password,
             redis_cli_bin: self.redis_cli_bin,
+            tls: TlsConfig {
+                cert_file: self.tls_cert_file,
+                key_file: self.tls_key_file,
+                ca_cert_file: self.tls_ca_cert_file,
+            },
         })
+    }
+}
+
+/// TLS configuration snapshot stored in the handle for building CLI instances.
+#[derive(Clone, Debug, Default)]
+struct TlsConfig {
+    cert_file: Option<PathBuf>,
+    key_file: Option<PathBuf>,
+    ca_cert_file: Option<PathBuf>,
+}
+
+impl TlsConfig {
+    fn has_tls(&self) -> bool {
+        self.cert_file.is_some() && self.key_file.is_some()
+    }
+
+    fn apply(&self, mut cli: RedisCli) -> RedisCli {
+        if self.has_tls() {
+            cli = cli.tls(true);
+            if let Some(ref ca) = self.ca_cert_file {
+                cli = cli.cacert(ca);
+            } else {
+                cli = cli.insecure(true);
+            }
+            if let Some(ref cert) = self.cert_file {
+                cli = cli.cert(cert);
+            }
+            if let Some(ref key) = self.key_file {
+                cli = cli.key(key);
+            }
+        }
+        cli
     }
 }
 
@@ -605,6 +752,7 @@ pub struct RedisClusterHandle {
     base_port: u16,
     password: Option<String>,
     redis_cli_bin: String,
+    tls: TlsConfig,
 }
 
 /// Entry point for building a Redis Cluster topology.
@@ -652,6 +800,14 @@ impl RedisCluster {
             repl_diskless_sync_delay: None,
             repl_ping_replica_period: None,
             repl_timeout: None,
+            tls_port: None,
+            tls_cert_file: None,
+            tls_key_file: None,
+            tls_ca_cert_file: None,
+            tls_ca_cert_dir: None,
+            tls_auth_clients: None,
+            tls_replication: None,
+            tls_cluster: None,
             extra: HashMap::new(),
             redis_server_bin: "redis-server".into(),
             redis_cli_bin: "redis-cli".into(),
@@ -785,6 +941,7 @@ impl RedisClusterHandle {
         if let Some(ref password) = self.password {
             cli = cli.password(password);
         }
+        cli = self.tls.apply(cli);
         cli
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,10 @@ pub enum Error {
         binary: String,
     },
 
+    /// A TLS certificate generation error.
+    #[error("TLS error: {0}")]
+    Tls(String),
+
     /// An underlying I/O error.
     #[error(transparent)]
     Io(#[from] io::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,9 @@ pub mod server;
 #[cfg(feature = "blocking")]
 pub mod blocking;
 
+#[cfg(feature = "test-tls")]
+pub mod tls;
+
 #[cfg(feature = "tokio")]
 pub use cli::{IpPreference, OutputFormat, RedisCli, RespProtocol};
 #[cfg(feature = "tokio")]

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::fs;
+use std::path::PathBuf;
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -45,6 +46,13 @@ pub struct RedisSentinelBuilder {
     appendonly: Option<bool>,
     down_after_ms: u64,
     failover_timeout_ms: u64,
+    tls_port: Option<u16>,
+    tls_cert_file: Option<PathBuf>,
+    tls_key_file: Option<PathBuf>,
+    tls_ca_cert_file: Option<PathBuf>,
+    tls_ca_cert_dir: Option<PathBuf>,
+    tls_auth_clients: Option<bool>,
+    tls_replication: Option<bool>,
     extra: HashMap<String, String>,
     redis_server_bin: String,
     redis_cli_bin: String,
@@ -160,6 +168,50 @@ impl RedisSentinelBuilder {
         self
     }
 
+    // -- TLS directives --
+
+    /// Set the TLS listening port for the master and replica nodes.
+    pub fn tls_port(mut self, port: u16) -> Self {
+        self.tls_port = Some(port);
+        self
+    }
+
+    /// Set the TLS certificate file path for all nodes.
+    pub fn tls_cert_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.tls_cert_file = Some(path.into());
+        self
+    }
+
+    /// Set the TLS private key file path for all nodes.
+    pub fn tls_key_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.tls_key_file = Some(path.into());
+        self
+    }
+
+    /// Set the TLS CA certificate file path for all nodes.
+    pub fn tls_ca_cert_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.tls_ca_cert_file = Some(path.into());
+        self
+    }
+
+    /// Set the TLS CA certificate directory for all nodes.
+    pub fn tls_ca_cert_dir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.tls_ca_cert_dir = Some(path.into());
+        self
+    }
+
+    /// Require TLS client authentication for all nodes.
+    pub fn tls_auth_clients(mut self, auth: bool) -> Self {
+        self.tls_auth_clients = Some(auth);
+        self
+    }
+
+    /// Use TLS for replication traffic between nodes.
+    pub fn tls_replication(mut self, enable: bool) -> Self {
+        self.tls_replication = Some(enable);
+        self
+    }
+
     /// Set an arbitrary config directive for all processes in the topology.
     pub fn extra(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.extra.insert(key.into(), value.into());
@@ -210,6 +262,56 @@ impl RedisSentinelBuilder {
         self
     }
 
+    /// Whether TLS is configured (cert + key present).
+    fn has_tls(&self) -> bool {
+        self.tls_cert_file.is_some() && self.tls_key_file.is_some()
+    }
+
+    /// Apply TLS flags to a CLI instance based on builder config.
+    fn apply_tls_to_cli(&self, mut cli: RedisCli) -> RedisCli {
+        if self.has_tls() {
+            cli = cli.tls(true);
+            if let Some(ref ca) = self.tls_ca_cert_file {
+                cli = cli.cacert(ca);
+            } else {
+                cli = cli.insecure(true);
+            }
+            if let Some(ref cert) = self.tls_cert_file {
+                cli = cli.cert(cert);
+            }
+            if let Some(ref key) = self.tls_key_file {
+                cli = cli.key(key);
+            }
+        }
+        cli
+    }
+
+    /// Apply TLS config to a server builder.
+    fn apply_tls_to_server(&self, mut server: RedisServer) -> RedisServer {
+        if let Some(port) = self.tls_port {
+            server = server.tls_port(port);
+        }
+        if let Some(ref path) = self.tls_cert_file {
+            server = server.tls_cert_file(path);
+        }
+        if let Some(ref path) = self.tls_key_file {
+            server = server.tls_key_file(path);
+        }
+        if let Some(ref path) = self.tls_ca_cert_file {
+            server = server.tls_ca_cert_file(path);
+        }
+        if let Some(ref path) = self.tls_ca_cert_dir {
+            server = server.tls_ca_cert_dir(path);
+        }
+        if let Some(v) = self.tls_auth_clients {
+            server = server.tls_auth_clients(v);
+        }
+        if let Some(v) = self.tls_replication {
+            server = server.tls_replication(v);
+        }
+        server
+    }
+
     fn replica_ports(&self) -> impl Iterator<Item = u16> {
         let base = self.replica_base_port;
         let n = self.num_replicas;
@@ -235,11 +337,13 @@ impl RedisSentinelBuilder {
 
         // Kill leftover processes.
         let cli_for_shutdown = |port: u16| {
-            RedisCli::new()
-                .bin(&self.redis_cli_bin)
-                .host(&self.bind)
-                .port(port)
-                .shutdown();
+            let cli = self.apply_tls_to_cli(
+                RedisCli::new()
+                    .bin(&self.redis_cli_bin)
+                    .host(&self.bind)
+                    .port(port),
+            );
+            cli.shutdown();
         };
         cli_for_shutdown(self.master_port);
         for port in self.replica_ports() {
@@ -270,6 +374,7 @@ impl RedisSentinelBuilder {
             .appendonly(appendonly)
             .redis_server_bin(&self.redis_server_bin)
             .redis_cli_bin(&self.redis_cli_bin);
+        master = self.apply_tls_to_server(master);
         if let Some(ref logfile) = self.logfile {
             master = master.logfile(logfile.clone());
         }
@@ -296,6 +401,7 @@ impl RedisSentinelBuilder {
                 .replicaof(self.bind.clone(), self.master_port)
                 .redis_server_bin(&self.redis_server_bin)
                 .redis_cli_bin(&self.redis_cli_bin);
+            replica = self.apply_tls_to_server(replica);
             if let Some(ref logfile) = self.logfile {
                 replica = replica.logfile(logfile.clone());
             }
@@ -355,6 +461,34 @@ impl RedisSentinelBuilder {
                     failover_timeout = self.failover_timeout_ms,
                 ));
             }
+            // TLS directives for sentinels.
+            if let Some(ref path) = self.tls_cert_file {
+                conf.push_str(&format!("tls-cert-file {}\n", path.display()));
+            }
+            if let Some(ref path) = self.tls_key_file {
+                conf.push_str(&format!("tls-key-file {}\n", path.display()));
+            }
+            if let Some(ref path) = self.tls_ca_cert_file {
+                conf.push_str(&format!("tls-ca-cert-file {}\n", path.display()));
+            }
+            if let Some(ref path) = self.tls_ca_cert_dir {
+                conf.push_str(&format!("tls-ca-cert-dir {}\n", path.display()));
+            }
+            if let Some(tls_port) = self.tls_port {
+                conf.push_str(&format!("tls-port {tls_port}\n"));
+            }
+            if let Some(v) = self.tls_auth_clients {
+                conf.push_str(&format!(
+                    "tls-auth-clients {}\n",
+                    if v { "yes" } else { "no" }
+                ));
+            }
+            if let Some(v) = self.tls_replication {
+                conf.push_str(&format!(
+                    "tls-replication {}\n",
+                    if v { "yes" } else { "no" }
+                ));
+            }
             for (key, value) in &self.extra {
                 conf.push_str(&format!("{key} {value}\n"));
             }
@@ -372,10 +506,12 @@ impl RedisSentinelBuilder {
                 return Err(Error::SentinelStart { port });
             }
 
-            let cli = RedisCli::new()
-                .bin(&self.redis_cli_bin)
-                .host(&self.bind)
-                .port(port);
+            let cli = self.apply_tls_to_cli(
+                RedisCli::new()
+                    .bin(&self.redis_cli_bin)
+                    .host(&self.bind)
+                    .port(port),
+            );
             cli.wait_for_ready(Duration::from_secs(10)).await?;
 
             let pid_path = dir.join("sentinel.pid");
@@ -400,7 +536,44 @@ impl RedisSentinelBuilder {
             redis_cli_bin: self.redis_cli_bin,
             num_sentinels: self.num_sentinels,
             monitored_masters,
+            tls: TlsConfig {
+                cert_file: self.tls_cert_file,
+                key_file: self.tls_key_file,
+                ca_cert_file: self.tls_ca_cert_file,
+            },
         })
+    }
+}
+
+/// TLS configuration snapshot stored in the handle for building CLI instances.
+#[derive(Clone, Debug, Default)]
+struct TlsConfig {
+    cert_file: Option<PathBuf>,
+    key_file: Option<PathBuf>,
+    ca_cert_file: Option<PathBuf>,
+}
+
+impl TlsConfig {
+    fn has_tls(&self) -> bool {
+        self.cert_file.is_some() && self.key_file.is_some()
+    }
+
+    fn apply(&self, mut cli: RedisCli) -> RedisCli {
+        if self.has_tls() {
+            cli = cli.tls(true);
+            if let Some(ref ca) = self.ca_cert_file {
+                cli = cli.cacert(ca);
+            } else {
+                cli = cli.insecure(true);
+            }
+            if let Some(ref cert) = self.cert_file {
+                cli = cli.cert(cert);
+            }
+            if let Some(ref key) = self.key_file {
+                cli = cli.key(key);
+            }
+        }
+        cli
     }
 }
 
@@ -416,6 +589,7 @@ pub struct RedisSentinelHandle {
     redis_cli_bin: String,
     num_sentinels: u16,
     monitored_masters: Vec<MonitoredMaster>,
+    tls: TlsConfig,
 }
 
 /// Entry point for building a Redis Sentinel topology.
@@ -441,6 +615,13 @@ impl RedisSentinel {
             appendonly: None,
             down_after_ms: 5000,
             failover_timeout_ms: 10000,
+            tls_port: None,
+            tls_cert_file: None,
+            tls_key_file: None,
+            tls_ca_cert_file: None,
+            tls_ca_cert_dir: None,
+            tls_auth_clients: None,
+            tls_replication: None,
             extra: HashMap::new(),
             redis_server_bin: "redis-server".into(),
             redis_cli_bin: "redis-cli".into(),
@@ -514,10 +695,12 @@ impl RedisSentinelHandle {
     /// primary master configured for this topology.
     pub async fn poke_master(&self, master_name: &str) -> Result<HashMap<String, String>> {
         for port in &self.sentinel_ports {
-            let cli = RedisCli::new()
-                .bin(&self.redis_cli_bin)
-                .host(&self.bind)
-                .port(*port);
+            let cli = self.tls.apply(
+                RedisCli::new()
+                    .bin(&self.redis_cli_bin)
+                    .host(&self.bind)
+                    .port(*port),
+            );
             if let Ok(raw) = cli.run(&["SENTINEL", "MASTER", master_name]).await {
                 return Ok(parse_flat_kv(&raw));
             }
@@ -571,10 +754,13 @@ impl RedisSentinelHandle {
     pub fn stop(&self) {
         // Sentinels first.
         for port in &self.sentinel_ports {
-            RedisCli::new()
-                .bin(&self.redis_cli_bin)
-                .host(&self.bind)
-                .port(*port)
+            self.tls
+                .apply(
+                    RedisCli::new()
+                        .bin(&self.redis_cli_bin)
+                        .host(&self.bind)
+                        .port(*port),
+                )
                 .shutdown();
         }
         // Replicas and master stopped by their handles' Drop.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1995,6 +1995,21 @@ impl RedisServer {
         if let Some(ref pw) = self.config.password {
             cli = cli.password(pw);
         }
+        // When TLS is configured, enable it on the CLI so it can reach the server.
+        if self.config.tls_cert_file.is_some() && self.config.tls_key_file.is_some() {
+            cli = cli.tls(true);
+            if let Some(ref ca) = self.config.tls_ca_cert_file {
+                cli = cli.cacert(ca);
+            } else {
+                cli = cli.insecure(true);
+            }
+            if let Some(ref cert) = self.config.tls_cert_file {
+                cli = cli.cert(cert);
+            }
+            if let Some(ref key) = self.config.tls_key_file {
+                cli = cli.key(key);
+            }
+        }
 
         cli.wait_for_ready(Duration::from_secs(10)).await?;
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,95 @@
+//! Self-signed TLS certificate generation for testing.
+//!
+//! This module is available behind the `test-tls` feature flag and provides a
+//! helper to generate a CA + server certificate pair suitable for local Redis
+//! TLS testing.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use redis_server_wrapper::tls::generate_test_certs;
+//!
+//! # fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let certs = generate_test_certs("/tmp/my-test/tls")?;
+//!
+//! // Use with a server builder:
+//! // server.tls_cert_file(&certs.cert_file)
+//! //       .tls_key_file(&certs.key_file)
+//! //       .tls_ca_cert_file(&certs.ca_cert_file)
+//! # Ok(())
+//! # }
+//! ```
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, KeyPair, KeyUsagePurpose};
+
+use crate::error::{Error, Result};
+
+/// Paths to generated test certificates.
+#[derive(Debug, Clone)]
+pub struct TestCerts {
+    /// Path to the CA certificate file (PEM).
+    pub ca_cert_file: PathBuf,
+    /// Path to the server certificate file (PEM).
+    pub cert_file: PathBuf,
+    /// Path to the server private key file (PEM).
+    pub key_file: PathBuf,
+}
+
+/// Generate a self-signed CA and server certificate for testing.
+///
+/// Creates three files in `dir`:
+/// - `ca.crt` -- the CA certificate
+/// - `server.crt` -- the server certificate signed by the CA
+/// - `server.key` -- the server private key
+///
+/// The server certificate includes `localhost` and `127.0.0.1` as Subject
+/// Alternative Names so it works for local test clusters without hostname
+/// verification issues.
+pub fn generate_test_certs(dir: impl AsRef<Path>) -> Result<TestCerts> {
+    let dir = dir.as_ref();
+    fs::create_dir_all(dir).map_err(Error::Io)?;
+
+    // Generate CA key pair and certificate.
+    let ca_key = KeyPair::generate().map_err(|e| Error::Tls(e.to_string()))?;
+    let mut ca_params =
+        CertificateParams::new(Vec::<String>::new()).map_err(|e| Error::Tls(e.to_string()))?;
+    ca_params
+        .distinguished_name
+        .push(DnType::CommonName, "Redis Test CA");
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    ca_params.key_usages.push(KeyUsagePurpose::KeyCertSign);
+    ca_params.key_usages.push(KeyUsagePurpose::CrlSign);
+    let ca_cert = ca_params
+        .self_signed(&ca_key)
+        .map_err(|e| Error::Tls(e.to_string()))?;
+
+    // Generate server key pair and certificate signed by the CA.
+    let server_key = KeyPair::generate().map_err(|e| Error::Tls(e.to_string()))?;
+    let server_san = vec!["localhost".to_string(), "127.0.0.1".to_string()];
+    let mut server_params =
+        CertificateParams::new(server_san).map_err(|e| Error::Tls(e.to_string()))?;
+    server_params
+        .distinguished_name
+        .push(DnType::CommonName, "Redis Test Server");
+    let server_cert = server_params
+        .signed_by(&server_key, &ca_cert, &ca_key)
+        .map_err(|e| Error::Tls(e.to_string()))?;
+
+    // Write files.
+    let ca_cert_file = dir.join("ca.crt");
+    let cert_file = dir.join("server.crt");
+    let key_file = dir.join("server.key");
+
+    fs::write(&ca_cert_file, ca_cert.pem()).map_err(Error::Io)?;
+    fs::write(&cert_file, server_cert.pem()).map_err(Error::Io)?;
+    fs::write(&key_file, server_key.serialize_pem()).map_err(Error::Io)?;
+
+    Ok(TestCerts {
+        ca_cert_file,
+        cert_file,
+        key_file,
+    })
+}


### PR DESCRIPTION
## Summary

- Add `test-tls` feature with `generate_test_certs()` helper that produces a self-signed CA + server certificate using `rcgen` -- includes `localhost` and `127.0.0.1` SANs for local testing (#62)
- Wire TLS flags (`--tls`, `--cacert`, `--cert`, `--key`, `--insecure`) through all internal `RedisCli` instances in `RedisServer::start()`, `RedisCluster`, and `RedisSentinel` so TLS-only deployments work end-to-end (#63)
- Add TLS builder methods to cluster and sentinel builders (`tls_port`, `tls_cert_file`, `tls_key_file`, `tls_ca_cert_file`, `tls_ca_cert_dir`, `tls_auth_clients`, `tls_replication`, `tls_cluster`) with blocking API forwarding

## Test plan

- [ ] `cargo test --lib --all-features` passes (20 tests)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] `cargo doc --no-deps --all-features` builds without warnings
- [ ] Integration test: standalone server with TLS cert generation + TLS config
- [ ] Integration test: TLS-only cluster (port 0, tls-port set)
- [ ] Integration test: TLS sentinel topology

Closes #62, closes #63