### PR TITLE
docs: add feature flag documentation to crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,20 @@
 //!
 //! You can also call `.stop()` explicitly on any handle to shut down early, or
 //! `.detach()` on a server handle to consume it without stopping the process.
+//!
+//! # Feature Flags
+//!
+//! | Feature | Default | Description |
+//! |---------|---------|-------------|
+//! | `tokio` | yes | Async API. Enables [`RedisServer`], [`RedisCluster`], [`RedisSentinel`]. |
+//! | `blocking` | no | Synchronous wrappers in [`blocking`]. Implies `tokio`. Enable with `features = ["blocking"]`. |
+//! | `test-tls` | no | TLS certificate generation helpers in [`tls`]. Requires `rcgen`. |
+//!
+//! To use only the blocking (sync) API without pulling in async code directly:
+//! ```toml
+//! [dev-dependencies]
+//! redis-server-wrapper = { version = "*", default-features = false, features = ["blocking"] }
+//! ```
 
 pub mod chaos;
 #[cfg(feature = "tokio")]


### PR DESCRIPTION
## Summary

Adds a `# Feature Flags` section to the crate-level doc comment in `src/lib.rs`, placed after "Lifecycle" and before the module declarations. This documents the `tokio`, `blocking`, and `test-tls` feature flags for docs.rs readers, who never see the README.

Content is adapted from README.md's "Installation" section, presented as a table plus a `Cargo.toml` snippet for the blocking-only use case.

Closes #86.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo doc --all-features --no-deps` with `RUSTDOCFLAGS="-D warnings"` (checks intra-doc links)
- [x] `cargo test` (unit, integration, and doctests all pass)