### PR TITLE
feat: support load-time arguments in loadmodule

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -951,6 +951,16 @@ impl RedisServer {
         self
     }
 
+    /// Load a Redis module at startup with load-time arguments.
+    pub fn loadmodule_with_args(
+        mut self,
+        path: impl Into<PathBuf>,
+        args: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.inner = self.inner.loadmodule_with_args(path, args);
+        self
+    }
+
     // -- advanced --
 
     /// Set the server tick frequency in Hz.

--- a/src/server.rs
+++ b/src/server.rs
@@ -303,8 +303,8 @@ pub struct RedisServerConfig {
     pub stream_idmp_maxsize: Option<u64>,
 
     // -- modules --
-    /// List of Redis module paths to load at startup.
-    pub loadmodule: Vec<PathBuf>,
+    /// List of Redis module paths to load at startup, each with its load-time arguments.
+    pub loadmodule: Vec<(PathBuf, Vec<String>)>,
 
     // -- advanced --
     /// Server tick frequency in Hz, if set (Redis default: `10`).
@@ -1535,7 +1535,23 @@ impl RedisServer {
 
     /// Load a Redis module at startup.
     pub fn loadmodule(mut self, path: impl Into<PathBuf>) -> Self {
-        self.config.loadmodule.push(path.into());
+        self.config.loadmodule.push((path.into(), Vec::new()));
+        self
+    }
+
+    /// Load a Redis module at startup with load-time arguments.
+    ///
+    /// Renders `loadmodule "<path>" arg1 arg2 ...`. The path is quoted; the
+    /// arguments are appended unquoted and space-separated, matching how Redis
+    /// parses module arguments.
+    pub fn loadmodule_with_args(
+        mut self,
+        path: impl Into<PathBuf>,
+        args: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.config
+            .loadmodule
+            .push((path.into(), args.into_iter().map(Into::into).collect()));
         self
     }
 
@@ -2493,8 +2509,13 @@ impl RedisServer {
         }
 
         // -- modules --
-        for path in &self.config.loadmodule {
-            conf.push_str(&format!("loadmodule \"{}\"\n", path.display()));
+        for (path, args) in &self.config.loadmodule {
+            conf.push_str(&format!("loadmodule \"{}\"", path.display()));
+            for arg in args {
+                conf.push(' ');
+                conf.push_str(arg);
+            }
+            conf.push('\n');
         }
 
         // -- advanced --
@@ -3136,5 +3157,20 @@ mod tests {
         assert_eq!(s.config.tls_session_cache_timeout, Some(300));
         assert_eq!(s.config.tls_replication, Some(true));
         assert_eq!(s.config.tls_cluster, Some(true));
+    }
+
+    #[test]
+    fn loadmodule_config() {
+        let s = RedisServer::new().loadmodule("/x/mod.so");
+        let config = s.generate_config(std::path::Path::new("/tmp/rsw-test"));
+        assert!(config.contains("loadmodule \"/x/mod.so\"\n"));
+    }
+
+    #[test]
+    fn loadmodule_with_args_config() {
+        let s = RedisServer::new()
+            .loadmodule_with_args("/x/mod.so", ["stream-prefix", "ks:", "events"]);
+        let config = s.generate_config(std::path::Path::new("/tmp/rsw-test"));
+        assert!(config.contains("loadmodule \"/x/mod.so\" stream-prefix ks: events\n"));
     }
 }


### PR DESCRIPTION
Closes #109.

## Problem

`RedisServerBuilder::loadmodule()` stores bare paths (`Vec<PathBuf>`) and renders `loadmodule "<path>"`, so there is no way to pass load-time module arguments (`loadmodule /path/to/module.so arg1 value1 ...`). Modules using `module_args_as_configuration` (redismodule-rs) need these for load-time config. The `.extra("loadmodule", "...")` workaround bypasses path quoting and, being a map, allows only one directive.

## Plan

- Change the internal representation of the module list from `Vec<PathBuf>` to `Vec<(PathBuf, Vec<String>)>` in `RedisServerConfig`. The field is behind the private `RedisServer.config`, so this is an internal change with no public-API break.
- Keep `loadmodule(path)` unchanged in behavior (pushes the path with an empty arg list).
- Add `loadmodule_with_args(path, args)` on both the async builder (`src/server.rs`) and the blocking builder (`src/blocking.rs`):

  ```rust
  pub fn loadmodule_with_args(
      mut self,
      path: impl Into<PathBuf>,
      args: impl IntoIterator<Item = impl Into<String>>,
  ) -> Self
  ```

- Render `loadmodule "<path>"` when there are no args, and `loadmodule "<path>" arg1 arg2 ...` when there are. The path stays quoted; args are appended unquoted and space-separated (Redis needs unprefixed args like `stream-prefix ks: events expired maxlen 50`).
- Add unit tests in the `server.rs` `mod tests` block asserting the rendered config for both the no-args and with-args cases.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] `cargo doc --no-deps --all-features`