### PR TITLE
test: add integration tests for existing chaos module operations

### DIFF
--- a/tests/chaos.rs
+++ b/tests/chaos.rs
@@ -1,0 +1,128 @@
+use redis_server_wrapper::{RedisCluster, RedisServer, chaos};
+use std::time::Duration;
+
+#[cfg_attr(not(unix), ignore)]
+#[tokio::test]
+async fn freeze_and_resume_node() {
+    let server = RedisServer::new()
+        .port(17700)
+        .start()
+        .await
+        .expect("failed to start server");
+
+    assert!(server.is_alive().await);
+
+    chaos::freeze_node(&server);
+
+    // SIGSTOP suspends the process but the kernel still completes the TCP
+    // handshake, so a PING can hang forever waiting for a reply that will
+    // never come. Bound the check with a timeout.
+    let frozen_ping = tokio::time::timeout(Duration::from_secs(2), server.is_alive()).await;
+    assert!(frozen_ping.is_err() || frozen_ping == Ok(false));
+
+    chaos::resume_node(&server);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(server.is_alive().await);
+}
+
+#[tokio::test]
+async fn kill_node_terminates_process() {
+    let server = RedisServer::new()
+        .port(17701)
+        .start()
+        .await
+        .expect("failed to start server");
+
+    assert!(server.is_alive().await);
+
+    chaos::kill_node(&server);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(!server.is_alive().await);
+}
+
+#[tokio::test]
+async fn slow_down_returns_ok() {
+    let server = RedisServer::new()
+        .port(17702)
+        .start()
+        .await
+        .expect("failed to start server");
+
+    let result = chaos::slow_down(&server, 100).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn trigger_save_and_flushall() {
+    let server = RedisServer::new()
+        .port(17703)
+        .start()
+        .await
+        .expect("failed to start server");
+
+    server.run(&["SET", "k", "v"]).await.expect("SET failed");
+
+    chaos::trigger_save(&server).await.expect("bgsave failed");
+    chaos::flushall(&server).await.expect("flushall failed");
+
+    let val = server.run(&["GET", "k"]).await.expect("GET failed");
+    assert!(val.trim().is_empty() || val.trim() == "(nil)");
+}
+
+#[tokio::test]
+async fn failover_and_recover_cluster() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(1)
+        .base_port(17710)
+        .start()
+        .await
+        .expect("failed to start cluster");
+
+    cluster
+        .wait_for_healthy(Duration::from_secs(30))
+        .await
+        .expect("cluster did not become healthy");
+
+    let replica = &cluster.replica_nodes()[0];
+    chaos::trigger_failover(replica)
+        .await
+        .expect("trigger_failover failed");
+
+    cluster
+        .wait_for_healthy(Duration::from_secs(30))
+        .await
+        .expect("cluster did not recover after failover");
+
+    chaos::recover(&cluster);
+    assert!(cluster.all_alive().await);
+}
+
+#[tokio::test]
+async fn kill_master_by_slot_removes_node() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(0)
+        .base_port(17730)
+        .start()
+        .await
+        .expect("failed to start cluster");
+
+    cluster
+        .wait_for_healthy(Duration::from_secs(30))
+        .await
+        .expect("cluster did not become healthy");
+
+    let killed_port = chaos::kill_master_by_slot(&cluster, 0)
+        .await
+        .expect("kill_master_by_slot failed");
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let killed_node = cluster
+        .nodes()
+        .iter()
+        .find(|n| n.port() == killed_port)
+        .expect("killed node not found among cluster nodes");
+    assert!(!killed_node.is_alive().await);
+}


### PR DESCRIPTION
## Summary

Adds `tests/chaos.rs`, an integration test suite for the public functions in `src/chaos.rs`. Previously the only coverage for this module was unit tests for internal parsing helpers (`slot_in_range`, `parse_cluster_node_port`); no test exercised the chaos operations against a real running server or cluster.

Closes #81.

## Coverage

- `freeze_and_resume_node`: SIGSTOP a server, confirm PING hangs/fails while frozen (bounded with a timeout since a stopped process still completes the TCP handshake), SIGCONT, confirm PING succeeds again. `#[cfg_attr(not(unix), ignore)]` since SIGSTOP/SIGCONT are POSIX signals.
- `kill_node_terminates_process`: SIGKILL a server, confirm it's no longer alive.
- `slow_down_returns_ok`: `CLIENT PAUSE` against a running server returns `Ok`.
- `trigger_save_and_flushall`: `BGSAVE` then `FLUSHALL`, confirm the flush actually cleared the previously set key.
- `failover_and_recover_cluster`: 3-master/1-replica-each cluster, `CLUSTER FAILOVER` on a replica, cluster becomes healthy again, then `recover` (SIGCONT sweep) leaves all nodes alive.
- `kill_master_by_slot_removes_node`: 3-master cluster, kill the master owning slot 0, confirm that specific node is no longer alive.

Note: the issue's example used a 1-master/1-replica cluster for the failover test, but `redis-cli --cluster create` enforces a minimum of 3 masters, so that test uses 3 masters with 1 replica each instead.

Uses port range 17700-17739 to avoid collisions with existing integration tests.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full suite, including new `tests/chaos.rs`)