### PR TITLE
feat: add loadmodule and enable_module_command to the cluster builder

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1755,6 +1755,30 @@ impl RedisClusterBuilder {
         self
     }
 
+    // -- modules --
+
+    /// Load a Redis module at startup on every cluster node.
+    pub fn loadmodule(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.loadmodule(path);
+        self
+    }
+
+    /// Load a Redis module at startup on every cluster node, with load-time arguments.
+    pub fn loadmodule_with_args(
+        mut self,
+        path: impl Into<PathBuf>,
+        args: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.inner = self.inner.loadmodule_with_args(path, args);
+        self
+    }
+
+    /// Enable the MODULE command on every cluster node.
+    pub fn enable_module_command(mut self, mode: impl Into<String>) -> Self {
+        self.inner = self.inner.enable_module_command(mode);
+        self
+    }
+
     /// Set an arbitrary config directive for all cluster nodes.
     pub fn extra(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.inner = self.inner.extra(key, value);

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -111,6 +111,8 @@ pub struct RedisClusterBuilder {
     tls_auth_clients: Option<bool>,
     tls_replication: Option<bool>,
     tls_cluster: Option<bool>,
+    loadmodule: Vec<(PathBuf, Vec<String>)>,
+    enable_module_command: Option<String>,
     extra: HashMap<String, String>,
     redis_server_bin: String,
     redis_cli_bin: String,
@@ -417,6 +419,31 @@ impl RedisClusterBuilder {
         self
     }
 
+    // -- modules --
+
+    /// Load a Redis module at startup on every cluster node.
+    pub fn loadmodule(mut self, path: impl Into<PathBuf>) -> Self {
+        self.loadmodule.push((path.into(), Vec::new()));
+        self
+    }
+
+    /// Load a Redis module at startup on every cluster node, with load-time arguments.
+    pub fn loadmodule_with_args(
+        mut self,
+        path: impl Into<PathBuf>,
+        args: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.loadmodule
+            .push((path.into(), args.into_iter().map(Into::into).collect()));
+        self
+    }
+
+    /// Enable the MODULE command (`"yes"`, `"local"`, or `"no"`) on every cluster node.
+    pub fn enable_module_command(mut self, mode: impl Into<String>) -> Self {
+        self.enable_module_command = Some(mode.into());
+        self
+    }
+
     /// Set a per-node configuration callback.
     ///
     /// The callback receives a [`NodeContext`] containing the pre-configured
@@ -671,6 +698,12 @@ impl RedisClusterBuilder {
             if let Some(v) = self.tls_cluster {
                 server = server.tls_cluster(v);
             }
+            for (path, args) in &self.loadmodule {
+                server = server.loadmodule_with_args(path.clone(), args.iter().cloned());
+            }
+            if let Some(ref mode) = self.enable_module_command {
+                server = server.enable_module_command(mode.clone());
+            }
             for (key, value) in &self.extra {
                 server = server.extra(key.clone(), value.clone());
             }
@@ -820,6 +853,8 @@ impl RedisCluster {
             tls_auth_clients: None,
             tls_replication: None,
             tls_cluster: None,
+            loadmodule: Vec::new(),
+            enable_module_command: None,
             extra: HashMap::new(),
             redis_server_bin: "redis-server".into(),
             redis_cli_bin: "redis-cli".into(),
@@ -1096,5 +1131,24 @@ mod tests {
             .extra("maxmemory", "10mb");
         assert_eq!(b.logfile.as_deref(), Some("/tmp/cluster.log"));
         assert_eq!(b.extra.get("maxmemory").map(String::as_str), Some("10mb"));
+    }
+
+    #[test]
+    fn builder_modules() {
+        let b = RedisCluster::builder()
+            .loadmodule("/x/mod.so")
+            .loadmodule_with_args("/y/mod.so", ["a", "b"])
+            .enable_module_command("yes");
+        assert_eq!(
+            b.loadmodule,
+            vec![
+                (PathBuf::from("/x/mod.so"), Vec::<String>::new()),
+                (
+                    PathBuf::from("/y/mod.so"),
+                    vec!["a".to_string(), "b".to_string()]
+                ),
+            ]
+        );
+        assert_eq!(b.enable_module_command.as_deref(), Some("yes"));
     }
 }

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -153,6 +153,27 @@ fn blocking_cluster_start_and_health() {
 }
 
 #[test]
+fn blocking_cluster_enable_module_command() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(0)
+        .base_port(17110)
+        .enable_module_command("yes")
+        .start()
+        .expect("failed to start redis cluster");
+
+    cluster
+        .wait_for_healthy(std::time::Duration::from_secs(30))
+        .expect("cluster did not become healthy");
+
+    for index in 0..cluster.node_addrs().len() {
+        cluster
+            .node_run(index, &["MODULE", "LIST"])
+            .expect("MODULE LIST should succeed on every node");
+    }
+}
+
+#[test]
 fn blocking_sentinel_start_and_health() {
     let sentinel = RedisSentinel::builder()
         .master_port(16590)

--- a/tests/cluster.rs
+++ b/tests/cluster.rs
@@ -184,3 +184,26 @@ async fn cluster_with_node_config() {
         "node 0 should have slowlog-max-len 512, got: {val}"
     );
 }
+
+#[tokio::test]
+async fn cluster_enable_module_command() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(0)
+        .base_port(17050)
+        .enable_module_command("yes")
+        .start()
+        .await
+        .expect("failed to start cluster");
+
+    cluster
+        .wait_for_healthy(std::time::Duration::from_secs(30))
+        .await
+        .expect("cluster did not become healthy");
+
+    for node in cluster.nodes() {
+        node.run(&["MODULE", "LIST"])
+            .await
+            .expect("MODULE LIST should succeed on every node");
+    }
+}


### PR DESCRIPTION
Closes #123.

## Problem

The single-server builder has `.loadmodule()`, `.loadmodule_with_args()`, and `.enable_module_command()`, but the cluster builder has none. Loading a module on every cluster node requires either the stringly `.extra("loadmodule", ...)` workaround (single directive only, caller-side concatenation) or a `node_config` callback. There is no cluster path to `enable-module-command`, so MODULE UNLOAD tests are not expressible in cluster mode.

## Plan

- Add `loadmodule: Vec<(PathBuf, Vec<String>)>` and `enable_module_command: Option<String>` fields to `RedisClusterBuilder`, following the existing option-field pattern.
- Add `.loadmodule(path)`, `.loadmodule_with_args(path, args)`, and `.enable_module_command(mode)` builder methods with signatures identical to the single-server builder.
- Apply them to every node in the build loop, next to the existing `extra` application.
- Mirror all three methods on the blocking cluster builder, delegating to the async builder.
- Tests: builder-state unit tests for the new fields, plus an integration test starting a small cluster with `.enable_module_command("yes")` and verifying `MODULE LIST` succeeds on every node (exercises the directive cluster-wide without needing a module binary).

Context: needed by redis-event-stream-module's cluster-mode test harness (joshrotenberg/redis-event-stream-module#19).

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] `cargo test --no-default-features --features blocking`
- [ ] `cargo doc --no-deps --all-features`