### PR TITLE
fix: quote path values in generated Redis config

### DIFF
--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -439,9 +439,9 @@ impl RedisSentinelBuilder {
                 "port {port}\n\
                  bind {bind}\n\
                  daemonize yes\n\
-                 pidfile {dir}/sentinel.pid\n\
-                 logfile {logfile}\n\
-                 dir {dir}\n",
+                 pidfile \"{dir}/sentinel.pid\"\n\
+                 logfile \"{logfile}\"\n\
+                 dir \"{dir}\"\n",
                 port = port,
                 bind = self.bind,
                 dir = dir.display(),
@@ -463,16 +463,16 @@ impl RedisSentinelBuilder {
             }
             // TLS directives for sentinels.
             if let Some(ref path) = self.tls_cert_file {
-                conf.push_str(&format!("tls-cert-file {}\n", path.display()));
+                conf.push_str(&format!("tls-cert-file \"{}\"\n", path.display()));
             }
             if let Some(ref path) = self.tls_key_file {
-                conf.push_str(&format!("tls-key-file {}\n", path.display()));
+                conf.push_str(&format!("tls-key-file \"{}\"\n", path.display()));
             }
             if let Some(ref path) = self.tls_ca_cert_file {
-                conf.push_str(&format!("tls-ca-cert-file {}\n", path.display()));
+                conf.push_str(&format!("tls-ca-cert-file \"{}\"\n", path.display()));
             }
             if let Some(ref path) = self.tls_ca_cert_dir {
-                conf.push_str(&format!("tls-ca-cert-dir {}\n", path.display()));
+                conf.push_str(&format!("tls-ca-cert-dir \"{}\"\n", path.display()));
             }
             if let Some(tls_port) = self.tls_port {
                 conf.push_str(&format!("tls-port {tls_port}\n"));

--- a/src/server.rs
+++ b/src/server.rs
@@ -2069,8 +2069,8 @@ impl RedisServer {
             "port {port}\n\
              bind {bind}\n\
              daemonize {daemonize}\n\
-             pidfile {dir}/redis.pid\n\
-             dir {dir}\n\
+             pidfile \"{dir}/redis.pid\"\n\
+             dir \"{dir}\"\n\
              loglevel {level}\n\
              protected-mode {protected}\n",
             port = self.config.port,
@@ -2087,14 +2087,14 @@ impl RedisServer {
             .as_deref()
             .map(str::to_owned)
             .unwrap_or_else(|| format!("{}/redis.log", node_dir.display()));
-        conf.push_str(&format!("logfile {logfile}\n"));
+        conf.push_str(&format!("logfile \"{logfile}\"\n"));
 
         // -- network --
         if let Some(backlog) = self.config.tcp_backlog {
             conf.push_str(&format!("tcp-backlog {backlog}\n"));
         }
         if let Some(ref path) = self.config.unixsocket {
-            conf.push_str(&format!("unixsocket {}\n", path.display()));
+            conf.push_str(&format!("unixsocket \"{}\"\n", path.display()));
         }
         if let Some(perm) = self.config.unixsocketperm {
             conf.push_str(&format!("unixsocketperm {perm}\n"));
@@ -2111,34 +2111,34 @@ impl RedisServer {
             conf.push_str(&format!("tls-port {port}\n"));
         }
         if let Some(ref path) = self.config.tls_cert_file {
-            conf.push_str(&format!("tls-cert-file {}\n", path.display()));
+            conf.push_str(&format!("tls-cert-file \"{}\"\n", path.display()));
         }
         if let Some(ref path) = self.config.tls_key_file {
-            conf.push_str(&format!("tls-key-file {}\n", path.display()));
+            conf.push_str(&format!("tls-key-file \"{}\"\n", path.display()));
         }
         if let Some(ref pass) = self.config.tls_key_file_pass {
             conf.push_str(&format!("tls-key-file-pass {pass}\n"));
         }
         if let Some(ref path) = self.config.tls_ca_cert_file {
-            conf.push_str(&format!("tls-ca-cert-file {}\n", path.display()));
+            conf.push_str(&format!("tls-ca-cert-file \"{}\"\n", path.display()));
         }
         if let Some(ref path) = self.config.tls_ca_cert_dir {
-            conf.push_str(&format!("tls-ca-cert-dir {}\n", path.display()));
+            conf.push_str(&format!("tls-ca-cert-dir \"{}\"\n", path.display()));
         }
         if let Some(auth) = self.config.tls_auth_clients {
             conf.push_str(&format!("tls-auth-clients {}\n", yn(auth)));
         }
         if let Some(ref path) = self.config.tls_client_cert_file {
-            conf.push_str(&format!("tls-client-cert-file {}\n", path.display()));
+            conf.push_str(&format!("tls-client-cert-file \"{}\"\n", path.display()));
         }
         if let Some(ref path) = self.config.tls_client_key_file {
-            conf.push_str(&format!("tls-client-key-file {}\n", path.display()));
+            conf.push_str(&format!("tls-client-key-file \"{}\"\n", path.display()));
         }
         if let Some(ref pass) = self.config.tls_client_key_file_pass {
             conf.push_str(&format!("tls-client-key-file-pass {pass}\n"));
         }
         if let Some(ref path) = self.config.tls_dh_params_file {
-            conf.push_str(&format!("tls-dh-params-file {}\n", path.display()));
+            conf.push_str(&format!("tls-dh-params-file \"{}\"\n", path.display()));
         }
         if let Some(ref ciphers) = self.config.tls_ciphers {
             conf.push_str(&format!("tls-ciphers {ciphers}\n"));
@@ -2345,17 +2345,17 @@ impl RedisServer {
             conf.push_str(&format!("requirepass {pw}\n"));
         }
         if let Some(ref path) = self.config.acl_file {
-            conf.push_str(&format!("aclfile {}\n", path.display()));
+            conf.push_str(&format!("aclfile \"{}\"\n", path.display()));
         }
 
         // -- cluster --
         if self.config.cluster_enabled {
             conf.push_str("cluster-enabled yes\n");
             if let Some(ref path) = self.config.cluster_config_file {
-                conf.push_str(&format!("cluster-config-file {}\n", path.display()));
+                conf.push_str(&format!("cluster-config-file \"{}\"\n", path.display()));
             } else {
                 conf.push_str(&format!(
-                    "cluster-config-file {}/nodes.conf\n",
+                    "cluster-config-file \"{}/nodes.conf\"\n",
                     node_dir.display()
                 ));
             }
@@ -2476,7 +2476,7 @@ impl RedisServer {
 
         // -- modules --
         for path in &self.config.loadmodule {
-            conf.push_str(&format!("loadmodule {}\n", path.display()));
+            conf.push_str(&format!("loadmodule \"{}\"\n", path.display()));
         }
 
         // -- advanced --
@@ -2661,7 +2661,7 @@ impl RedisServer {
             conf.push_str(&format!("ignore-warnings {warning}\n"));
         }
         for path in &self.config.include {
-            conf.push_str(&format!("include {}\n", path.display()));
+            conf.push_str(&format!("include \"{}\"\n", path.display()));
         }
         if let Some(enable) = self.config.jemalloc_bg_thread {
             conf.push_str(&format!("jemalloc-bg-thread {}\n", yn(enable)));

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,4 +1,5 @@
 use redis_server_wrapper::{LogLevel, RedisServer};
+use std::fs;
 
 #[tokio::test]
 async fn start_and_ping() {
@@ -94,4 +95,22 @@ async fn detach_leaves_server_running() {
     cli.shutdown();
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     assert!(!cli.ping().await);
+}
+
+#[tokio::test]
+async fn dir_with_spaces() {
+    // Verify that a working directory whose path contains a space does not
+    // cause redis-server to fail parsing the generated config.
+    let base = std::env::temp_dir().join("redis wrapper test");
+    fs::create_dir_all(&base).expect("failed to create temp dir with space");
+
+    let server = RedisServer::new()
+        .port(16406)
+        .dir(&base)
+        .loglevel(LogLevel::Warning)
+        .start()
+        .await
+        .expect("server with space in dir should start cleanly");
+
+    assert!(server.is_alive().await);
 }


### PR DESCRIPTION
Paths written into the generated Redis config file were emitted without quoting,
causing `redis-server` to fail to parse the config with an opaque `ServerStart`
error when any path component contains a space.

Changes:
- `src/server.rs`: wrap every path-valued directive (`dir`, `pidfile`, `logfile`,
  `unixsocket`, `tls-*-file`, `tls-*-dir`, `aclfile`, `cluster-config-file`,
  `loadmodule`, `include`) in double-quotes. The existing `appenddirname` was
  already correctly quoted and is left as-is.
- `src/sentinel.rs`: quote `pidfile`, `logfile`, `dir`, and all `tls-*-file`/
  `tls-*-dir` directives in the sentinel config writer.
- `tests/server.rs`: add regression test `dir_with_spaces` that starts a server
  whose working directory path contains a space and asserts it starts cleanly.

Closes #85.