### PR TITLE
feat: additional chaos module operations

### DIFF
--- a/src/chaos.rs
+++ b/src/chaos.rs
@@ -41,6 +41,8 @@ use crate::error::Result;
 use crate::server::RedisServerHandle;
 
 use std::process::Command;
+#[cfg(feature = "tokio")]
+use std::time::Duration;
 
 // ---------------------------------------------------------------------------
 // Node-level operations
@@ -80,6 +82,23 @@ pub fn resume_node(handle: &RedisServerHandle) {
     let _ = Command::new("kill").args(["-CONT", &pid]).output();
 }
 
+/// Freeze a node for a fixed duration, then resume it automatically.
+///
+/// Sends SIGSTOP immediately and returns without blocking. A background
+/// tokio task sleeps for `duration` and then sends SIGCONT, so the node
+/// comes back on its own -- there's no need to call [`resume_node`] or
+/// [`recover`] afterward. Useful for testing timeout handling where the
+/// outage has a bounded, known length.
+#[cfg(feature = "tokio")]
+pub fn pause_node(handle: &RedisServerHandle, duration: Duration) {
+    let pid = handle.pid().to_string();
+    let _ = Command::new("kill").args(["-STOP", &pid]).output();
+    tokio::spawn(async move {
+        tokio::time::sleep(duration).await;
+        let _ = Command::new("kill").args(["-CONT", &pid]).output();
+    });
+}
+
 /// Pause client connections for a duration using `CLIENT PAUSE`.
 ///
 /// Unlike [`freeze_node`], the server process stays responsive for
@@ -100,6 +119,22 @@ pub async fn trigger_save(handle: &RedisServerHandle) -> Result<String> {
 #[cfg(feature = "tokio")]
 pub async fn flushall(handle: &RedisServerHandle) -> Result<String> {
     handle.run(&["FLUSHALL"]).await
+}
+
+/// Fill a node with `count` keys holding fixed-size values.
+///
+/// Writes keys named `<prefix>0` through `<prefix>{count-1}`, each holding a
+/// 1 KiB value. Useful for exercising `maxmemory` and eviction-policy
+/// behavior with a deterministic, bounded key count.
+#[cfg(feature = "tokio")]
+pub async fn fill_memory(handle: &RedisServerHandle, prefix: &str, count: usize) -> Result<()> {
+    let value = "x".repeat(1024);
+    for i in 0..count {
+        handle
+            .run(&["SET", &format!("{prefix}{i}"), &value])
+            .await?;
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -154,6 +189,25 @@ pub async fn trigger_failover(replica: &RedisServerHandle) -> Result<String> {
         return replica.run(&["CLUSTER", "FAILOVER", "FORCE"]).await;
     }
     Ok(result)
+}
+
+/// Simulate a network partition by freezing every node not in `reachable`.
+///
+/// `reachable` holds the indices, matching the order of
+/// [`RedisClusterHandle::nodes`], of the nodes that stay up; every other
+/// node is sent SIGSTOP. Returns the ports of the frozen nodes. Call
+/// [`recover`] to heal the partition.
+#[cfg(feature = "tokio")]
+pub fn partition(cluster: &RedisClusterHandle, reachable: &[usize]) -> Vec<u16> {
+    let mut frozen = Vec::new();
+    for (i, node) in cluster.nodes().iter().enumerate() {
+        if !reachable.contains(&i) {
+            let pid = node.pid().to_string();
+            let _ = Command::new("kill").args(["-STOP", &pid]).output();
+            frozen.push(node.port());
+        }
+    }
+    frozen
 }
 
 /// Resume all nodes in a cluster by sending SIGCONT.

--- a/tests/chaos.rs
+++ b/tests/chaos.rs
@@ -98,6 +98,67 @@ async fn failover_and_recover_cluster() {
     assert!(cluster.all_alive().await);
 }
 
+#[cfg_attr(not(unix), ignore)]
+#[tokio::test]
+async fn pause_node_resumes_automatically() {
+    let server = RedisServer::new()
+        .port(17704)
+        .start()
+        .await
+        .expect("failed to start server");
+
+    assert!(server.is_alive().await);
+
+    chaos::pause_node(&server, Duration::from_millis(300));
+
+    tokio::time::sleep(Duration::from_millis(600)).await;
+
+    let resumed_ping = tokio::time::timeout(Duration::from_secs(2), server.is_alive()).await;
+    assert_eq!(resumed_ping, Ok(true));
+}
+
+#[tokio::test]
+async fn fill_memory_writes_keys() {
+    let server = RedisServer::new()
+        .port(17705)
+        .start()
+        .await
+        .expect("failed to start server");
+
+    chaos::fill_memory(&server, "k:", 50)
+        .await
+        .expect("fill_memory failed");
+
+    let dbsize = server.run(&["DBSIZE"]).await.expect("DBSIZE failed");
+    assert!(dbsize.contains("50"));
+}
+
+#[cfg_attr(not(unix), ignore)]
+#[tokio::test]
+async fn partition_freezes_unreachable_nodes() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(0)
+        .base_port(17740)
+        .start()
+        .await
+        .expect("failed to start cluster");
+
+    cluster
+        .wait_for_healthy(Duration::from_secs(30))
+        .await
+        .expect("cluster did not become healthy");
+
+    let frozen = chaos::partition(&cluster, &[0]);
+    assert!(!frozen.is_empty());
+    assert_eq!(frozen.len(), cluster.nodes().len() - 1);
+
+    chaos::recover(&cluster);
+
+    let node0 = &cluster.nodes()[0];
+    assert!(node0.run(&["PING"]).await.is_ok());
+}
+
 #[tokio::test]
 async fn kill_master_by_slot_removes_node() {
     let cluster = RedisCluster::builder()


### PR DESCRIPTION
## Summary

Adds three more fault-injection primitives to the `chaos` module, follow-up to #74:

- `pause_node(handle, duration)` -- SIGSTOP a node, then SIGCONT it automatically after `duration` via a spawned tokio task. For simulating a brief network blip without a manual resume call.
- `partition(cluster, reachable)` -- freeze (SIGSTOP) every node whose index is not in `reachable`, simulating a network split where only the `reachable` group can be reached. Returns the ports of the frozen nodes. `recover` heals it.
- `fill_memory(handle, prefix, count)` -- loop of SET commands with a fixed-size value to build up memory pressure for eviction-policy testing.

`random_kill` is intentionally left out: the issue itself notes it's a thin wrapper around picking a random index, and adding a `rand` dependency for that isn't worth it. Callers can pick an index themselves and call the existing `kill_master_by_slot`/`kill_node` functions.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] `cargo doc --no-deps --all-features`

Closes #75