### PR TITLE
chore: bump MSRV to 1.88 to fix time crate vulnerability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         rust: [stable]
         include:
           - os: ubuntu-latest
-            rust: 1.87.0
+            rust: 1.88.0
     steps:
       - uses: actions/checkout@v4
 
@@ -112,7 +112,7 @@ jobs:
       - name: Install Rust MSRV
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.87.0
+          toolchain: 1.88.0
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/joshrotenberg/redis-server-wrapper"
 keywords = ["redis", "testing", "wrapper", "server"]
 categories = ["development-tools::testing", "database"]
 readme = "README.md"
-rust-version = "1.87"
+rust-version = "1.88"
 exclude = [".github/", "tests/", "examples/"]
 
 [features]

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -845,10 +845,11 @@ impl RedisClusterHandle {
     /// Check CLUSTER INFO for state=ok and all slots assigned.
     pub async fn is_healthy(&self) -> bool {
         for node in &self.nodes {
-            if let Ok(info) = node.run(&["CLUSTER", "INFO"]).await {
-                if info.contains("cluster_state:ok") && info.contains("cluster_slots_ok:16384") {
-                    return true;
-                }
+            if let Ok(info) = node.run(&["CLUSTER", "INFO"]).await
+                && info.contains("cluster_state:ok")
+                && info.contains("cluster_slots_ok:16384")
+            {
+                return true;
             }
         }
         false


### PR DESCRIPTION
## Summary

- Bump MSRV from 1.87 to 1.88 so `time` resolves to 0.3.47+, fixing RUSTSEC-2026-0009
- Fix collapsible_if clippy lint in `cluster.rs` caught by newer toolchain

The vulnerability is in the `time` crate pulled transitively by `rcgen` (behind the `test-tls` feature). `time 0.3.47` contains the fix but requires Rust 1.88.

## Test plan

- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] `cargo test --lib --all-features` passes
- [ ] Security audit passes