### PR TITLE
feat: auto-detect redis-stack-server binary and load modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ blocking = ["tokio"]
 test-tls = ["dep:rcgen"]
 
 [dependencies]
+glob = "0.3"
 thiserror = "2"
 tokio = { version = "1", features = ["process", "time", "rt", "macros", "rt-multi-thread"], optional = true }
 which = "7"

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1361,6 +1361,16 @@ impl RedisServer {
         self
     }
 
+    /// Disable automatic Redis Stack module detection and loading.
+    ///
+    /// By default, if the server binary is part of a redis-stack installation,
+    /// modules like RedisJSON, RediSearch, etc. are loaded automatically.
+    /// Call this to suppress that behavior.
+    pub fn no_stack_modules(mut self) -> Self {
+        self.inner = self.inner.no_stack_modules();
+        self
+    }
+
     /// Set an arbitrary config directive not covered by dedicated methods.
     pub fn extra(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.inner = self.inner.extra(key, value);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,7 @@ pub mod process;
 pub mod sentinel;
 #[cfg(feature = "tokio")]
 pub mod server;
+pub mod stack;
 
 #[cfg(feature = "blocking")]
 pub mod blocking;

--- a/src/server.rs
+++ b/src/server.rs
@@ -455,10 +455,14 @@ pub struct RedisServerConfig {
     pub extra: HashMap<String, String>,
 
     // -- binary paths --
-    /// Path to the `redis-server` binary (default: `"redis-server"`).
+    /// Path to the `redis-server` binary (default: auto-detected).
     pub redis_server_bin: String,
     /// Path to the `redis-cli` binary (default: `"redis-cli"`).
     pub redis_cli_bin: String,
+
+    // -- stack --
+    /// When `true`, skip automatic Redis Stack module detection and loading.
+    pub no_stack_modules: bool,
 }
 
 /// AOF fsync policy.
@@ -735,8 +739,9 @@ impl Default for RedisServerConfig {
             propagation_error_behavior: None,
             tracking_table_max_keys: None,
             extra: HashMap::new(),
-            redis_server_bin: "redis-server".into(),
+            redis_server_bin: crate::stack::detect_server_bin(),
             redis_cli_bin: "redis-cli".into(),
+            no_stack_modules: false,
         }
     }
 }
@@ -1946,6 +1951,16 @@ impl RedisServer {
         self
     }
 
+    /// Disable automatic Redis Stack module detection and loading.
+    ///
+    /// By default, if the server binary is part of a redis-stack installation,
+    /// modules like RedisJSON, RediSearch, etc. are loaded automatically.
+    /// Call this to suppress that behavior.
+    pub fn no_stack_modules(mut self) -> Self {
+        self.config.no_stack_modules = true;
+        self
+    }
+
     /// Set an arbitrary config directive not covered by dedicated methods.
     pub fn extra(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.config.extra.insert(key.into(), value.into());
@@ -1986,8 +2001,14 @@ impl RedisServer {
         let conf_content = self.generate_config(&node_dir);
         fs::write(&conf_path, conf_content)?;
 
+        let module_args = if self.config.no_stack_modules {
+            Vec::new()
+        } else {
+            crate::stack::detect_stack_modules(&self.config.redis_server_bin)
+        };
         let status = Command::new(&self.config.redis_server_bin)
             .arg(&conf_path)
+            .args(&module_args)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,0 +1,127 @@
+//! Redis Stack server detection and module loading.
+//!
+//! This module handles auto-detection of the `redis-stack-server` binary and
+//! the Stack modules (RedisJSON, RediSearch, etc.) bundled with it.
+
+use std::path::Path;
+
+/// Detect the best redis-server binary.
+///
+/// Prefers the real `redis-server` binary inside a redis-stack-server
+/// Homebrew cask (not the wrapper script which overrides `--dir`), then
+/// falls back to `redis-server` on PATH.
+///
+/// # Example
+///
+/// ```no_run
+/// use redis_server_wrapper::stack::detect_server_bin;
+///
+/// let bin = detect_server_bin();
+/// println!("using redis-server binary: {bin}");
+/// ```
+pub fn detect_server_bin() -> String {
+    let patterns = [
+        "/opt/homebrew/Caskroom/redis-stack-server/*/bin/redis-server",
+        "/usr/local/Caskroom/redis-stack-server/*/bin/redis-server",
+    ];
+
+    for pattern in &patterns {
+        if let Ok(mut paths) = glob::glob(pattern)
+            && let Some(Ok(path)) = paths.next()
+            && let Some(s) = path.to_str()
+        {
+            return s.to_string();
+        }
+    }
+
+    "redis-server".to_string()
+}
+
+/// Detect Redis Stack modules next to the given binary.
+///
+/// If the binary lives inside a redis-stack installation (a sibling `lib/`
+/// directory exists), returns `--loadmodule` arguments for each discovered
+/// module. Returns an empty vec if no modules are found.
+///
+/// Modules are checked in this order:
+/// - `rediscompat.so`
+/// - `redisearch.so` (with `MAXSEARCHRESULTS 10000 MAXAGGREGATERESULTS 10000`)
+/// - `redistimeseries.so`
+/// - `rejson.so`
+/// - `redisbloom.so`
+///
+/// # Example
+///
+/// ```no_run
+/// use redis_server_wrapper::stack::{detect_server_bin, detect_stack_modules};
+///
+/// let bin = detect_server_bin();
+/// let module_args = detect_stack_modules(&bin);
+/// println!("module args: {module_args:?}");
+/// ```
+pub fn detect_stack_modules(server_bin: &str) -> Vec<String> {
+    let bin_path = Path::new(server_bin);
+
+    let lib_dir = match bin_path.parent().and_then(|p| p.parent()) {
+        Some(base) => base.join("lib"),
+        None => return Vec::new(),
+    };
+
+    if !lib_dir.is_dir() {
+        return Vec::new();
+    }
+
+    // (filename, extra args)
+    let modules: &[(&str, &[&str])] = &[
+        ("rediscompat.so", &[]),
+        (
+            "redisearch.so",
+            &["MAXSEARCHRESULTS", "10000", "MAXAGGREGATERESULTS", "10000"],
+        ),
+        ("redistimeseries.so", &[]),
+        ("rejson.so", &[]),
+        ("redisbloom.so", &[]),
+    ];
+
+    let mut args: Vec<String> = Vec::new();
+
+    for (filename, extra) in modules {
+        let module_path = lib_dir.join(filename);
+        if module_path.is_file() {
+            args.push("--loadmodule".to_string());
+            args.push(module_path.to_string_lossy().into_owned());
+            for arg in *extra {
+                args.push(arg.to_string());
+            }
+        }
+    }
+
+    args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_server_bin_fallback() {
+        // Without a real redis-stack installation the function must fall back
+        // to the plain binary name.
+        let bin = detect_server_bin();
+        // Either the fallback or a real path -- just make sure it's non-empty.
+        assert!(!bin.is_empty());
+    }
+
+    #[test]
+    fn detect_stack_modules_missing_lib() {
+        // A binary that has no sibling lib/ dir should produce no module args.
+        let args = detect_stack_modules("redis-server");
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn detect_stack_modules_nonexistent_path() {
+        let args = detect_stack_modules("/nonexistent/bin/redis-server");
+        assert!(args.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `stack` module with `detect_server_bin()` and `detect_stack_modules()` for transparent redis-stack-server support
- Auto-detect the real `redis-server` binary inside Homebrew's redis-stack cask (bypasses the wrapper script that overrides `--dir`)
- Auto-discover and load Stack modules (rediscompat, redisearch, redistimeseries, rejson, redisbloom) from the sibling `lib/` directory
- Add `no_stack_modules()` builder method to opt out of auto-loading
- Add `glob` dependency for Homebrew path matching

## Test plan

- [ ] `cargo test --lib --all-features` passes (23 tests including 3 new stack tests)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] On a machine with redis-stack-server installed: verify modules are loaded (check `MODULE LIST`)
- [ ] With `no_stack_modules()`: verify no modules loaded
- [ ] On a machine without redis-stack: verify fallback to plain `redis-server`

Closes #65