### PR TITLE
feat: add addr() to RedisSentinelHandle for cross-topology parity

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -2026,7 +2026,13 @@ pub struct RedisSentinelHandle {
 }
 
 impl RedisSentinelHandle {
-    /// The master's address.
+    /// The master's address as "host:port". Kept consistent with
+    /// `RedisServerHandle::addr` and `RedisClusterHandle::addr`.
+    pub fn addr(&self) -> String {
+        self.inner.addr()
+    }
+
+    /// The master's address. Alias for [`Self::addr`].
     pub fn master_addr(&self) -> String {
         self.inner.master_addr()
     }

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -641,7 +641,14 @@ impl RedisSentinel {
 }
 
 impl RedisSentinelHandle {
-    /// The master's address.
+    /// The master's address as "host:port". Kept consistent with
+    /// [`RedisServerHandle::addr`](crate::server::RedisServerHandle::addr) and
+    /// [`RedisClusterHandle::addr`](crate::cluster::RedisClusterHandle::addr).
+    pub fn addr(&self) -> String {
+        self.master.addr()
+    }
+
+    /// The master's address. Alias for [`Self::addr`].
     pub fn master_addr(&self) -> String {
         self.master.addr()
     }


### PR DESCRIPTION
## Summary

- `RedisServerHandle::addr()` and `RedisClusterHandle::addr()` both return `"host:port"`, but `RedisSentinelHandle` only exposed `master_addr()`, so topology-agnostic code had to special-case sentinel.
- Add `RedisSentinelHandle::addr()` (async, `src/sentinel.rs`) and `blocking::RedisSentinelHandle::addr()` (`src/blocking.rs`), both returning the master's address.
- `master_addr()` is kept in both APIs as an alias.

Closes #83

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features blocking -- -D warnings`
- [x] `cargo test`