### PR TITLE
fix: use unique per-invocation temp dir for cluster node working dirs

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1,8 +1,9 @@
 //! Redis Cluster lifecycle management built on `RedisServer`.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::cli::RedisCli;
 use crate::error::{Error, Result};
@@ -529,10 +530,18 @@ impl RedisClusterBuilder {
         // Start each node.
         let total_nodes = self.total_nodes();
         let ports: Vec<u16> = self.ports().collect();
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        let cluster_base = std::env::temp_dir().join(format!(
+            "redis-cluster-wrapper-{}-{}",
+            std::process::id(),
+            unique
+        ));
         let mut nodes = Vec::new();
         for (index, port) in ports.into_iter().enumerate() {
-            let node_dir = std::env::temp_dir().join(format!("redis-cluster-wrapper/node-{port}"));
-            let _ = std::fs::remove_dir_all(&node_dir);
+            let node_dir = cluster_base.join(format!("node-{port}"));
             let mut server = RedisServer::new()
                 .port(port)
                 .bind(&self.bind)
@@ -708,6 +717,7 @@ impl RedisClusterBuilder {
                 key_file: self.tls_key_file,
                 ca_cert_file: self.tls_ca_cert_file,
             },
+            cluster_base,
         })
     }
 }
@@ -753,6 +763,8 @@ pub struct RedisClusterHandle {
     password: Option<String>,
     redis_cli_bin: String,
     tls: TlsConfig,
+    /// Unique per-invocation base directory holding all node working directories.
+    cluster_base: PathBuf,
 }
 
 /// Entry point for building a Redis Cluster topology.
@@ -944,6 +956,11 @@ impl RedisClusterHandle {
         }
         cli = self.tls.apply(cli);
         cli
+    }
+
+    /// The unique per-invocation base directory holding all node working directories.
+    pub fn cluster_base(&self) -> &Path {
+        &self.cluster_base
     }
 }
 


### PR DESCRIPTION
## Summary

`RedisClusterBuilder::start()` built node working directories from the port number alone (`$TMPDIR/redis-cluster-wrapper/node-<port>`), then unconditionally `remove_dir_all`'d that path before starting each node. Two concurrent cluster startups at the same `base_port` (a common pattern in parallel test suites) would share these directories, and the second caller's cleanup could delete the first caller's live working directory, config, pidfile, or RDB snapshot out from under it.

This mirrors the fix already applied to `RedisSentinelBuilder` (`src/sentinel.rs`), which uniquifies its base directory with PID + timestamp.

## Changes

- `RedisClusterBuilder::start()` now generates a `cluster_base` directory unique per invocation (`redis-cluster-wrapper-<pid>-<nanos>`), and each node directory is nested under it (`cluster_base/node-<port>`). No more shared paths, no more racy `remove_dir_all` on another process's live directory.
- `RedisClusterHandle` stores `cluster_base` and exposes it via a new `cluster_base()` accessor for inspection/debugging.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (unit, integration, and doc tests all pass, including `tests/cluster.rs`)

Closes #91