### PR TITLE
test: add TLS roundtrip tests for generate_test_certs

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -2020,15 +2020,24 @@ impl RedisServer {
             });
         }
 
+        // The plain `port` always speaks unencrypted Redis protocol; `tls-port`
+        // is the only listener that speaks TLS. When the plain port is
+        // disabled (0), the server is only reachable over `tls-port`, so the
+        // admin CLI must connect there with TLS enabled instead.
+        let tls_only = self.config.port == 0;
+        let admin_port = if tls_only {
+            self.config.tls_port.unwrap_or(self.config.port)
+        } else {
+            self.config.port
+        };
         let mut cli = RedisCli::new()
             .bin(&self.config.redis_cli_bin)
             .host(&self.config.bind)
-            .port(self.config.port);
+            .port(admin_port);
         if let Some(ref pw) = self.config.password {
             cli = cli.password(pw);
         }
-        // When TLS is configured, enable it on the CLI so it can reach the server.
-        if self.config.tls_cert_file.is_some() && self.config.tls_key_file.is_some() {
+        if tls_only && self.config.tls_cert_file.is_some() && self.config.tls_key_file.is_some() {
             cli = cli.tls(true);
             if let Some(ref ca) = self.config.tls_ca_cert_file {
                 cli = cli.cacert(ca);

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -1,0 +1,80 @@
+#![cfg(feature = "test-tls")]
+
+use redis_server_wrapper::tls::generate_test_certs;
+use redis_server_wrapper::{RedisCli, RedisServer};
+
+#[tokio::test]
+async fn generate_test_certs_writes_files() {
+    let dir = std::env::temp_dir().join("rsw-tls-test-certs");
+    let certs = generate_test_certs(&dir).expect("cert generation failed");
+
+    assert!(certs.ca_cert_file.is_file(), "ca.crt not found");
+    assert!(certs.cert_file.is_file(), "server.crt not found");
+    assert!(certs.key_file.is_file(), "server.key not found");
+    assert!(std::fs::metadata(&certs.ca_cert_file).unwrap().len() > 0);
+    assert!(std::fs::metadata(&certs.cert_file).unwrap().len() > 0);
+    assert!(std::fs::metadata(&certs.key_file).unwrap().len() > 0);
+}
+
+#[tokio::test]
+async fn tls_server_roundtrip() {
+    let dir = std::env::temp_dir().join("rsw-tls-roundtrip");
+    let certs = generate_test_certs(&dir).expect("cert generation failed");
+
+    let server = RedisServer::new()
+        .port(16800)
+        .tls_port(16801)
+        .tls_cert_file(&certs.cert_file)
+        .tls_key_file(&certs.key_file)
+        .tls_ca_cert_file(&certs.ca_cert_file)
+        .tls_auth_clients(false)
+        .start()
+        .await
+        .expect("failed to start TLS-enabled server");
+
+    assert!(server.is_alive().await);
+
+    let reply = RedisCli::new()
+        .host("127.0.0.1")
+        .port(16801)
+        .tls(true)
+        .cacert(&certs.ca_cert_file)
+        .run(&["PING"])
+        .await
+        .expect("PING over TLS failed");
+    assert_eq!(reply.trim(), "PONG");
+}
+
+#[tokio::test]
+async fn tls_auth_clients_rejects_missing_client_cert() {
+    let dir = std::env::temp_dir().join("rsw-tls-auth-clients");
+    let certs = generate_test_certs(&dir).expect("cert generation failed");
+
+    let server = RedisServer::new()
+        .port(16802)
+        .tls_port(16803)
+        .tls_cert_file(&certs.cert_file)
+        .tls_key_file(&certs.key_file)
+        .tls_ca_cert_file(&certs.ca_cert_file)
+        .tls_auth_clients(true)
+        .start()
+        .await
+        .expect("failed to start TLS-enabled server");
+
+    assert!(server.is_alive().await);
+
+    // tls_auth_clients(true) requires mutual TLS, so a client that presents
+    // no certificate of its own must be rejected.
+    let result = RedisCli::new()
+        .host("127.0.0.1")
+        .port(16803)
+        .tls(true)
+        .cacert(&certs.ca_cert_file)
+        .run(&["PING"])
+        .await;
+
+    assert!(
+        result.is_err(),
+        "expected PING without a client cert to fail under tls_auth_clients(true)"
+    );
+}


### PR DESCRIPTION
Closes #84.

## Summary

`generate_test_certs` and the `test-tls` feature had no test coverage. This adds `tests/tls.rs`, gated on `#[cfg(feature = "test-tls")]`, with three tests:

- `generate_test_certs_writes_files` - confirms `ca.crt`, `server.crt`, and `server.key` are written to disk and non-empty.
- `tls_server_roundtrip` - starts a `RedisServer` with `tls_port`, `tls_cert_file`, `tls_key_file`, and `tls_ca_cert_file`, then confirms it responds to PING over TLS via `RedisCli`.
- `tls_auth_clients_rejects_missing_client_cert` - confirms a client without a client cert is rejected when `tls_auth_clients(true)` is set.

While writing the roundtrip test, found and fixed a bug in `RedisServer::start`: the admin `RedisCli` used internally for health checks enabled TLS whenever cert files were configured, even when a plain `port` was also active alongside `tls_port`. That broke startup for servers exposing both a plain and a TLS listener. The fix only enables TLS on the admin CLI when the plain port is disabled (TLS-only mode); otherwise it uses the plain port as before.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --features test-tls -- -D warnings`
- [x] `cargo test --features test-tls` (all tests pass, including the 3 new TLS tests)
- [x] `cargo test` (default feature set unaffected)

No CI changes needed: the existing workflow already runs `cargo test --all-features` on both Ubuntu and macOS runners, and both install Redis builds with TLS support.