### PR TITLE
feat: stale pidfile cleanup before server start

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -1,9 +1,13 @@
-//! OS-level process utilities for robust server shutdown.
+//! OS-level process utilities for robust server shutdown and stale process cleanup.
 //!
-//! This module provides functions for checking process liveness and performing
-//! escalating kills, including process-group kills to handle wrapper scripts
-//! that spawn child processes.
+//! This module provides functions for checking process liveness, performing
+//! escalating kills (including process-group kills to handle wrapper scripts),
+//! and cleaning up stale pidfiles from crashed test runs.
+//!
+//! All utilities are intentionally synchronous so they can be used from
+//! [`Drop`] implementations as well as from async startup paths.
 
+use std::path::Path;
 use std::process::Command;
 use std::thread;
 use std::time::Duration;
@@ -63,6 +67,16 @@ pub fn force_kill(pid: u32) {
         // Also kill the individual PID as fallback.
         let _ = Command::new("kill").args(["-9", &pid_str]).output();
     }
+}
+
+/// Read a PID from a pidfile.
+///
+/// Returns `None` if the file does not exist, cannot be read, or its contents
+/// cannot be parsed as a `u32`.
+pub fn read_pidfile(path: &Path) -> Option<u32> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
 }
 
 /// Kill any process listening on a TCP port via `lsof -ti :$port`.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1969,6 +1969,17 @@ impl RedisServer {
         }
 
         let node_dir = self.config.dir.join(format!("node-{}", self.config.port));
+
+        // Clean up any stale process from a previous run before (re)creating
+        // the node directory. This handles test crashes that leave orphaned
+        // redis-server processes behind.
+        let stale_pidfile = node_dir.join("redis.pid");
+        if let Some(stale_pid) = crate::process::read_pidfile(&stale_pidfile)
+            && crate::process::pid_alive(stale_pid)
+        {
+            crate::process::force_kill(stale_pid);
+        }
+
         fs::create_dir_all(&node_dir)?;
 
         let conf_path = node_dir.join("redis.conf");


### PR DESCRIPTION
## Summary

- Add `process` module with OS-level utilities: `pid_alive()`, `kill_stale()`, `read_pidfile()`, `kill_by_port()`
- Before starting a server, check for stale pidfiles from crashed test runs and kill orphaned processes (SIGTERM then SIGKILL escalation)
- All process utilities are synchronous (`std::process::Command`) so they work from `Drop` impls

## Test plan

- [ ] `cargo test --lib --all-features` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] Manual: start a server, `kill -9` the test process, restart -- verify the stale server is cleaned up
- [ ] Manual: verify clean start when no stale process exists

Closes #68