### PR TITLE
fix: chaos and cli consistency pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ async fn test_chaos_pause() {
     let server = RedisServer::new().port(6400).start().await.unwrap();
 
     // Freeze the node for 2 seconds, then resume it automatically.
-    chaos::pause_node(&server, Duration::from_secs(2));
+    chaos::pause_node(&server, Duration::from_secs(2)).unwrap();
 
     // ... test client behavior while the node is frozen ...
 }
@@ -217,7 +217,12 @@ async fn test_chaos_pause() {
 
 `chaos::partition` and `chaos::recover` simulate a network partition across a cluster by
 freezing every node outside a reachable set, and `chaos::fill_memory` writes a bounded number
-of fixed-size keys for exercising `maxmemory` and eviction behavior.
+of fixed-size keys for exercising `maxmemory` and eviction behavior. `chaos::slow_down` and
+`chaos::slow_down_writes` use `CLIENT PAUSE` to delay all commands or writes only.
+
+Signal-sending functions (`kill_node`, `freeze_node`, `resume_node`, `pause_node`, `partition`,
+`recover`, and the cluster `*_by_slot`/`*_by_key` variants) return `Result` -- a failed `kill`
+invocation or a non-zero exit status is surfaced as an error instead of being silently ignored.
 
 `FaultProxy` operates at the byte level instead of the process level, injecting faults into
 the TCP connection itself -- delay, mid-frame drops, chunked writes -- without touching the

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -2142,39 +2142,48 @@ pub mod chaos {
     use std::time::Duration;
 
     /// Kill a node immediately with SIGKILL. See [`crate::chaos::kill_node`].
-    pub fn kill_node(handle: &RedisServerHandle) {
-        crate::chaos::kill_node(&handle.inner);
+    pub fn kill_node(handle: &RedisServerHandle) -> Result<()> {
+        crate::chaos::kill_node(&handle.inner)
     }
 
     /// Freeze a node by sending SIGSTOP. See [`crate::chaos::freeze_node`].
-    pub fn freeze_node(handle: &RedisServerHandle) {
-        crate::chaos::freeze_node(&handle.inner);
+    pub fn freeze_node(handle: &RedisServerHandle) -> Result<()> {
+        crate::chaos::freeze_node(&handle.inner)
     }
 
     /// Resume a frozen node by sending SIGCONT. See [`crate::chaos::resume_node`].
-    pub fn resume_node(handle: &RedisServerHandle) {
-        crate::chaos::resume_node(&handle.inner);
+    pub fn resume_node(handle: &RedisServerHandle) -> Result<()> {
+        crate::chaos::resume_node(&handle.inner)
     }
 
     /// Freeze a node for a fixed duration, then resume it automatically.
     ///
-    /// Sends SIGSTOP immediately and returns without blocking. Unlike the
-    /// other functions here, this one enters `handle`'s runtime (via
-    /// [`Runtime::enter`](tokio::runtime::Runtime::enter)) before delegating,
-    /// so the background resume task that
+    /// Sends SIGSTOP immediately and returns once that signal is confirmed
+    /// delivered. Unlike the other functions here, this one enters `handle`'s
+    /// runtime (via [`Runtime::enter`](tokio::runtime::Runtime::enter))
+    /// before delegating, so the background resume task that
     /// [`crate::chaos::pause_node`] spawns internally lands on that runtime
     /// instead of panicking for lack of a runtime context.
-    pub fn pause_node(handle: &RedisServerHandle, duration: Duration) {
+    pub fn pause_node(handle: &RedisServerHandle, duration: Duration) -> Result<()> {
         let _guard = handle.rt.enter();
-        crate::chaos::pause_node(&handle.inner, duration);
+        crate::chaos::pause_node(&handle.inner, duration)
     }
 
-    /// Pause client connections for a duration using `CLIENT PAUSE`. Blocks
-    /// on the handle's runtime. See [`crate::chaos::slow_down`].
+    /// Pause client connections for a duration using `CLIENT PAUSE ... ALL`.
+    /// Blocks on the handle's runtime. See [`crate::chaos::slow_down`].
     pub fn slow_down(handle: &RedisServerHandle, millis: u64) -> Result<String> {
         handle
             .rt
             .block_on(crate::chaos::slow_down(&handle.inner, millis))
+    }
+
+    /// Pause only write commands for a duration using `CLIENT PAUSE ...
+    /// WRITE`. Blocks on the handle's runtime. See
+    /// [`crate::chaos::slow_down_writes`].
+    pub fn slow_down_writes(handle: &RedisServerHandle, millis: u64) -> Result<String> {
+        handle
+            .rt
+            .block_on(crate::chaos::slow_down_writes(&handle.inner, millis))
     }
 
     /// Trigger a background RDB save. Blocks on the handle's runtime. See
@@ -2233,14 +2242,14 @@ pub mod chaos {
 
     /// Simulate a network partition by freezing every node not in
     /// `reachable`. See [`crate::chaos::partition`].
-    pub fn partition(cluster: &RedisClusterHandle, reachable: &[usize]) -> Vec<u16> {
+    pub fn partition(cluster: &RedisClusterHandle, reachable: &[usize]) -> Result<Vec<u16>> {
         crate::chaos::partition(&cluster.inner, reachable)
     }
 
     /// Resume all nodes in a cluster by sending SIGCONT. See
     /// [`crate::chaos::recover`].
-    pub fn recover(cluster: &RedisClusterHandle) {
-        crate::chaos::recover(&cluster.inner);
+    pub fn recover(cluster: &RedisClusterHandle) -> Result<()> {
+        crate::chaos::recover(&cluster.inner)
     }
 
     /// Migrate a single hash slot from one master to another. Blocks on the

--- a/src/chaos.rs
+++ b/src/chaos.rs
@@ -272,12 +272,24 @@ pub fn partition(cluster: &RedisClusterHandle, reachable: &[usize]) -> Result<Ve
 /// Useful after freezing nodes for partition simulation. Sends SIGCONT to
 /// every node regardless of whether it was frozen -- signaling an
 /// already-running node with SIGCONT is a no-op, not an error.
+///
+/// Every node is attempted before any failure is reported, so a dead node
+/// (e.g. one removed with [`kill_node`]) does not prevent later frozen nodes
+/// from resuming. Returns the first failure, if any, after the full pass.
 #[cfg(feature = "tokio")]
 pub fn recover(cluster: &RedisClusterHandle) -> Result<()> {
+    let mut first_err = None;
     for node in cluster.nodes() {
-        send_signal(node.pid(), "-CONT")?;
+        if let Err(e) = send_signal(node.pid(), "-CONT")
+            && first_err.is_none()
+        {
+            first_err = Some(e);
+        }
     }
-    Ok(())
+    match first_err {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/chaos.rs
+++ b/src/chaos.rs
@@ -24,25 +24,47 @@
 //!     .unwrap();
 //!
 //! // Freeze a node (SIGSTOP) -- it stops processing but stays in memory.
-//! chaos::freeze_node(cluster.node(0));
+//! chaos::freeze_node(cluster.node(0)).unwrap();
 //!
 //! // ... test client behavior with a frozen node ...
 //!
 //! // Resume the node (SIGCONT).
-//! chaos::resume_node(cluster.node(0));
+//! chaos::resume_node(cluster.node(0)).unwrap();
 //! # }
 //! ```
 
 #[cfg(feature = "tokio")]
 use crate::cluster::RedisClusterHandle;
 #[cfg(feature = "tokio")]
-use crate::error::Result;
+use crate::error::{Error, Result};
 #[cfg(feature = "tokio")]
 use crate::server::RedisServerHandle;
 
 use std::process::Command;
 #[cfg(feature = "tokio")]
 use std::time::Duration;
+
+/// Send a POSIX signal to `pid` via `kill <signal_flag> <pid>`.
+///
+/// Propagates both failure to spawn `kill` at all and a non-zero exit status
+/// (e.g. the target PID no longer exists) as [`Error::Signal`]. Shared by
+/// every signal-sending function in this module so none of them silently
+/// swallows a failed kill.
+#[cfg(feature = "tokio")]
+fn send_signal(pid: u32, signal_flag: &str) -> Result<()> {
+    let output = Command::new("kill")
+        .args([signal_flag, &pid.to_string()])
+        .output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(Error::Signal {
+            signal: signal_flag.to_string(),
+            pid,
+            detail: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        })
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Node-level operations
@@ -53,9 +75,8 @@ use std::time::Duration;
 /// The process is terminated without any chance to clean up. This simulates
 /// a hard crash (e.g., OOM kill, hardware failure).
 #[cfg(feature = "tokio")]
-pub fn kill_node(handle: &RedisServerHandle) {
-    let pid = handle.pid().to_string();
-    let _ = Command::new("kill").args(["-9", &pid]).output();
+pub fn kill_node(handle: &RedisServerHandle) -> Result<()> {
+    send_signal(handle.pid(), "-9")
 }
 
 /// Freeze a node by sending SIGSTOP.
@@ -67,9 +88,8 @@ pub fn kill_node(handle: &RedisServerHandle) {
 /// This is more useful than [`kill_node`] for testing timeout handling and
 /// partition scenarios because the node can be resumed without losing state.
 #[cfg(feature = "tokio")]
-pub fn freeze_node(handle: &RedisServerHandle) {
-    let pid = handle.pid().to_string();
-    let _ = Command::new("kill").args(["-STOP", &pid]).output();
+pub fn freeze_node(handle: &RedisServerHandle) -> Result<()> {
+    send_signal(handle.pid(), "-STOP")
 }
 
 /// Resume a frozen node by sending SIGCONT.
@@ -77,36 +97,57 @@ pub fn freeze_node(handle: &RedisServerHandle) {
 /// The process resumes from where it was suspended. Buffered writes and
 /// replication will catch up automatically.
 #[cfg(feature = "tokio")]
-pub fn resume_node(handle: &RedisServerHandle) {
-    let pid = handle.pid().to_string();
-    let _ = Command::new("kill").args(["-CONT", &pid]).output();
+pub fn resume_node(handle: &RedisServerHandle) -> Result<()> {
+    send_signal(handle.pid(), "-CONT")
 }
 
 /// Freeze a node for a fixed duration, then resume it automatically.
 ///
-/// Sends SIGSTOP immediately and returns without blocking. A background
-/// tokio task sleeps for `duration` and then sends SIGCONT, so the node
-/// comes back on its own -- there's no need to call [`resume_node`] or
-/// [`recover`] afterward. Useful for testing timeout handling where the
-/// outage has a bounded, known length.
+/// Sends SIGSTOP immediately and returns once that signal is confirmed
+/// delivered. A background tokio task then sleeps for `duration` and sends
+/// SIGCONT, so the node comes back on its own -- there's no need to call
+/// [`resume_node`] or [`recover`] afterward. Useful for testing timeout
+/// handling where the outage has a bounded, known length.
+///
+/// The initial SIGSTOP's success is surfaced via the returned `Result`. The
+/// deferred SIGCONT sent by the background task is best-effort -- by the
+/// time it runs there's no caller left to hand an error back to, so a failed
+/// resume is silently ignored the way it always was.
 #[cfg(feature = "tokio")]
-pub fn pause_node(handle: &RedisServerHandle, duration: Duration) {
-    let pid = handle.pid().to_string();
-    let _ = Command::new("kill").args(["-STOP", &pid]).output();
+pub fn pause_node(handle: &RedisServerHandle, duration: Duration) -> Result<()> {
+    let pid = handle.pid();
+    send_signal(pid, "-STOP")?;
     tokio::spawn(async move {
         tokio::time::sleep(duration).await;
-        let _ = Command::new("kill").args(["-CONT", &pid]).output();
+        let _ = send_signal(pid, "-CONT");
     });
+    Ok(())
 }
 
-/// Pause client connections for a duration using `CLIENT PAUSE`.
+/// Pause client connections for a duration using `CLIENT PAUSE ... ALL`
+/// (the default mode since Redis 6.2).
 ///
 /// Unlike [`freeze_node`], the server process stays responsive for
 /// replication and cluster protocol. Only client commands are delayed.
 /// After the duration expires, clients resume automatically.
+///
+/// See [`slow_down_writes`] to pause only write commands instead.
 #[cfg(feature = "tokio")]
 pub async fn slow_down(handle: &RedisServerHandle, millis: u64) -> Result<String> {
     handle.run(&["CLIENT", "PAUSE", &millis.to_string()]).await
+}
+
+/// Pause only write commands for a duration using `CLIENT PAUSE ... WRITE`
+/// (available since Redis 6.2).
+///
+/// Unlike [`slow_down`], reads keep flowing while the pause is in effect --
+/// useful for testing client behavior around write-availability windows
+/// (e.g. during a failover) without blocking reads too.
+#[cfg(feature = "tokio")]
+pub async fn slow_down_writes(handle: &RedisServerHandle, millis: u64) -> Result<String> {
+    handle
+        .run(&["CLIENT", "PAUSE", &millis.to_string(), "WRITE"])
+        .await
 }
 
 /// Trigger a background RDB save.
@@ -126,14 +167,31 @@ pub async fn flushall(handle: &RedisServerHandle) -> Result<String> {
 /// Writes keys named `<prefix>0` through `<prefix>{count-1}`, each holding a
 /// 1 KiB value. Useful for exercising `maxmemory` and eviction-policy
 /// behavior with a deterministic, bounded key count.
+///
+/// All `count` writes are issued through a single `EVAL` call (one
+/// `redis-cli` invocation total) instead of spawning a `redis-cli` process
+/// per key, which is the difference between one process and `count`
+/// processes for a large fill.
+///
+/// Passing a cluster node directly (rather than going through
+/// `redis-cli -c`) restricts the script to keys that hash to slots owned by
+/// that node -- non-owned keys would fail the same way a plain per-key `SET`
+/// against a single node already does in cluster mode (a `-MOVED` error), so
+/// this isn't a behavior change for cluster use, just a faster single-node
+/// one.
 #[cfg(feature = "tokio")]
 pub async fn fill_memory(handle: &RedisServerHandle, prefix: &str, count: usize) -> Result<()> {
     let value = "x".repeat(1024);
-    for i in 0..count {
-        handle
-            .run(&["SET", &format!("{prefix}{i}"), &value])
-            .await?;
-    }
+    handle
+        .run(&[
+            "EVAL",
+            "for i=0,tonumber(ARGV[1])-1 do redis.call('SET', ARGV[2]..i, ARGV[3]) end",
+            "0",
+            &count.to_string(),
+            prefix,
+            &value,
+        ])
+        .await?;
     Ok(())
 }
 
@@ -147,12 +205,11 @@ pub async fn fill_memory(handle: &RedisServerHandle, prefix: &str, count: usize)
 /// slot, then sends SIGKILL to that process.
 ///
 /// Returns `Ok(port)` of the killed node, or an error if the slot owner
-/// could not be determined.
+/// could not be determined or the signal could not be delivered.
 #[cfg(feature = "tokio")]
 pub async fn kill_master_by_slot(cluster: &RedisClusterHandle, slot: u16) -> Result<u16> {
     let owner = find_slot_owner(cluster, slot).await?;
-    let pid = owner.pid().to_string();
-    let _ = Command::new("kill").args(["-9", &pid]).output();
+    send_signal(owner.pid(), "-9")?;
     Ok(owner.port())
 }
 
@@ -173,53 +230,54 @@ pub async fn kill_master_by_key(cluster: &RedisClusterHandle, key: &str) -> Resu
 #[cfg(feature = "tokio")]
 pub async fn freeze_master_by_slot(cluster: &RedisClusterHandle, slot: u16) -> Result<u16> {
     let owner = find_slot_owner(cluster, slot).await?;
-    let pid = owner.pid().to_string();
-    let _ = Command::new("kill").args(["-STOP", &pid]).output();
+    send_signal(owner.pid(), "-STOP")?;
     Ok(owner.port())
 }
 
 /// Trigger a `CLUSTER FAILOVER` on a replica node.
 ///
-/// If the initial failover fails because the master is down, retries with
+/// If the initial failover fails because the master is down -- either the
+/// command returns an error result containing `"ERR"`, or the `redis-cli`
+/// invocation itself fails (e.g. the master is unreachable) -- retries with
 /// `CLUSTER FAILOVER FORCE`.
 #[cfg(feature = "tokio")]
 pub async fn trigger_failover(replica: &RedisServerHandle) -> Result<String> {
-    let result = replica.run(&["CLUSTER", "FAILOVER"]).await?;
-    if result.contains("ERR") {
-        return replica.run(&["CLUSTER", "FAILOVER", "FORCE"]).await;
+    match replica.run(&["CLUSTER", "FAILOVER"]).await {
+        Ok(result) if !result.contains("ERR") => Ok(result),
+        _ => replica.run(&["CLUSTER", "FAILOVER", "FORCE"]).await,
     }
-    Ok(result)
 }
 
 /// Simulate a network partition by freezing every node not in `reachable`.
 ///
 /// `reachable` holds the indices, matching the order of
 /// [`RedisClusterHandle::nodes`], of the nodes that stay up; every other
-/// node is sent SIGSTOP. Returns the ports of the frozen nodes. Call
-/// [`recover`] to heal the partition.
+/// node is sent SIGSTOP. Returns the ports of the frozen nodes, or an error
+/// if any signal failed to deliver -- nodes frozen before the failing one
+/// stay frozen; call [`recover`] to heal the partition either way.
 #[cfg(feature = "tokio")]
-pub fn partition(cluster: &RedisClusterHandle, reachable: &[usize]) -> Vec<u16> {
+pub fn partition(cluster: &RedisClusterHandle, reachable: &[usize]) -> Result<Vec<u16>> {
     let mut frozen = Vec::new();
     for (i, node) in cluster.nodes().iter().enumerate() {
         if !reachable.contains(&i) {
-            let pid = node.pid().to_string();
-            let _ = Command::new("kill").args(["-STOP", &pid]).output();
+            send_signal(node.pid(), "-STOP")?;
             frozen.push(node.port());
         }
     }
-    frozen
+    Ok(frozen)
 }
 
 /// Resume all nodes in a cluster by sending SIGCONT.
 ///
 /// Useful after freezing nodes for partition simulation. Sends SIGCONT to
-/// every node regardless of whether it was frozen.
+/// every node regardless of whether it was frozen -- signaling an
+/// already-running node with SIGCONT is a no-op, not an error.
 #[cfg(feature = "tokio")]
-pub fn recover(cluster: &RedisClusterHandle) {
+pub fn recover(cluster: &RedisClusterHandle) -> Result<()> {
     for node in cluster.nodes() {
-        let pid = node.pid().to_string();
-        let _ = Command::new("kill").args(["-CONT", &pid]).output();
+        send_signal(node.pid(), "-CONT")?;
     }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,10 +2,25 @@
 
 use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
+use std::time::Duration;
 
 use tokio::process::Command as TokioCommand;
 
 use crate::error::{Error, Result};
+
+/// Default bound applied to the internal health-check probes (`ping`, and by
+/// extension `wait_for_ready` / `wait_for_healthy`) so that observing a
+/// frozen node cannot hang forever.
+///
+/// `redis-cli -t` only bounds the initial TCP connect: a node suspended with
+/// `SIGSTOP` still completes the handshake from the kernel's accept queue and
+/// then never replies, so `-t` alone does not help here. The child process
+/// itself has to be wrapped in a [`tokio::time::timeout`] and killed on
+/// expiry instead.
+///
+/// This bound is **not** applied to [`RedisCli::run`] -- tests legitimately
+/// issue long-running commands (e.g. `DEBUG SLEEP`) through it.
+pub(crate) const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// RESP protocol version for client connections.
 #[derive(Debug, Clone, Copy)]
@@ -637,8 +652,12 @@ impl RedisCli {
     }
 
     /// Send PING and return true if PONG is received.
+    ///
+    /// Bounded by a modest internal timeout so a frozen (`SIGSTOP`ped) node
+    /// cannot hang this check forever -- `redis-cli -t` cannot be used for
+    /// this instead, since it only bounds the initial TCP connect.
     pub async fn ping(&self) -> bool {
-        self.run(&["PING"])
+        self.run_bounded(&["PING"], HEALTH_CHECK_TIMEOUT)
             .await
             .map(|r| r.trim() == "PONG")
             .unwrap_or(false)
@@ -965,6 +984,49 @@ impl RedisCli {
             .args(args)
             .output()
             .await
+    }
+
+    /// Like [`Self::run`], but bounds the child process with `timeout` and
+    /// kills it if it hasn't produced output by the deadline.
+    ///
+    /// Used internally by the health-check paths ([`Self::ping`], and by
+    /// extension `wait_for_ready` / `wait_for_healthy`); not exposed on the
+    /// general command path since tests legitimately run long commands (e.g.
+    /// `DEBUG SLEEP`) through [`Self::run`].
+    pub(crate) async fn run_bounded(&self, args: &[&str], timeout: Duration) -> Result<String> {
+        let output = self.raw_output_bounded(args, timeout).await?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            Err(Error::Cli {
+                host: self.host.clone(),
+                port: self.port,
+                detail: stderr.into_owned(),
+            })
+        }
+    }
+
+    async fn raw_output_bounded(
+        &self,
+        args: &[&str],
+        timeout: Duration,
+    ) -> std::io::Result<Output> {
+        let fut = TokioCommand::new(&self.bin)
+            .args(self.base_args())
+            .args(args)
+            .kill_on_drop(true)
+            .output();
+        match tokio::time::timeout(timeout, fut).await {
+            Ok(result) => result,
+            Err(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!(
+                    "redis-cli {}:{} did not respond within {timeout:?}",
+                    self.host, self.port
+                ),
+            )),
+        }
     }
 }
 

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -855,9 +855,16 @@ impl RedisClusterHandle {
     }
 
     /// Check CLUSTER INFO for state=ok and all slots assigned.
+    ///
+    /// Bounded by a modest internal timeout (not the general
+    /// [`RedisServerHandle::run`] path) so a frozen node can't hang
+    /// [`Self::wait_for_healthy`] forever.
     pub async fn is_healthy(&self) -> bool {
         for node in &self.nodes {
-            if let Ok(info) = node.run(&["CLUSTER", "INFO"]).await
+            if let Ok(info) = node
+                .cli()
+                .run_bounded(&["CLUSTER", "INFO"], crate::cli::HEALTH_CHECK_TIMEOUT)
+                .await
                 && info.contains("cluster_state:ok")
                 && info.contains("cluster_slots_ok:16384")
             {

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,19 @@ pub enum Error {
         message: String,
     },
 
+    /// Sending a POSIX signal to a node process failed, either because the
+    /// `kill` invocation itself could not be spawned or because it exited
+    /// with a non-zero status (e.g. the target PID no longer exists).
+    #[error("failed to send signal {signal} to pid {pid}: {detail}")]
+    Signal {
+        /// The `kill` signal flag that was sent (e.g. `-9`, `-STOP`, `-CONT`).
+        signal: String,
+        /// The target process ID.
+        pid: u32,
+        /// Stderr output or other detail from the failed invocation.
+        detail: String,
+    },
+
     /// No sentinel was reachable.
     #[error("no reachable sentinel")]
     NoReachableSentinel,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@
 //! let server = RedisServer::new().port(6400).start().await.unwrap();
 //!
 //! // Freeze the node for 2 seconds, then resume it automatically.
-//! chaos::pause_node(&server, Duration::from_secs(2));
+//! chaos::pause_node(&server, Duration::from_secs(2)).unwrap();
 //! # }
 //! ```
 //!

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -721,6 +721,19 @@ impl RedisSentinelHandle {
     /// Like [`poke`](Self::poke) but targets `master_name` instead of the
     /// primary master configured for this topology.
     pub async fn poke_master(&self, master_name: &str) -> Result<HashMap<String, String>> {
+        self.poke_master_bounded(master_name, None).await
+    }
+
+    /// Shared implementation for [`Self::poke_master`] and [`Self::is_healthy`].
+    ///
+    /// `bound`, when set, caps each `SENTINEL MASTER` invocation so a
+    /// health-check loop can't hang on an unreachable sentinel; `poke_master`
+    /// itself passes `None` to keep its existing unbounded behavior.
+    async fn poke_master_bounded(
+        &self,
+        master_name: &str,
+        bound: Option<Duration>,
+    ) -> Result<HashMap<String, String>> {
         for port in &self.sentinel_ports {
             let cli = self.tls.apply(
                 RedisCli::new()
@@ -728,7 +741,14 @@ impl RedisSentinelHandle {
                     .host(&self.bind)
                     .port(*port),
             );
-            if let Ok(raw) = cli.run(&["SENTINEL", "MASTER", master_name]).await {
+            let result = match bound {
+                Some(timeout) => {
+                    cli.run_bounded(&["SENTINEL", "MASTER", master_name], timeout)
+                        .await
+                }
+                None => cli.run(&["SENTINEL", "MASTER", master_name]).await,
+            };
+            if let Ok(raw) = result {
                 return Ok(parse_flat_kv(&raw));
             }
         }
@@ -736,9 +756,16 @@ impl RedisSentinelHandle {
     }
 
     /// Check if the topology is healthy.
+    ///
+    /// Bounded by a modest internal timeout (not the general
+    /// [`RedisCli::run`] path) so an unreachable sentinel can't hang
+    /// [`Self::wait_for_healthy`] forever.
     pub async fn is_healthy(&self) -> bool {
         for master in &self.monitored_masters {
-            let Ok(info) = self.poke_master(&master.name).await else {
+            let Ok(info) = self
+                .poke_master_bounded(&master.name, Some(crate::cli::HEALTH_CHECK_TIMEOUT))
+                .await
+            else {
                 return false;
             };
             let flags = info.get("flags").map(|s| s.as_str()).unwrap_or("");

--- a/tests/blocking_chaos.rs
+++ b/tests/blocking_chaos.rs
@@ -13,10 +13,10 @@ fn freeze_and_resume_node() {
 
     assert!(server.is_alive());
 
-    chaos::freeze_node(&server);
+    chaos::freeze_node(&server).expect("freeze_node failed");
     std::thread::sleep(Duration::from_millis(200));
 
-    chaos::resume_node(&server);
+    chaos::resume_node(&server).expect("resume_node failed");
     std::thread::sleep(Duration::from_millis(200));
 
     let pong = server.run(&["PING"]).expect("PING failed after resume");
@@ -33,7 +33,7 @@ fn pause_node_resumes_automatically() {
 
     assert!(server.is_alive());
 
-    chaos::pause_node(&server, Duration::from_millis(300));
+    chaos::pause_node(&server, Duration::from_millis(300)).expect("pause_node failed");
 
     std::thread::sleep(Duration::from_millis(600));
 
@@ -50,7 +50,11 @@ fn fill_memory_writes_keys() {
     chaos::fill_memory(&server, "k:", 50).expect("fill_memory failed");
 
     let dbsize = server.run(&["DBSIZE"]).expect("DBSIZE failed");
-    assert!(dbsize.contains("50"));
+    let dbsize: u64 = dbsize
+        .trim()
+        .parse()
+        .expect("DBSIZE did not return an integer");
+    assert_eq!(dbsize, 50);
 }
 
 #[cfg_attr(not(unix), ignore)]
@@ -67,11 +71,11 @@ fn partition_and_recover_cluster() {
         .wait_for_healthy(Duration::from_secs(30))
         .expect("cluster did not become healthy");
 
-    let frozen = chaos::partition(&cluster, &[0]);
+    let frozen = chaos::partition(&cluster, &[0]).expect("partition failed");
     assert!(!frozen.is_empty());
     assert_eq!(frozen.len(), cluster.node_addrs().len() - 1);
 
-    chaos::recover(&cluster);
+    chaos::recover(&cluster).expect("recover failed");
 
     let pong = cluster
         .node_run(0, &["PING"])

--- a/tests/chaos.rs
+++ b/tests/chaos.rs
@@ -12,7 +12,7 @@ async fn freeze_and_resume_node() {
 
     assert!(server.is_alive().await);
 
-    chaos::freeze_node(&server);
+    chaos::freeze_node(&server).expect("freeze_node failed");
 
     // SIGSTOP suspends the process but the kernel still completes the TCP
     // handshake, so a PING can hang forever waiting for a reply that will
@@ -20,7 +20,7 @@ async fn freeze_and_resume_node() {
     let frozen_ping = tokio::time::timeout(Duration::from_secs(2), server.is_alive()).await;
     assert!(frozen_ping.is_err() || frozen_ping == Ok(false));
 
-    chaos::resume_node(&server);
+    chaos::resume_node(&server).expect("resume_node failed");
     tokio::time::sleep(Duration::from_millis(200)).await;
     assert!(server.is_alive().await);
 }
@@ -35,7 +35,7 @@ async fn kill_node_terminates_process() {
 
     assert!(server.is_alive().await);
 
-    chaos::kill_node(&server);
+    chaos::kill_node(&server).expect("kill_node failed");
     tokio::time::sleep(Duration::from_millis(300)).await;
     assert!(!server.is_alive().await);
 }
@@ -94,7 +94,7 @@ async fn failover_and_recover_cluster() {
         .await
         .expect("cluster did not recover after failover");
 
-    chaos::recover(&cluster);
+    chaos::recover(&cluster).expect("recover failed");
     assert!(cluster.all_alive().await);
 }
 
@@ -109,7 +109,7 @@ async fn pause_node_resumes_automatically() {
 
     assert!(server.is_alive().await);
 
-    chaos::pause_node(&server, Duration::from_millis(300));
+    chaos::pause_node(&server, Duration::from_millis(300)).expect("pause_node failed");
 
     tokio::time::sleep(Duration::from_millis(600)).await;
 
@@ -130,7 +130,11 @@ async fn fill_memory_writes_keys() {
         .expect("fill_memory failed");
 
     let dbsize = server.run(&["DBSIZE"]).await.expect("DBSIZE failed");
-    assert!(dbsize.contains("50"));
+    let dbsize: u64 = dbsize
+        .trim()
+        .parse()
+        .expect("DBSIZE did not return an integer");
+    assert_eq!(dbsize, 50);
 }
 
 #[cfg_attr(not(unix), ignore)]
@@ -149,11 +153,11 @@ async fn partition_freezes_unreachable_nodes() {
         .await
         .expect("cluster did not become healthy");
 
-    let frozen = chaos::partition(&cluster, &[0]);
+    let frozen = chaos::partition(&cluster, &[0]).expect("partition failed");
     assert!(!frozen.is_empty());
     assert_eq!(frozen.len(), cluster.nodes().len() - 1);
 
-    chaos::recover(&cluster);
+    chaos::recover(&cluster).expect("recover failed");
 
     let node0 = &cluster.nodes()[0];
     assert!(node0.run(&["PING"]).await.is_ok());


### PR DESCRIPTION
Closes #122.

## Plan

Fix the defects found by the research audit in the existing chaos surface:

- Signal-sending functions (`kill_node`, `freeze_node`, `resume_node`, `pause_node`, `partition`, `recover`, and the slot-targeted kill/freeze) silently swallow `kill` command failures; convert to `Result` so failures surface. API-affecting for a test-harness crate on 0.x; called out for the release notes.
- `trigger_failover` retries with FORCE only when the first attempt returns `Ok` containing `ERR`; also retry on the `Err` path.
- `slow_down` cannot express `CLIENT PAUSE <ms> WRITE|ALL`; add mode support.
- `fill_memory` spawns one redis-cli process per key with a hardcoded 1 KiB value; reduce process count without changing observable behavior or adding a DEBUG-command requirement.
- Health-observation paths can hang forever against a frozen node because the CLI sets no timeout; add bounded-wait support without changing `run()`'s default behavior.
- Fix the `dbsize.contains("50")` brittleness in tests/chaos.rs.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] `cargo test --no-default-features --features blocking`
- [ ] `cargo doc --no-deps --all-features`