### PR TITLE
test: add blocking API parity tests for password, extra config, logfile, and RedisCli options

### DIFF
--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -64,6 +64,64 @@ fn blocking_server_detach_leaves_server_running() {
 }
 
 #[test]
+fn blocking_server_password_auth() {
+    let server = RedisServer::new()
+        .port(16540)
+        .password("testpass")
+        .start()
+        .expect("failed to start redis-server");
+
+    assert!(server.is_alive());
+}
+
+#[test]
+fn blocking_server_extra_config() {
+    let server = RedisServer::new()
+        .port(16541)
+        .extra("maxmemory", "10mb")
+        .start()
+        .expect("failed to start redis-server");
+
+    let info = server.run(&["CONFIG", "GET", "maxmemory"]).unwrap();
+    assert!(info.contains("10485760") || info.contains("10mb"));
+}
+
+#[test]
+fn blocking_server_logfile() {
+    let server = RedisServer::new()
+        .port(16542)
+        .logfile("/tmp/blocking-test.log")
+        .start()
+        .expect("failed to start redis-server");
+
+    assert!(server.is_alive());
+    let logfile = server.run(&["CONFIG", "GET", "logfile"]).unwrap();
+    assert!(logfile.contains("/tmp/blocking-test.log"));
+}
+
+#[test]
+fn blocking_cli_run_command() {
+    let _server = RedisServer::new()
+        .port(16543)
+        .start()
+        .expect("failed to start redis-server");
+
+    let cli = redis_server_wrapper::blocking::RedisCli::new().port(16543);
+    let result = cli.run(&["SET", "foo", "bar"]).unwrap();
+    assert_eq!(result.trim(), "OK");
+
+    let result = cli.run(&["GET", "foo"]).unwrap();
+    assert_eq!(result.trim(), "bar");
+}
+
+#[test]
+fn blocking_cli_wait_for_ready_timeout() {
+    let cli = redis_server_wrapper::blocking::RedisCli::new().port(16560);
+    let result = cli.wait_for_ready(std::time::Duration::from_millis(500));
+    assert!(result.is_err());
+}
+
+#[test]
 fn blocking_cluster_start_and_health() {
     let cluster = RedisCluster::builder()
         .masters(3)


### PR DESCRIPTION
## Summary

`tests/blocking.rs` covered the happy path for `blocking::RedisServer`, `blocking::RedisCluster`, and `blocking::RedisSentinel`, but several builder options and `RedisCli` methods already tested in the async suite had no blocking counterparts.

Adds:
- `blocking_server_password_auth` — server started with `.password(...)`, asserts `is_alive()`.
- `blocking_server_extra_config` — server started with `.extra("maxmemory", "10mb")`, asserts via `CONFIG GET maxmemory`.
- `blocking_server_logfile` — server started with `.logfile(...)`, asserts `is_alive()` and `CONFIG GET logfile`.
- `blocking_cli_run_command` — `blocking::RedisCli::run` used to SET/GET.
- `blocking_cli_wait_for_ready_timeout` — `wait_for_ready` against a port with no server returns `Err`.

New tests use ports in the 16540-16560 range to avoid collisions with existing blocking tests (16500-16530).

Closes #90.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --features blocking --test blocking`
- [x] `cargo test --all-features`