### PR TITLE
feat: add cli() accessor to blocking handles

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1398,6 +1398,13 @@ pub struct RedisServerHandle {
 }
 
 impl RedisServerHandle {
+    /// Get a `RedisCli` configured for this server.
+    pub fn cli(&self) -> RedisCli {
+        RedisCli {
+            inner: self.inner.cli().clone(),
+        }
+    }
+
     /// The server's address as "host:port".
     pub fn addr(&self) -> String {
         self.inner.addr()
@@ -1769,6 +1776,13 @@ pub struct RedisClusterHandle {
 }
 
 impl RedisClusterHandle {
+    /// Get a `RedisCli` for the seed node.
+    pub fn cli(&self) -> RedisCli {
+        RedisCli {
+            inner: self.inner.cli(),
+        }
+    }
+
     /// The seed address (first node).
     pub fn addr(&self) -> String {
         self.inner.addr()
@@ -2026,6 +2040,13 @@ pub struct RedisSentinelHandle {
 }
 
 impl RedisSentinelHandle {
+    /// Get a `RedisCli` for the seed sentinel (first sentinel process).
+    pub fn cli(&self) -> RedisCli {
+        RedisCli {
+            inner: self.inner.cli(),
+        }
+    }
+
     /// The master's address as "host:port". Kept consistent with
     /// `RedisServerHandle::addr` and `RedisClusterHandle::addr`.
     pub fn addr(&self) -> String {

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -653,6 +653,16 @@ impl RedisSentinelHandle {
         self.master.addr()
     }
 
+    /// Get a `RedisCli` for the seed sentinel (first sentinel process).
+    pub fn cli(&self) -> RedisCli {
+        self.tls.apply(
+            RedisCli::new()
+                .bin(&self.redis_cli_bin)
+                .host(&self.bind)
+                .port(self.sentinel_ports[0]),
+        )
+    }
+
     /// All monitored master names.
     pub fn monitored_master_names(&self) -> Vec<&str> {
         self.monitored_masters

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -122,6 +122,17 @@ fn blocking_cli_wait_for_ready_timeout() {
 }
 
 #[test]
+fn blocking_server_cli_accessor() {
+    let server = RedisServer::new()
+        .port(16544)
+        .start()
+        .expect("failed to start redis-server");
+
+    let cli = server.cli();
+    assert!(cli.ping());
+}
+
+#[test]
 fn blocking_cluster_start_and_health() {
     let cluster = RedisCluster::builder()
         .masters(3)
@@ -136,6 +147,9 @@ fn blocking_cluster_start_and_health() {
     assert!(cluster.is_healthy());
     assert_eq!(cluster.node_addrs().len(), 3);
     assert_eq!(cluster.addr(), "127.0.0.1:17100");
+
+    let cli = cluster.cli();
+    assert!(cli.ping());
 }
 
 #[test]
@@ -156,6 +170,9 @@ fn blocking_sentinel_start_and_health() {
     assert_eq!(sentinel.master_name(), "mymaster");
     assert_eq!(sentinel.master_addr(), "127.0.0.1:16590");
     assert_eq!(sentinel.sentinel_addrs().len(), 3);
+
+    let cli = sentinel.cli();
+    assert!(cli.ping());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds a `cli()` accessor to `blocking::RedisServerHandle`, `blocking::RedisClusterHandle`, and `blocking::RedisSentinelHandle`, mirroring the async handle surface. Previously a synchronous caller had no way to obtain a `blocking::RedisCli` from a handle and had to reconstruct one manually with the correct host/port/password.

- `blocking::RedisServerHandle::cli()` clones the inner async handle's `RedisCli`.
- `blocking::RedisClusterHandle::cli()` delegates to `cluster::RedisClusterHandle::cli()` (seed node).
- `blocking::RedisSentinelHandle::cli()` delegates to a new `sentinel::RedisSentinelHandle::cli()` (seed sentinel), added since the async sentinel handle didn't previously expose one.

Closes #89

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (includes new `blocking_server_cli_accessor` test and `cli()` assertions added to the existing cluster/sentinel health tests)