### PR TITLE
fix: document Unix-only platform requirement and enforce at compile time

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ just `redis-server` and `redis-cli` on PATH.
 `redis-server` and `redis-cli` must be available on your PATH (or specify custom paths with
 `.redis_server_bin()` and `.redis_cli_bin()` on any builder).
 
+## Platform support
+
+Unix-like platforms only (Linux, macOS, BSD). Process lifecycle management relies on POSIX
+signals (`SIGTERM`/`SIGKILL`/`SIGSTOP`/`SIGCONT`) and Unix utilities (`kill`, `lsof`) that have
+no equivalent on Windows. Building on a non-Unix target fails at compile time.
+
 ## Installation
 
 Add to `Cargo.toml` for async use (the default):

--- a/src/chaos.rs
+++ b/src/chaos.rs
@@ -5,6 +5,9 @@
 //! triggering failovers, and more. All operations work with the handle
 //! types returned by the server, cluster, and sentinel builders.
 //!
+//! Unix-only: the node-kill and freeze/resume operations send POSIX signals
+//! via `kill`. See the crate-level "Platform Support" docs for details.
+//!
 //! # Example
 //!
 //! ```no_run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,22 @@
 //! [dev-dependencies]
 //! redis-server-wrapper = { version = "*", default-features = false, features = ["blocking"] }
 //! ```
+//!
+//! # Platform Support
+//!
+//! This crate only supports Unix-like platforms (Linux, macOS, BSD). Process
+//! lifecycle management in the [`process`] and [`chaos`] modules relies on
+//! POSIX signals (`SIGTERM`, `SIGKILL`, `SIGSTOP`, `SIGCONT`) and Unix
+//! utilities (`kill`, `lsof`) that have no equivalent on Windows. Building on
+//! a non-Unix target fails at compile time rather than silently leaking
+//! processes at runtime.
+
+#[cfg(not(unix))]
+compile_error!(
+    "redis-server-wrapper only supports Unix-like platforms (Linux, macOS, BSD). \
+     Process lifecycle management relies on POSIX signals (SIGTERM/SIGKILL/SIGSTOP/SIGCONT) \
+     and Unix utilities (`kill`, `lsof`) that have no equivalent on Windows."
+);
 
 pub mod chaos;
 #[cfg(feature = "tokio")]

--- a/src/process.rs
+++ b/src/process.rs
@@ -6,6 +6,9 @@
 //!
 //! All utilities are intentionally synchronous so they can be used from
 //! [`Drop`] implementations as well as from async startup paths.
+//!
+//! Unix-only: every function here shells out to `kill` or `lsof`. See the
+//! crate-level "Platform Support" docs for details.
 
 use std::path::Path;
 use std::process::Command;


### PR DESCRIPTION
## Summary

- Adds a `compile_error!` guard in `src/lib.rs` for `#[cfg(not(unix))]` so building on Windows fails clearly at compile time instead of silently leaking `redis-server` processes at runtime (via `Drop` calling into no-op `kill`/`lsof` shell-outs).
- Documents the Unix-only requirement in the crate-level docs (`src/lib.rs`), the `process` module docs, the `chaos` module docs, and the README.

## Why this approach

The issue offered two options: per-function `#[cfg(unix)]` guards with Windows stubs returning a new `Error::UnsupportedPlatform`, or a crate-level compile-time guard plus documentation. I went with the compile-time guard because it fixes the actual failure mode (silent process leaks on unsupported platforms) without changing any public function signatures, and it's a much smaller, lower-risk change for a crate that has never claimed Windows support.

Closes #88

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (unit, integration, and doc tests all pass)