### PR TITLE
feat: robust multi-layer shutdown with escalating cleanup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,7 @@ pub mod cli;
 #[cfg(feature = "tokio")]
 pub mod cluster;
 pub mod error;
+pub mod process;
 #[cfg(feature = "tokio")]
 pub mod sentinel;
 #[cfg(feature = "tokio")]

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,96 @@
+//! OS-level process utilities for robust server shutdown.
+//!
+//! This module provides functions for checking process liveness and performing
+//! escalating kills, including process-group kills to handle wrapper scripts
+//! that spawn child processes.
+
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+
+/// Check if a process is alive via `kill -0`.
+///
+/// Returns `true` if the process exists and is reachable, `false` otherwise.
+///
+/// # Example
+///
+/// ```no_run
+/// use redis_server_wrapper::process;
+///
+/// let alive = process::pid_alive(12345);
+/// println!("process alive: {alive}");
+/// ```
+pub fn pid_alive(pid: u32) -> bool {
+    Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Escalating kill: SIGTERM, wait grace period, then SIGKILL process group and individual PID.
+///
+/// Strategy:
+/// 1. Send SIGTERM to give the process a chance to shut down cleanly.
+/// 2. Sleep 500ms.
+/// 3. If still alive, SIGKILL the process group (`kill -9 -$pid`) to catch wrapper
+///    scripts and any children they spawned (e.g. `redis-stack-server`).
+/// 4. SIGKILL the individual PID as a fallback.
+///
+/// Uses synchronous [`std::process::Command`] so this is safe to call from [`Drop`] impls.
+///
+/// # Example
+///
+/// ```no_run
+/// use redis_server_wrapper::process;
+///
+/// process::force_kill(12345);
+/// ```
+pub fn force_kill(pid: u32) {
+    let pid_str = pid.to_string();
+    let pgid_str = format!("-{pid}");
+
+    // Step 1: SIGTERM -- graceful shutdown attempt.
+    let _ = Command::new("kill").args([&pid_str]).output();
+
+    // Step 2: Grace period.
+    thread::sleep(Duration::from_millis(500));
+
+    // Step 3: If still alive, escalate to SIGKILL on process group.
+    if pid_alive(pid) {
+        // Kill the whole process group to catch wrapper script children.
+        let _ = Command::new("kill").args(["-9", &pgid_str]).output();
+        // Also kill the individual PID as fallback.
+        let _ = Command::new("kill").args(["-9", &pid_str]).output();
+    }
+}
+
+/// Kill any process listening on a TCP port via `lsof -ti :$port`.
+///
+/// Best-effort -- all errors are silently ignored. This is intended as a
+/// final safety net to release the port after shutdown, not as a primary
+/// kill mechanism.
+///
+/// # Example
+///
+/// ```no_run
+/// use redis_server_wrapper::process;
+///
+/// process::kill_by_port(6379);
+/// ```
+pub fn kill_by_port(port: u16) {
+    let port_str = format!(":{port}");
+    let Ok(output) = Command::new("lsof").args(["-ti", &port_str]).output() else {
+        return;
+    };
+    if !output.status.success() {
+        return;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        let line = line.trim();
+        if !line.is_empty() {
+            let _ = Command::new("kill").args(["-9", line]).output();
+        }
+    }
+}

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -750,9 +750,17 @@ impl RedisSentinelHandle {
         }
     }
 
-    /// Stop everything.
+    /// Stop everything via an escalating shutdown strategy.
+    ///
+    /// 1. Sends `SHUTDOWN NOSAVE` to each sentinel process.
+    /// 2. Waits 500ms for them to exit.
+    /// 3. For each sentinel PID that is still alive, calls [`crate::process::force_kill`].
+    /// 4. Calls [`crate::process::kill_by_port`] for each sentinel port as a safety net.
+    ///
+    /// Replicas and the master are stopped by their own handles' [`Drop`] impls,
+    /// which also use the escalating strategy.
     pub fn stop(&self) {
-        // Sentinels first.
+        // Step 1: graceful shutdown for each sentinel.
         for port in &self.sentinel_ports {
             self.tls
                 .apply(
@@ -762,6 +770,18 @@ impl RedisSentinelHandle {
                         .port(*port),
                 )
                 .shutdown();
+        }
+        // Step 2: grace period.
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        // Step 3: force kill any sentinels still alive.
+        for pid in &self.sentinel_pids {
+            if crate::process::pid_alive(*pid) {
+                crate::process::force_kill(*pid);
+            }
+        }
+        // Step 4: port cleanup as safety net.
+        for port in &self.sentinel_ports {
+            crate::process::kill_by_port(*port);
         }
         // Replicas and master stopped by their handles' Drop.
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -2717,9 +2717,23 @@ impl RedisServerHandle {
         self.detached = true;
     }
 
-    /// Stop the server via SHUTDOWN NOSAVE.
+    /// Stop the server via an escalating shutdown strategy.
+    ///
+    /// 1. Sends `SHUTDOWN NOSAVE` via `redis-cli` for a graceful shutdown.
+    /// 2. Waits 500ms for the process to exit.
+    /// 3. If still alive, calls [`crate::process::force_kill`] (SIGTERM then SIGKILL).
+    /// 4. Attempts to release the port via [`crate::process::kill_by_port`] as a final safety net.
     pub fn stop(&self) {
+        // Step 1: graceful shutdown.
         self.cli.shutdown();
+        // Step 2: grace period.
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        // Step 3: force kill if still alive.
+        if crate::process::pid_alive(self.pid) {
+            crate::process::force_kill(self.pid);
+        }
+        // Step 4: port cleanup as safety net.
+        crate::process::kill_by_port(self.config.port);
     }
 
     /// Wait until the server is ready (PING -> PONG).


### PR DESCRIPTION
## Summary

- Add `process` module with `pid_alive()`, `force_kill()` (process group kill), and `kill_by_port()` (lsof fallback)
- Upgrade `RedisServerHandle::stop()` to a 4-step escalating strategy: SHUTDOWN NOSAVE, grace period, SIGKILL process group (catches redis-stack-server wrapper children), port cleanup via lsof
- Same escalating strategy for `RedisSentinelHandle::stop()`
- All utilities are synchronous for safe use from `Drop` impls

**Note:** This PR and #70 (stale pidfile cleanup) both introduce `src/process.rs`. They're independent features but the second to merge will need a trivial conflict resolution to combine both sets of functions. Recommend merging this one first since it's the larger change.

## Test plan

- [ ] `cargo test --lib --all-features` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] Manual: start a cluster, `kill -9` the test process, verify all redis-server processes are cleaned up on next run
- [ ] Manual: test with redis-stack-server -- verify wrapper script children are killed

Closes #67