### PR TITLE
fix: retry sentinel pidfile read on startup

### DIFF
--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -515,10 +515,20 @@ impl RedisSentinelBuilder {
             cli.wait_for_ready(Duration::from_secs(10)).await?;
 
             let pid_path = dir.join("sentinel.pid");
-            let pid: u32 = fs::read_to_string(&pid_path)?
-                .trim()
-                .parse()
-                .map_err(|_| Error::SentinelStart { port })?;
+            let pid: u32 = {
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+                loop {
+                    if let Ok(s) = fs::read_to_string(&pid_path)
+                        && let Ok(p) = s.trim().parse::<u32>()
+                    {
+                        break p;
+                    }
+                    if std::time::Instant::now() >= deadline {
+                        return Err(Error::SentinelStart { port });
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+            };
 
             sentinel_handles.push((port, pid, cli));
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -2046,13 +2046,22 @@ impl RedisServer {
         cli.wait_for_ready(Duration::from_secs(10)).await?;
 
         let pid_path = node_dir.join("redis.pid");
-        let pid: u32 = fs::read_to_string(&pid_path)
-            .map_err(Error::Io)?
-            .trim()
-            .parse()
-            .map_err(|_| Error::ServerStart {
-                port: self.config.port,
-            })?;
+        let pid: u32 = {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+            loop {
+                if let Ok(s) = fs::read_to_string(&pid_path)
+                    && let Ok(p) = s.trim().parse::<u32>()
+                {
+                    break p;
+                }
+                if std::time::Instant::now() >= deadline {
+                    return Err(Error::ServerStart {
+                        port: self.config.port,
+                    });
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        };
 
         Ok(RedisServerHandle {
             config: self.config,


### PR DESCRIPTION
Add a bounded retry loop around the pidfile read in both `RedisSentinelBuilder::start()` and `RedisServerBuilder::start()`.

On a loaded host, Redis may have started accepting connections (PING succeeds) but not yet flushed the pidfile to disk. The previous single-shot `fs::read_to_string` would hard-fail in that window. The fix retries up to ~1 second (20 attempts x 50ms) before returning the existing error type.

Files changed:
- `src/sentinel.rs` -- retry loop around `sentinel.pid` read
- `src/server.rs` -- retry loop around `redis.pid` read

Closes #92.