### PR TITLE
feat: expose chaos and fault-injection functionality to the blocking API

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -5,9 +5,11 @@
 //! the underlying async handle (and its `Drop` impl) keeps working correctly.
 
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use tokio::net::ToSocketAddrs;
 use tokio::runtime::Runtime;
 
 use crate::error::Result;
@@ -2116,5 +2118,256 @@ impl RedisSentinelHandle {
     /// Stop everything.
     pub fn stop(&self) {
         self.inner.stop();
+    }
+}
+
+// ── chaos ─────────────────────────────────────────────────────────────────────
+
+/// Synchronous wrappers for [`crate::chaos`], operating on the blocking handle
+/// types in this module instead of the async ones.
+///
+/// Every function here mirrors an async function of the same name in
+/// [`crate::chaos`]. Calls that are async upstream block the calling thread
+/// on the handle's own [`Runtime`] (the same runtime that drives the rest of
+/// that handle's blocking methods); calls that are already synchronous
+/// upstream (signal sends) delegate directly.
+///
+/// [`crate::chaos::ReshardGuard`] is not wrapped here -- it's built around
+/// borrowed async handles held across multiple calls, which doesn't have a
+/// natural blocking shape. Use the async API directly if you need deterministic
+/// control over an in-flight slot migration.
+pub mod chaos {
+    use super::{RedisClusterHandle, RedisServerHandle};
+    use crate::error::Result;
+    use std::time::Duration;
+
+    /// Kill a node immediately with SIGKILL. See [`crate::chaos::kill_node`].
+    pub fn kill_node(handle: &RedisServerHandle) {
+        crate::chaos::kill_node(&handle.inner);
+    }
+
+    /// Freeze a node by sending SIGSTOP. See [`crate::chaos::freeze_node`].
+    pub fn freeze_node(handle: &RedisServerHandle) {
+        crate::chaos::freeze_node(&handle.inner);
+    }
+
+    /// Resume a frozen node by sending SIGCONT. See [`crate::chaos::resume_node`].
+    pub fn resume_node(handle: &RedisServerHandle) {
+        crate::chaos::resume_node(&handle.inner);
+    }
+
+    /// Freeze a node for a fixed duration, then resume it automatically.
+    ///
+    /// Sends SIGSTOP immediately and returns without blocking. Unlike the
+    /// other functions here, this one enters `handle`'s runtime (via
+    /// [`Runtime::enter`](tokio::runtime::Runtime::enter)) before delegating,
+    /// so the background resume task that
+    /// [`crate::chaos::pause_node`] spawns internally lands on that runtime
+    /// instead of panicking for lack of a runtime context.
+    pub fn pause_node(handle: &RedisServerHandle, duration: Duration) {
+        let _guard = handle.rt.enter();
+        crate::chaos::pause_node(&handle.inner, duration);
+    }
+
+    /// Pause client connections for a duration using `CLIENT PAUSE`. Blocks
+    /// on the handle's runtime. See [`crate::chaos::slow_down`].
+    pub fn slow_down(handle: &RedisServerHandle, millis: u64) -> Result<String> {
+        handle
+            .rt
+            .block_on(crate::chaos::slow_down(&handle.inner, millis))
+    }
+
+    /// Trigger a background RDB save. Blocks on the handle's runtime. See
+    /// [`crate::chaos::trigger_save`].
+    pub fn trigger_save(handle: &RedisServerHandle) -> Result<String> {
+        handle
+            .rt
+            .block_on(crate::chaos::trigger_save(&handle.inner))
+    }
+
+    /// Flush all data from a node. Blocks on the handle's runtime. See
+    /// [`crate::chaos::flushall`].
+    pub fn flushall(handle: &RedisServerHandle) -> Result<String> {
+        handle.rt.block_on(crate::chaos::flushall(&handle.inner))
+    }
+
+    /// Fill a node with `count` keys holding fixed-size values. Blocks on the
+    /// handle's runtime. See [`crate::chaos::fill_memory`].
+    pub fn fill_memory(handle: &RedisServerHandle, prefix: &str, count: usize) -> Result<()> {
+        handle
+            .rt
+            .block_on(crate::chaos::fill_memory(&handle.inner, prefix, count))
+    }
+
+    /// Kill the master node that owns a given hash slot. Blocks on the
+    /// cluster's runtime. See [`crate::chaos::kill_master_by_slot`].
+    pub fn kill_master_by_slot(cluster: &RedisClusterHandle, slot: u16) -> Result<u16> {
+        cluster
+            .rt
+            .block_on(crate::chaos::kill_master_by_slot(&cluster.inner, slot))
+    }
+
+    /// Kill the master node that owns the hash slot for a given key. Blocks
+    /// on the cluster's runtime. See [`crate::chaos::kill_master_by_key`].
+    pub fn kill_master_by_key(cluster: &RedisClusterHandle, key: &str) -> Result<u16> {
+        cluster
+            .rt
+            .block_on(crate::chaos::kill_master_by_key(&cluster.inner, key))
+    }
+
+    /// Freeze the master node that owns a given hash slot. Blocks on the
+    /// cluster's runtime. See [`crate::chaos::freeze_master_by_slot`].
+    pub fn freeze_master_by_slot(cluster: &RedisClusterHandle, slot: u16) -> Result<u16> {
+        cluster
+            .rt
+            .block_on(crate::chaos::freeze_master_by_slot(&cluster.inner, slot))
+    }
+
+    /// Trigger a `CLUSTER FAILOVER` on a replica node. Blocks on the
+    /// replica's runtime. See [`crate::chaos::trigger_failover`].
+    pub fn trigger_failover(replica: &RedisServerHandle) -> Result<String> {
+        replica
+            .rt
+            .block_on(crate::chaos::trigger_failover(&replica.inner))
+    }
+
+    /// Simulate a network partition by freezing every node not in
+    /// `reachable`. See [`crate::chaos::partition`].
+    pub fn partition(cluster: &RedisClusterHandle, reachable: &[usize]) -> Vec<u16> {
+        crate::chaos::partition(&cluster.inner, reachable)
+    }
+
+    /// Resume all nodes in a cluster by sending SIGCONT. See
+    /// [`crate::chaos::recover`].
+    pub fn recover(cluster: &RedisClusterHandle) {
+        crate::chaos::recover(&cluster.inner);
+    }
+
+    /// Migrate a single hash slot from one master to another. Blocks on the
+    /// cluster's runtime. See [`crate::chaos::migrate_slot`].
+    ///
+    /// `from` and `to` are node indices, matching the order of
+    /// [`RedisClusterHandle::node_addrs`], rather than node handles like the
+    /// async version. The blocking cluster handle doesn't expose individual
+    /// nodes as blocking handle types (each would need its own runtime, and
+    /// this operation needs both nodes driven from a single `block_on` call),
+    /// so indices are resolved internally against the cluster's underlying
+    /// async node handles instead.
+    pub fn migrate_slot(
+        cluster: &RedisClusterHandle,
+        slot: u16,
+        from: usize,
+        to: usize,
+    ) -> Result<usize> {
+        cluster.rt.block_on(crate::chaos::migrate_slot(
+            &cluster.inner,
+            slot,
+            cluster.inner.node(from),
+            cluster.inner.node(to),
+        ))
+    }
+
+    /// Migrate a range of hash slots from one master to another. Blocks on
+    /// the cluster's runtime. See [`crate::chaos::migrate_slots`].
+    ///
+    /// `from` and `to` are node indices; see [`migrate_slot`] for why.
+    pub fn migrate_slots(
+        cluster: &RedisClusterHandle,
+        slots: std::ops::RangeInclusive<u16>,
+        from: usize,
+        to: usize,
+    ) -> Result<usize> {
+        cluster.rt.block_on(crate::chaos::migrate_slots(
+            &cluster.inner,
+            slots,
+            cluster.inner.node(from),
+            cluster.inner.node(to),
+        ))
+    }
+}
+
+// ── FaultProxy ────────────────────────────────────────────────────────────────
+
+pub use crate::fault_proxy::{Delay, Direction};
+
+/// Synchronous wrapper for [`crate::fault_proxy::FaultProxy`].
+///
+/// Owns a dedicated multi-thread [`Runtime`] that drives the proxy's accept
+/// loop and per-connection forwarding tasks for as long as this handle is
+/// alive. Dropping the handle drops the inner
+/// [`crate::fault_proxy::FaultProxy`] first, which aborts its accept task so
+/// no new connections are accepted, and then drops the runtime, which tears
+/// down any connections that were still being forwarded.
+///
+/// Fault controls (`set_delay`, `close_after`, `set_chunk_size`,
+/// `set_drop_all`, `reset`, ...) are synchronous in the async API already, so
+/// they delegate directly here without touching the runtime.
+pub struct FaultProxy {
+    inner: crate::fault_proxy::FaultProxy,
+    // Never read directly after construction; kept alive so its worker
+    // threads keep running the accept loop and per-connection forwarding
+    // tasks spawned during `spawn`, and so it shuts them down on drop.
+    #[allow(dead_code)]
+    rt: Runtime,
+}
+
+impl FaultProxy {
+    /// Bind an ephemeral local TCP listener that proxies to `upstream_addr`
+    /// and return a handle to it, backed by a new dedicated [`Runtime`]. The
+    /// proxy starts in clean-passthrough mode. See
+    /// [`crate::fault_proxy::FaultProxy::spawn`].
+    pub fn spawn(upstream_addr: impl ToSocketAddrs) -> Result<Self> {
+        let rt = Runtime::new()?;
+        let inner = rt.block_on(crate::fault_proxy::FaultProxy::spawn(upstream_addr))?;
+        Ok(Self { inner, rt })
+    }
+
+    /// The local address clients should connect to.
+    pub fn addr(&self) -> SocketAddr {
+        self.inner.addr()
+    }
+
+    /// Set (or replace) the delay applied before forwarding data in `direction`.
+    pub fn set_delay(&self, direction: Direction, delay: Delay) {
+        self.inner.set_delay(direction, delay);
+    }
+
+    /// Remove any delay configured for `direction`.
+    pub fn clear_delay(&self, direction: Direction) {
+        self.inner.clear_delay(direction);
+    }
+
+    /// Close the connection once `bytes` total have been forwarded in
+    /// `direction`, cutting mid-buffer if the triggering read straddles the
+    /// threshold.
+    pub fn close_after(&self, direction: Direction, bytes: u64) {
+        self.inner.close_after(direction, bytes);
+    }
+
+    /// Remove the close-after threshold configured for `direction`.
+    pub fn clear_close_after(&self, direction: Direction) {
+        self.inner.clear_close_after(direction);
+    }
+
+    /// Split forwarded writes into pieces of at most `size` bytes, in both
+    /// directions.
+    pub fn set_chunk_size(&self, size: usize) {
+        self.inner.set_chunk_size(size);
+    }
+
+    /// Stop chunking writes; forward reads in whatever size they arrive.
+    pub fn clear_chunk_size(&self) {
+        self.inner.clear_chunk_size();
+    }
+
+    /// Enable or disable black-hole mode.
+    pub fn set_drop_all(&self, drop_all: bool) {
+        self.inner.set_drop_all(drop_all);
+    }
+
+    /// Clear every fault control, returning the proxy to clean passthrough
+    /// for new connections.
+    pub fn reset(&self) {
+        self.inner.reset();
     }
 }

--- a/tests/blocking_chaos.rs
+++ b/tests/blocking_chaos.rs
@@ -1,0 +1,80 @@
+#![cfg(feature = "blocking")]
+
+use redis_server_wrapper::blocking::{RedisCluster, RedisServer, chaos};
+use std::time::Duration;
+
+#[cfg_attr(not(unix), ignore)]
+#[test]
+fn freeze_and_resume_node() {
+    let server = RedisServer::new()
+        .port(17800)
+        .start()
+        .expect("failed to start server");
+
+    assert!(server.is_alive());
+
+    chaos::freeze_node(&server);
+    std::thread::sleep(Duration::from_millis(200));
+
+    chaos::resume_node(&server);
+    std::thread::sleep(Duration::from_millis(200));
+
+    let pong = server.run(&["PING"]).expect("PING failed after resume");
+    assert_eq!(pong.trim(), "PONG");
+}
+
+#[cfg_attr(not(unix), ignore)]
+#[test]
+fn pause_node_resumes_automatically() {
+    let server = RedisServer::new()
+        .port(17801)
+        .start()
+        .expect("failed to start server");
+
+    assert!(server.is_alive());
+
+    chaos::pause_node(&server, Duration::from_millis(300));
+
+    std::thread::sleep(Duration::from_millis(600));
+
+    assert!(server.is_alive());
+}
+
+#[test]
+fn fill_memory_writes_keys() {
+    let server = RedisServer::new()
+        .port(17802)
+        .start()
+        .expect("failed to start server");
+
+    chaos::fill_memory(&server, "k:", 50).expect("fill_memory failed");
+
+    let dbsize = server.run(&["DBSIZE"]).expect("DBSIZE failed");
+    assert!(dbsize.contains("50"));
+}
+
+#[cfg_attr(not(unix), ignore)]
+#[test]
+fn partition_and_recover_cluster() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(0)
+        .base_port(17820)
+        .start()
+        .expect("failed to start cluster");
+
+    cluster
+        .wait_for_healthy(Duration::from_secs(30))
+        .expect("cluster did not become healthy");
+
+    let frozen = chaos::partition(&cluster, &[0]);
+    assert!(!frozen.is_empty());
+    assert_eq!(frozen.len(), cluster.node_addrs().len() - 1);
+
+    chaos::recover(&cluster);
+
+    let pong = cluster
+        .node_run(0, &["PING"])
+        .expect("node 0 did not respond after recover");
+    assert_eq!(pong.trim(), "PONG");
+}

--- a/tests/blocking_fault_proxy.rs
+++ b/tests/blocking_fault_proxy.rs
@@ -1,0 +1,43 @@
+#![cfg(feature = "blocking")]
+
+use redis_server_wrapper::blocking::{Direction, FaultProxy, RedisServer};
+use std::io::{Read, Write};
+use std::net::TcpStream;
+
+#[test]
+fn passthrough_ping_roundtrip() {
+    let server = RedisServer::new()
+        .port(17850)
+        .start()
+        .expect("failed to start server");
+
+    let proxy = FaultProxy::spawn(server.addr()).expect("failed to spawn proxy");
+
+    let mut client = TcpStream::connect(proxy.addr()).expect("failed to connect to proxy");
+    client.write_all(b"PING\r\n").expect("write failed");
+
+    let mut buf = [0u8; 7];
+    client.read_exact(&mut buf).expect("read failed");
+    assert_eq!(&buf, b"+PONG\r\n");
+}
+
+#[test]
+fn close_after_drops_connection_mid_frame() {
+    let server = RedisServer::new()
+        .port(17851)
+        .start()
+        .expect("failed to start server");
+
+    let proxy = FaultProxy::spawn(server.addr()).expect("failed to spawn proxy");
+    proxy.close_after(Direction::UpstreamToClient, 3);
+
+    let mut client = TcpStream::connect(proxy.addr()).expect("failed to connect to proxy");
+    client.write_all(b"PING\r\n").expect("write failed");
+
+    let mut received = Vec::new();
+    client
+        .read_to_end(&mut received)
+        .expect("read_to_end failed");
+
+    assert_eq!(received, b"+PO");
+}


### PR DESCRIPTION
Closes #112.

## Problem

Every `chaos::` function takes the async handle types, and `FaultProxy::spawn` is async. The blocking handles wrap their async counterparts privately with no accessor, so `blocking`-only users cannot reach any fault-injection functionality.

## Plan

Option (b) from the issue: blocking wrappers, mirroring the crate's method-for-method parity pattern.

- Add a nested `pub mod chaos` inside `src/blocking.rs` with free functions taking blocking handles, mirroring the async `chaos::` surface: `kill_node`, `freeze_node`, `resume_node`, `pause_node`, `slow_down`, `trigger_save`, `flushall`, `fill_memory`, `kill_master_by_slot`, `kill_master_by_key`, `freeze_master_by_slot`, `trigger_failover`, `partition`, `recover`, `migrate_slot`, `migrate_slots`. Sync signal functions delegate directly; async functions run on the handle's owned runtime via `block_on`; `pause_node` enters the runtime context before delegating so its internal `tokio::spawn` lands on the handle's runtime.
- Add `blocking::FaultProxy` owning its own `Runtime` (same shape as `blocking::RedisServerHandle`): `spawn` via `block_on`, sync control methods delegate directly. Re-export `Direction` and `Delay` for blocking users.
- `ReshardGuard` is out of scope: its hold-the-window use case is inherently async-driven; `migrate_slot`/`migrate_slots` cover the blocking reshard need.
- Integration tests in the blocking test suite: freeze/resume, pause auto-resume, fill_memory, partition/recover, and a FaultProxy datapath roundtrip.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] `cargo doc --no-deps --all-features`