### PR TITLE
test: cover BinaryNotFound and ServerStart error paths

### DIFF
--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,4 +1,4 @@
-use redis_server_wrapper::{LogLevel, RedisServer};
+use redis_server_wrapper::{Error, LogLevel, RedisServer};
 use std::fs;
 
 #[tokio::test]
@@ -113,4 +113,55 @@ async fn dir_with_spaces() {
         .expect("server with space in dir should start cleanly");
 
     assert!(server.is_alive().await);
+}
+
+#[tokio::test]
+async fn bad_server_binary_returns_binary_not_found() {
+    let result = RedisServer::new()
+        .port(16407)
+        .redis_server_bin("/nonexistent/redis-server")
+        .start()
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(Error::BinaryNotFound { binary }) if binary == "/nonexistent/redis-server"
+    ));
+}
+
+#[tokio::test]
+async fn bad_cli_binary_returns_binary_not_found() {
+    let result = RedisServer::new()
+        .port(16408)
+        .redis_cli_bin("/nonexistent/redis-cli")
+        .start()
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(Error::BinaryNotFound { binary }) if binary == "/nonexistent/redis-cli"
+    ));
+}
+
+#[tokio::test]
+async fn port_already_in_use_returns_server_start_error() {
+    let _first = RedisServer::new()
+        .port(16409)
+        .dir(std::env::temp_dir().join("rsw-port-conflict-a"))
+        .start()
+        .await
+        .expect("first server should start");
+
+    // A daemonizing redis-server forks and its parent exits 0 before the
+    // child even attempts to bind, so a second daemonized start on the same
+    // port would falsely report success. Run the second attempt in the
+    // foreground so the bind failure surfaces synchronously.
+    let result = RedisServer::new()
+        .port(16409)
+        .dir(std::env::temp_dir().join("rsw-port-conflict-b"))
+        .extra("daemonize", "no")
+        .start()
+        .await;
+
+    assert!(matches!(result, Err(Error::ServerStart { port: 16409 })));
 }


### PR DESCRIPTION
## Summary

Adds tests for two `Error` variants that were previously never provoked by the test suite:

- `BinaryNotFound`, returned by `RedisServer::start` when `redis_server_bin` or `redis_cli_bin` points at a nonexistent path.
- `ServerStart`, returned when `redis-server` exits with a non-zero status (e.g. the target port is already in use).

`SentinelStart` and `ClusterCreate` are left uncovered per the issue's stated priority; they can follow up separately.

## Implementation notes

- `bad_server_binary_returns_binary_not_found` and `bad_cli_binary_returns_binary_not_found` set a nonexistent binary path and assert `Error::BinaryNotFound { binary }` with the expected path.
- `port_already_in_use_returns_server_start_error` starts a first server on a port, keeps the handle alive, then starts a second server on the same port with `daemonize=no`. The foreground run is required because a daemonizing `redis-server` forks and its parent process exits 0 before the child attempts to bind, which would make the second start falsely appear to succeed.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full suite, including the new tests)

Closes #87