### PR TITLE
feat: FaultProxy parity upgrades for stats and connection-level faults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ test-tls = ["dep:rcgen"]
 [dependencies]
 glob = "0.3"
 thiserror = "2"
-tokio = { version = "1", features = ["process", "time", "rt", "macros", "rt-multi-thread", "net", "io-util"], optional = true }
+tokio = { version = "1", features = ["process", "time", "rt", "macros", "rt-multi-thread", "net", "io-util", "sync"], optional = true }
 which = "7"
 rcgen = { version = "0.13", optional = true }
 

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -2288,7 +2288,7 @@ pub mod chaos {
 
 // ── FaultProxy ────────────────────────────────────────────────────────────────
 
-pub use crate::fault_proxy::{Delay, Direction};
+pub use crate::fault_proxy::{CloseKind, Delay, Direction, ProxyStats};
 
 /// Synchronous wrapper for [`crate::fault_proxy::FaultProxy`].
 ///
@@ -2301,13 +2301,14 @@ pub use crate::fault_proxy::{Delay, Direction};
 ///
 /// Fault controls (`set_delay`, `close_after`, `set_chunk_size`,
 /// `set_drop_all`, `reset`, ...) are synchronous in the async API already, so
-/// they delegate directly here without touching the runtime.
+/// they delegate directly here without touching the runtime. `disable` and
+/// `enable` are async in the inner API, so they block on the runtime here.
 pub struct FaultProxy {
     inner: crate::fault_proxy::FaultProxy,
-    // Never read directly after construction; kept alive so its worker
-    // threads keep running the accept loop and per-connection forwarding
-    // tasks spawned during `spawn`, and so it shuts them down on drop.
-    #[allow(dead_code)]
+    // Kept alive so its worker threads keep running the accept loop and
+    // per-connection forwarding tasks spawned during `spawn`, and so it
+    // shuts them down on drop. Also used directly by `disable`/`enable` to
+    // drive the inner async calls.
     rt: Runtime,
 }
 
@@ -2322,9 +2323,15 @@ impl FaultProxy {
         Ok(Self { inner, rt })
     }
 
-    /// The local address clients should connect to.
+    /// The local address clients should connect to. Stable across
+    /// `disable`/`enable` cycles.
     pub fn addr(&self) -> SocketAddr {
         self.inner.addr()
+    }
+
+    /// Cumulative counters since `spawn`. Lock-free snapshot.
+    pub fn stats(&self) -> ProxyStats {
+        self.inner.stats()
     }
 
     /// Set (or replace) the delay applied before forwarding data in `direction`.
@@ -2339,9 +2346,16 @@ impl FaultProxy {
 
     /// Close the connection once `bytes` total have been forwarded in
     /// `direction`, cutting mid-buffer if the triggering read straddles the
-    /// threshold.
+    /// threshold. Closes with a clean FIN; use `close_after_with` for a TCP
+    /// reset instead.
     pub fn close_after(&self, direction: Direction, bytes: u64) {
         self.inner.close_after(direction, bytes);
+    }
+
+    /// Like `close_after`, but the connection is closed with `kind` once the
+    /// threshold trips.
+    pub fn close_after_with(&self, direction: Direction, bytes: u64, kind: CloseKind) {
+        self.inner.close_after_with(direction, bytes, kind);
     }
 
     /// Remove the close-after threshold configured for `direction`.
@@ -2360,9 +2374,72 @@ impl FaultProxy {
         self.inner.clear_chunk_size();
     }
 
+    /// Sleep `delay` between chunked write pieces so the client observes each
+    /// piece as a separate read. No effect unless `set_chunk_size` splits a
+    /// read into more than one piece.
+    pub fn set_chunk_delay(&self, delay: Duration) {
+        self.inner.set_chunk_delay(delay);
+    }
+
+    /// Remove the inter-chunk delay configured by `set_chunk_delay`.
+    pub fn clear_chunk_delay(&self) {
+        self.inner.clear_chunk_delay();
+    }
+
     /// Enable or disable black-hole mode.
     pub fn set_drop_all(&self, drop_all: bool) {
         self.inner.set_drop_all(drop_all);
+    }
+
+    /// Stop forwarding bytes in `direction` on every connection, existing and
+    /// new, until cleared or severed by a pending `stall_then_close` deadline.
+    pub fn set_stall(&self, direction: Direction) {
+        self.inner.set_stall(direction);
+    }
+
+    /// Resume forwarding in `direction`; bytes read while stalled are flushed.
+    pub fn clear_stall(&self, direction: Direction) {
+        self.inner.clear_stall(direction);
+    }
+
+    /// Stall both directions now, then sever every connection `after` later.
+    pub fn stall_then_close(&self, after: Duration) {
+        self.inner.stall_then_close(after);
+    }
+
+    /// Cancel any pending `stall_then_close` deadline and clear both stalls.
+    pub fn clear_stall_all(&self) {
+        self.inner.clear_stall_all();
+    }
+
+    /// Sever every live connection right now with a TCP RST, simulating a
+    /// crashed server.
+    pub fn reset_peer(&self) {
+        self.inner.reset_peer();
+    }
+
+    /// Fail the next `n` accepted connections by closing them immediately
+    /// (with `kind`) before any upstream connect; passthrough resumes after.
+    pub fn reject_next(&self, n: u32, kind: CloseKind) {
+        self.inner.reject_next(n, kind);
+    }
+
+    /// Cancel any pending `reject_next` countdown.
+    pub fn clear_reject(&self) {
+        self.inner.clear_reject();
+    }
+
+    /// Stop listening and sever all live connections; new connect attempts
+    /// fail with `ECONNREFUSED`. The port is released and re-claimed by
+    /// `enable`.
+    pub fn disable(&self) -> Result<()> {
+        self.rt.block_on(self.inner.disable())
+    }
+
+    /// Rebind the same local port and resume passthrough with the current
+    /// fault state.
+    pub fn enable(&self) -> Result<()> {
+        self.rt.block_on(self.inner.enable())
     }
 
     /// Clear every fault control, returning the proxy to clean passthrough

--- a/src/fault_proxy.rs
+++ b/src/fault_proxy.rs
@@ -2,10 +2,15 @@
 //!
 //! [`FaultProxy`] sits between a test client and an upstream Redis node,
 //! forwarding bytes over TCP while allowing tests to inject faults: per-
-//! direction delay, mid-frame connection drops, chunked writes, and a
-//! black-hole mode. Unlike [`crate::chaos`], which operates on the server
-//! process, this module operates purely on the wire and needs no Docker or
-//! root privileges.
+//! direction delay, mid-frame connection drops (clean or reset), live-
+//! connection stalls, chunked writes with inter-chunk delay, deterministic
+//! connection rejection, a proxy-down mode, and a black-hole mode. Unlike
+//! [`crate::chaos`], which operates on the server process, this module
+//! operates purely on the wire and needs no Docker or root privileges.
+//!
+//! Cumulative counters are available via [`FaultProxy::stats`] so a test can
+//! assert that a configured fault actually fired, rather than trusting that
+//! it did.
 //!
 //! # Example
 //!
@@ -31,12 +36,12 @@
 
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
+use tokio::sync::{Notify, watch};
 use tokio::task::JoinHandle;
 
 use crate::error::Result;
@@ -57,6 +62,20 @@ impl Direction {
             Direction::UpstreamToClient => 1,
         }
     }
+}
+
+/// How a connection is closed by [`FaultProxy::close_after_with`],
+/// [`FaultProxy::reject_next`], [`FaultProxy::reset_peer`], and
+/// [`FaultProxy::disable`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum CloseKind {
+    /// A clean TCP close (FIN). The peer sees a normal EOF.
+    #[default]
+    Fin,
+    /// An abrupt TCP reset (`SO_LINGER` set to zero before close). The peer
+    /// sees `ECONNRESET` rather than EOF, matching a crashed server rather
+    /// than a cleanly closed one.
+    Rst,
 }
 
 /// A delay applied before forwarding data in one direction.
@@ -110,27 +129,137 @@ fn next_pseudo_random() -> u64 {
     x
 }
 
+/// Cumulative counters for a [`FaultProxy`] since it was spawned.
+///
+/// A `Copy` snapshot taken with `Relaxed` atomic loads; cheap enough to call
+/// from a synchronous assertion or the planned CLI status output. Every
+/// counter only ever increases -- call [`FaultProxy::stats`] again and
+/// compare against a previous snapshot to measure activity in a window.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ProxyStats {
+    /// Total connections accepted by the listener, including ones that were
+    /// black-holed or rejected.
+    pub connections_accepted: u64,
+    /// Connections accepted while black-hole mode ([`FaultProxy::set_drop_all`])
+    /// was active.
+    pub connections_black_holed: u64,
+    /// Connections accepted then immediately closed by a pending
+    /// [`FaultProxy::reject_next`] countdown.
+    pub connections_rejected: u64,
+    /// Total bytes forwarded from the test client to the upstream node.
+    pub bytes_client_to_upstream: u64,
+    /// Total bytes forwarded from the upstream node to the test client.
+    pub bytes_upstream_to_client: u64,
+    /// Number of read-chunks delayed by [`FaultProxy::set_delay`] while
+    /// forwarding client-to-upstream traffic.
+    pub delays_client_to_upstream: u64,
+    /// Number of read-chunks delayed by [`FaultProxy::set_delay`] while
+    /// forwarding upstream-to-client traffic.
+    pub delays_upstream_to_client: u64,
+    /// Number of times a [`FaultProxy::close_after`] /
+    /// [`FaultProxy::close_after_with`] threshold tripped in the
+    /// client-to-upstream direction.
+    pub closes_client_to_upstream: u64,
+    /// Number of times a [`FaultProxy::close_after`] /
+    /// [`FaultProxy::close_after_with`] threshold tripped in the
+    /// upstream-to-client direction.
+    pub closes_upstream_to_client: u64,
+    /// Number of reads that were split into more than one write by
+    /// [`FaultProxy::set_chunk_size`] in the client-to-upstream direction.
+    pub chunked_writes_client_to_upstream: u64,
+    /// Number of reads that were split into more than one write by
+    /// [`FaultProxy::set_chunk_size`] in the upstream-to-client direction.
+    pub chunked_writes_upstream_to_client: u64,
+}
+
+/// Lock-free cumulative counters backing [`ProxyStats`], held outside the
+/// `RwLock<FaultState>` so that [`FaultProxy::reset`] never silently zeroes
+/// them.
+#[derive(Debug)]
+struct StatsInner {
+    connections_accepted: AtomicU64,
+    connections_black_holed: AtomicU64,
+    connections_rejected: AtomicU64,
+    bytes: [AtomicU64; 2],
+    delays: [AtomicU64; 2],
+    closes: [AtomicU64; 2],
+    chunked_writes: [AtomicU64; 2],
+}
+
+impl Default for StatsInner {
+    fn default() -> Self {
+        StatsInner {
+            connections_accepted: AtomicU64::new(0),
+            connections_black_holed: AtomicU64::new(0),
+            connections_rejected: AtomicU64::new(0),
+            bytes: [AtomicU64::new(0), AtomicU64::new(0)],
+            delays: [AtomicU64::new(0), AtomicU64::new(0)],
+            closes: [AtomicU64::new(0), AtomicU64::new(0)],
+            chunked_writes: [AtomicU64::new(0), AtomicU64::new(0)],
+        }
+    }
+}
+
+impl StatsInner {
+    fn snapshot(&self) -> ProxyStats {
+        let c2u = Direction::ClientToUpstream.idx();
+        let u2c = Direction::UpstreamToClient.idx();
+        ProxyStats {
+            connections_accepted: self.connections_accepted.load(Ordering::Relaxed),
+            connections_black_holed: self.connections_black_holed.load(Ordering::Relaxed),
+            connections_rejected: self.connections_rejected.load(Ordering::Relaxed),
+            bytes_client_to_upstream: self.bytes[c2u].load(Ordering::Relaxed),
+            bytes_upstream_to_client: self.bytes[u2c].load(Ordering::Relaxed),
+            delays_client_to_upstream: self.delays[c2u].load(Ordering::Relaxed),
+            delays_upstream_to_client: self.delays[u2c].load(Ordering::Relaxed),
+            closes_client_to_upstream: self.closes[c2u].load(Ordering::Relaxed),
+            closes_upstream_to_client: self.closes[u2c].load(Ordering::Relaxed),
+            chunked_writes_client_to_upstream: self.chunked_writes[c2u].load(Ordering::Relaxed),
+            chunked_writes_upstream_to_client: self.chunked_writes[u2c].load(Ordering::Relaxed),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 struct FaultState {
     delay: [Option<Delay>; 2],
-    close_after: [Option<u64>; 2],
+    close_after: [Option<(u64, CloseKind)>; 2],
     chunk_size: Option<usize>,
+    chunk_delay: Option<Duration>,
     drop_all: bool,
+    stall: [bool; 2],
+    reject_remaining: u32,
+    reject_kind: CloseKind,
+}
+
+/// Generation-counted broadcast used to sever every live connection at once,
+/// from [`FaultProxy::reset_peer`], [`FaultProxy::disable`], and the deadline
+/// scheduled by [`FaultProxy::stall_then_close`].
+#[derive(Clone, Copy, Debug)]
+struct ShutdownSignal {
+    generation: u64,
+    kind: CloseKind,
 }
 
 /// A TCP proxy that forwards bytes between test clients and an upstream
 /// Redis node while injecting configurable network faults.
 ///
 /// Construct with [`FaultProxy::spawn`]. Fault controls can be changed at
-/// any time via the returned handle; delay, close-after, and chunk-size take
-/// effect on data already in flight (checked on every read), while
-/// [`FaultProxy::set_drop_all`] is snapshotted once per accepted connection.
-/// The proxy stops accepting new connections when the handle is dropped;
-/// already-established connections run to completion.
+/// any time via the returned handle; delay, close-after, chunk-size, and
+/// stall take effect on data already in flight (checked on every read),
+/// while [`FaultProxy::set_drop_all`] and [`FaultProxy::reject_next`] are
+/// snapshotted once per accepted connection. The proxy stops accepting new
+/// connections when the handle is dropped; already-established connections
+/// run to completion.
 pub struct FaultProxy {
     addr: SocketAddr,
+    upstream_addr: SocketAddr,
     state: Arc<RwLock<FaultState>>,
-    accept_task: JoinHandle<()>,
+    stats: Arc<StatsInner>,
+    notify: Arc<Notify>,
+    shutdown_tx: watch::Sender<ShutdownSignal>,
+    accept_task: Mutex<Option<JoinHandle<()>>>,
+    stall_timer: Mutex<Option<JoinHandle<()>>>,
 }
 
 impl FaultProxy {
@@ -150,32 +279,44 @@ impl FaultProxy {
         let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
         let addr = listener.local_addr()?;
         let state = Arc::new(RwLock::new(FaultState::default()));
-
-        let accept_state = state.clone();
-        let accept_task = tokio::spawn(async move {
-            loop {
-                let (client, _) = match listener.accept().await {
-                    Ok(pair) => pair,
-                    Err(_) => break,
-                };
-                tokio::spawn(handle_connection(
-                    client,
-                    upstream_addr,
-                    accept_state.clone(),
-                ));
-            }
+        let stats = Arc::new(StatsInner::default());
+        let notify = Arc::new(Notify::new());
+        let (shutdown_tx, shutdown_rx) = watch::channel(ShutdownSignal {
+            generation: 0,
+            kind: CloseKind::Fin,
         });
+
+        let accept_task = spawn_accept_task(
+            listener,
+            upstream_addr,
+            state.clone(),
+            stats.clone(),
+            notify.clone(),
+            shutdown_rx,
+        );
 
         Ok(FaultProxy {
             addr,
+            upstream_addr,
             state,
-            accept_task,
+            stats,
+            notify,
+            shutdown_tx,
+            accept_task: Mutex::new(Some(accept_task)),
+            stall_timer: Mutex::new(None),
         })
     }
 
-    /// The local address clients should connect to.
+    /// The local address clients should connect to. Stable across
+    /// [`FaultProxy::disable`] / [`FaultProxy::enable`] cycles.
     pub fn addr(&self) -> SocketAddr {
         self.addr
+    }
+
+    /// Cumulative counters since [`FaultProxy::spawn`]. Lock-free snapshot;
+    /// safe to call from a synchronous assertion.
+    pub fn stats(&self) -> ProxyStats {
+        self.stats.snapshot()
     }
 
     /// Set (or replace) the delay applied before forwarding data in `direction`.
@@ -191,9 +332,16 @@ impl FaultProxy {
     /// Close the connection once `bytes` total have been forwarded in
     /// `direction`, cutting mid-buffer if the triggering read straddles the
     /// threshold. Applies independently to every connection accepted while
-    /// this setting is active.
+    /// this setting is active. Closes with a clean FIN; use
+    /// [`FaultProxy::close_after_with`] for a TCP reset instead.
     pub fn close_after(&self, direction: Direction, bytes: u64) {
-        self.state.write().unwrap().close_after[direction.idx()] = Some(bytes);
+        self.state.write().unwrap().close_after[direction.idx()] = Some((bytes, CloseKind::Fin));
+    }
+
+    /// Like [`FaultProxy::close_after`], but the connection is closed with
+    /// `kind` once the threshold trips.
+    pub fn close_after_with(&self, direction: Direction, bytes: u64, kind: CloseKind) {
+        self.state.write().unwrap().close_after[direction.idx()] = Some((bytes, kind));
     }
 
     /// Remove the close-after threshold configured for `direction`.
@@ -202,7 +350,9 @@ impl FaultProxy {
     }
 
     /// Split forwarded writes into pieces of at most `size` bytes, in both
-    /// directions. Use `size == 1` to exercise incremental decoders.
+    /// directions. Use `size == 1` to exercise incremental decoders. Combine
+    /// with [`FaultProxy::set_chunk_delay`] so the pieces genuinely arrive as
+    /// separate reads instead of being coalesced by the kernel on loopback.
     pub fn set_chunk_size(&self, size: usize) {
         self.state.write().unwrap().chunk_size = Some(size.max(1));
     }
@@ -212,85 +362,365 @@ impl FaultProxy {
         self.state.write().unwrap().chunk_size = None;
     }
 
+    /// Sleep `delay` between chunked write pieces so the client observes each
+    /// piece as a separate read. No effect unless [`FaultProxy::set_chunk_size`]
+    /// splits a read into more than one piece.
+    pub fn set_chunk_delay(&self, delay: Duration) {
+        self.state.write().unwrap().chunk_delay = Some(delay);
+    }
+
+    /// Remove the inter-chunk delay configured by [`FaultProxy::set_chunk_delay`].
+    pub fn clear_chunk_delay(&self) {
+        self.state.write().unwrap().chunk_delay = None;
+    }
+
     /// Enable or disable black-hole mode. While enabled, newly accepted
     /// connections are held open (no upstream connection is made, nothing is
     /// ever forwarded or written back) until the client disconnects or the
-    /// proxy is dropped. Existing connections are unaffected.
+    /// proxy is dropped. Existing connections are unaffected; use
+    /// [`FaultProxy::set_stall`] to affect connections already established.
     pub fn set_drop_all(&self, drop_all: bool) {
         self.state.write().unwrap().drop_all = drop_all;
     }
 
+    /// Stop forwarding bytes in `direction` on every connection, existing and
+    /// new. Client writes still succeed; reads on the other end never
+    /// complete until [`FaultProxy::clear_stall`] is called or the connection
+    /// is severed by a pending [`FaultProxy::stall_then_close`] deadline.
+    pub fn set_stall(&self, direction: Direction) {
+        self.state.write().unwrap().stall[direction.idx()] = true;
+    }
+
+    /// Resume forwarding in `direction`; bytes read while stalled are flushed
+    /// (matches toxiproxy's `timeout` toxic, which delays data rather than
+    /// discarding it).
+    pub fn clear_stall(&self, direction: Direction) {
+        self.state.write().unwrap().stall[direction.idx()] = false;
+        self.notify.notify_waiters();
+    }
+
+    /// Stall both directions now, then sever every connection (existing and
+    /// new) `after` later. Use [`FaultProxy::set_stall`] alone for an
+    /// indefinite hold. Replaces any previously pending deadline.
+    pub fn stall_then_close(&self, after: Duration) {
+        {
+            let mut state = self.state.write().unwrap();
+            state.stall[Direction::ClientToUpstream.idx()] = true;
+            state.stall[Direction::UpstreamToClient.idx()] = true;
+        }
+        self.cancel_pending_stall_close();
+
+        let shutdown_tx = self.shutdown_tx.clone();
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(after).await;
+            shutdown_tx.send_modify(|signal| {
+                signal.generation = signal.generation.wrapping_add(1);
+                signal.kind = CloseKind::Fin;
+            });
+        });
+        *self.stall_timer.lock().unwrap() = Some(handle);
+    }
+
+    /// Cancel any pending [`FaultProxy::stall_then_close`] deadline and clear
+    /// both stalls.
+    pub fn clear_stall_all(&self) {
+        self.cancel_pending_stall_close();
+        {
+            let mut state = self.state.write().unwrap();
+            state.stall[0] = false;
+            state.stall[1] = false;
+        }
+        self.notify.notify_waiters();
+    }
+
+    fn cancel_pending_stall_close(&self) {
+        if let Some(handle) = self.stall_timer.lock().unwrap().take() {
+            handle.abort();
+        }
+    }
+
+    /// Sever every live connection right now with a TCP RST, simulating a
+    /// crashed server. New connections are unaffected; combine with
+    /// [`FaultProxy::disable`] to also stop accepting.
+    pub fn reset_peer(&self) {
+        self.sever_all(CloseKind::Rst);
+    }
+
+    fn sever_all(&self, kind: CloseKind) {
+        self.shutdown_tx.send_modify(|signal| {
+            signal.generation = signal.generation.wrapping_add(1);
+            signal.kind = kind;
+        });
+    }
+
+    /// Fail the next `n` accepted connections by closing them immediately
+    /// (with `kind`) before any upstream connect; passthrough resumes after.
+    /// Deterministic replacement for toxiproxy's probabilistic `toxicity`.
+    pub fn reject_next(&self, n: u32, kind: CloseKind) {
+        let mut state = self.state.write().unwrap();
+        state.reject_remaining = n;
+        state.reject_kind = kind;
+    }
+
+    /// Cancel any pending [`FaultProxy::reject_next`] countdown.
+    pub fn clear_reject(&self) {
+        self.state.write().unwrap().reject_remaining = 0;
+    }
+
+    /// Stop listening and sever all live connections; new connect attempts
+    /// fail with `ECONNREFUSED`. The port is released and re-claimed by
+    /// [`FaultProxy::enable`].
+    ///
+    /// Note: another process can claim the port while disabled (rare for
+    /// localhost tests, but a real race).
+    pub async fn disable(&self) -> Result<()> {
+        let handle = self.accept_task.lock().unwrap().take();
+        if let Some(handle) = handle {
+            handle.abort();
+            // Wait for the aborted task (and the listener it owns) to
+            // actually finish tearing down before returning, so a
+            // subsequent `enable()` can reliably rebind the same port.
+            let _ = handle.await;
+        }
+        self.sever_all(CloseKind::Fin);
+        Ok(())
+    }
+
+    /// Rebind the same local port and resume passthrough with the current
+    /// fault state. Fails if the port was taken while disabled. A no-op if
+    /// the proxy is already enabled.
+    pub async fn enable(&self) -> Result<()> {
+        if self.accept_task.lock().unwrap().is_some() {
+            return Ok(());
+        }
+
+        let listener = TcpListener::bind(self.addr).await?;
+        let handle = spawn_accept_task(
+            listener,
+            self.upstream_addr,
+            self.state.clone(),
+            self.stats.clone(),
+            self.notify.clone(),
+            self.shutdown_tx.subscribe(),
+        );
+        *self.accept_task.lock().unwrap() = Some(handle);
+        Ok(())
+    }
+
     /// Clear every fault control, returning the proxy to clean passthrough
-    /// for new connections.
+    /// for new connections. Also cancels any pending
+    /// [`FaultProxy::stall_then_close`] deadline and wakes any connections
+    /// currently blocked on a stall.
     pub fn reset(&self) {
+        self.cancel_pending_stall_close();
         *self.state.write().unwrap() = FaultState::default();
+        self.notify.notify_waiters();
     }
 }
 
 impl Drop for FaultProxy {
     fn drop(&mut self) {
-        self.accept_task.abort();
+        if let Some(handle) = self.accept_task.lock().unwrap().take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.stall_timer.lock().unwrap().take() {
+            handle.abort();
+        }
     }
+}
+
+/// Run the accept loop for a bound `listener`: accept connections, apply the
+/// [`FaultProxy::reject_next`] countdown, and spawn [`handle_connection`] for
+/// everything else. Shared between [`FaultProxy::spawn`] and
+/// [`FaultProxy::enable`].
+fn spawn_accept_task(
+    listener: TcpListener,
+    upstream_addr: SocketAddr,
+    state: Arc<RwLock<FaultState>>,
+    stats: Arc<StatsInner>,
+    notify: Arc<Notify>,
+    shutdown_rx: watch::Receiver<ShutdownSignal>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            let (client, _) = match listener.accept().await {
+                Ok(pair) => pair,
+                Err(_) => break,
+            };
+            stats.connections_accepted.fetch_add(1, Ordering::Relaxed);
+
+            let reject_kind = {
+                let mut s = state.write().unwrap();
+                if s.reject_remaining > 0 {
+                    s.reject_remaining -= 1;
+                    Some(s.reject_kind)
+                } else {
+                    None
+                }
+            };
+
+            if let Some(kind) = reject_kind {
+                stats.connections_rejected.fetch_add(1, Ordering::Relaxed);
+                if kind == CloseKind::Rst {
+                    let _ = client.set_zero_linger();
+                }
+                drop(client);
+                continue;
+            }
+
+            tokio::spawn(handle_connection(
+                client,
+                upstream_addr,
+                state.clone(),
+                stats.clone(),
+                notify.clone(),
+                shutdown_rx.clone(),
+            ));
+        }
+    })
 }
 
 async fn handle_connection(
     mut client: TcpStream,
     upstream_addr: SocketAddr,
     state: Arc<RwLock<FaultState>>,
+    stats: Arc<StatsInner>,
+    notify: Arc<Notify>,
+    mut shutdown_rx: watch::Receiver<ShutdownSignal>,
 ) {
     if state.read().unwrap().drop_all {
+        stats
+            .connections_black_holed
+            .fetch_add(1, Ordering::Relaxed);
         let mut buf = [0u8; 4096];
         loop {
-            match client.read(&mut buf).await {
-                Ok(0) | Err(_) => return,
-                Ok(_) => {}
+            tokio::select! {
+                changed = shutdown_rx.changed() => {
+                    if changed.is_ok() && shutdown_rx.borrow().kind == CloseKind::Rst {
+                        let _ = client.set_zero_linger();
+                    }
+                    return;
+                }
+                result = client.read(&mut buf) => {
+                    match result {
+                        Ok(0) | Err(_) => return,
+                        Ok(_) => {}
+                    }
+                }
             }
         }
     }
 
-    let upstream = match TcpStream::connect(upstream_addr).await {
+    let mut upstream = match TcpStream::connect(upstream_addr).await {
         Ok(s) => s,
         Err(_) => return,
     };
 
-    let (client_r, client_w) = client.into_split();
-    let (upstream_r, upstream_w) = upstream.into_split();
+    let outcome = {
+        let (client_r, client_w) = client.split();
+        let (upstream_r, upstream_w) = upstream.split();
+        tokio::select! {
+            outcome = forward(
+                client_r,
+                upstream_w,
+                state.clone(),
+                stats.clone(),
+                notify.clone(),
+                shutdown_rx.clone(),
+                Direction::ClientToUpstream,
+            ) => outcome,
+            outcome = forward(
+                upstream_r,
+                client_w,
+                state,
+                stats,
+                notify,
+                shutdown_rx,
+                Direction::UpstreamToClient,
+            ) => outcome,
+        }
+    };
 
-    tokio::select! {
-        _ = forward(client_r, upstream_w, state.clone(), Direction::ClientToUpstream) => {},
-        _ = forward(upstream_r, client_w, state, Direction::UpstreamToClient) => {},
+    if outcome == Some(CloseKind::Rst) {
+        let _ = client.set_zero_linger();
+        let _ = upstream.set_zero_linger();
     }
+    // `client` and `upstream` drop here, actually closing the sockets with
+    // whatever linger setting was just applied.
 }
 
 /// Copy bytes from `reader` to `writer`, applying whatever delay,
-/// close-after, and chunk-size controls are configured for `direction` at
-/// the time each chunk is read. Returns when the source hits EOF/error, the
-/// sink fails, or the close-after threshold for `direction` is reached.
-async fn forward(
-    mut reader: OwnedReadHalf,
-    mut writer: OwnedWriteHalf,
+/// close-after, stall, and chunk-size/chunk-delay controls are configured
+/// for `direction` at the time each chunk is read. Returns `None` on a
+/// natural EOF/error (the caller should let the sockets close with a plain
+/// FIN), or `Some(kind)` when the proxy itself decided to end the
+/// connection (a close-after threshold, or a shutdown broadcast from
+/// [`FaultProxy::reset_peer`], [`FaultProxy::disable`], or a
+/// [`FaultProxy::stall_then_close`] deadline).
+async fn forward<R, W>(
+    mut reader: R,
+    mut writer: W,
     state: Arc<RwLock<FaultState>>,
+    stats: Arc<StatsInner>,
+    notify: Arc<Notify>,
+    mut shutdown_rx: watch::Receiver<ShutdownSignal>,
     direction: Direction,
-) {
+) -> Option<CloseKind>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
     let idx = direction.idx();
     let mut total: u64 = 0;
     let mut buf = [0u8; 4096];
 
     loop {
-        let n = match reader.read(&mut buf).await {
-            Ok(0) | Err(_) => return,
-            Ok(n) => n,
+        let n = tokio::select! {
+            biased;
+            changed = shutdown_rx.changed() => {
+                return if changed.is_ok() { Some(shutdown_rx.borrow().kind) } else { None };
+            }
+            result = reader.read(&mut buf) => {
+                match result {
+                    Ok(0) | Err(_) => return None,
+                    Ok(n) => n,
+                }
+            }
         };
         let mut data = &buf[..n];
 
-        let (delay, close_after, chunk_size) = {
+        // Hold already-read data until the direction is unstalled or the
+        // connection is severed. Existing and new connections both observe
+        // this, since it's checked fresh on every read.
+        if state.read().unwrap().stall[idx] {
+            loop {
+                let notified = notify.notified();
+                if !state.read().unwrap().stall[idx] {
+                    break;
+                }
+                tokio::select! {
+                    _ = notified => {}
+                    changed = shutdown_rx.changed() => {
+                        return if changed.is_ok() { Some(shutdown_rx.borrow().kind) } else { None };
+                    }
+                }
+            }
+        }
+
+        let (delay, close_after, chunk_size, chunk_delay) = {
             let s = state.read().unwrap();
-            (s.delay[idx], s.close_after[idx], s.chunk_size)
+            (
+                s.delay[idx],
+                s.close_after[idx],
+                s.chunk_size,
+                s.chunk_delay,
+            )
         };
 
-        if let Some(limit) = close_after {
+        if let Some((limit, kind)) = close_after {
             if total >= limit {
-                return;
+                stats.closes[idx].fetch_add(1, Ordering::Relaxed);
+                return Some(kind);
             }
             let remaining = (limit - total) as usize;
             if data.len() > remaining {
@@ -299,21 +729,35 @@ async fn forward(
         }
 
         if let Some(delay) = delay {
+            stats.delays[idx].fetch_add(1, Ordering::Relaxed);
             tokio::time::sleep(delay.resolve()).await;
         }
 
         let chunk = chunk_size.unwrap_or(data.len()).max(1);
-        for piece in data.chunks(chunk) {
+        let mut pieces = data.chunks(chunk).peekable();
+        let mut chunked = false;
+        while let Some(piece) = pieces.next() {
             if writer.write_all(piece).await.is_err() {
-                return;
+                return None;
+            }
+            if pieces.peek().is_some() {
+                chunked = true;
+                if let Some(delay) = chunk_delay {
+                    tokio::time::sleep(delay).await;
+                }
             }
         }
+        if chunked {
+            stats.chunked_writes[idx].fetch_add(1, Ordering::Relaxed);
+        }
         total += data.len() as u64;
+        stats.bytes[idx].fetch_add(data.len() as u64, Ordering::Relaxed);
 
-        if let Some(limit) = close_after
+        if let Some((limit, kind)) = close_after
             && total >= limit
         {
-            return;
+            stats.closes[idx].fetch_add(1, Ordering::Relaxed);
+            return Some(kind);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ pub use cli::{IpPreference, OutputFormat, RedisCli, RespProtocol};
 pub use cluster::{NodeContext, RedisCluster, RedisClusterBuilder, RedisClusterHandle};
 pub use error::{Error, Result};
 #[cfg(feature = "tokio")]
-pub use fault_proxy::{Delay, Direction, FaultProxy};
+pub use fault_proxy::{CloseKind, Delay, Direction, FaultProxy, ProxyStats};
 #[cfg(feature = "tokio")]
 pub use sentinel::{RedisSentinel, RedisSentinelBuilder, RedisSentinelHandle};
 #[cfg(feature = "tokio")]

--- a/tests/blocking_fault_proxy.rs
+++ b/tests/blocking_fault_proxy.rs
@@ -71,7 +71,17 @@ fn stats_and_reject_next_smoke_test() {
     client.read_exact(&mut buf).expect("read failed");
     assert_eq!(&buf, b"+PONG\r\n");
 
-    let stats = proxy.stats();
+    // The byte counters are updated by the proxy's forwarding task, which
+    // races the client's read: the reply can reach the client before the
+    // counter increment lands. Poll instead of asserting immediately.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let stats = loop {
+        let stats = proxy.stats();
+        if stats.bytes_upstream_to_client > 0 || std::time::Instant::now() > deadline {
+            break stats;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    };
     assert_eq!(stats.connections_accepted, 2);
     assert_eq!(stats.connections_rejected, 1);
     assert!(stats.bytes_upstream_to_client > 0);

--- a/tests/blocking_fault_proxy.rs
+++ b/tests/blocking_fault_proxy.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "blocking")]
 
-use redis_server_wrapper::blocking::{Direction, FaultProxy, RedisServer};
+use redis_server_wrapper::blocking::{CloseKind, Direction, FaultProxy, RedisServer};
 use std::io::{Read, Write};
 use std::net::TcpStream;
 
@@ -40,4 +40,39 @@ fn close_after_drops_connection_mid_frame() {
         .expect("read_to_end failed");
 
     assert_eq!(received, b"+PO");
+}
+
+#[test]
+fn stats_and_reject_next_smoke_test() {
+    let server = RedisServer::new()
+        .port(17852)
+        .start()
+        .expect("failed to start server");
+
+    let proxy = FaultProxy::spawn(server.addr()).expect("failed to spawn proxy");
+    proxy.reject_next(1, CloseKind::Fin);
+
+    // The first connection attempt is rejected: accepted, then closed
+    // immediately without any upstream connection or data.
+    {
+        let mut client = TcpStream::connect(proxy.addr()).expect("failed to connect to proxy");
+        let mut buf = [0u8; 8];
+        let n = client.read(&mut buf).expect("read failed");
+        assert_eq!(
+            n, 0,
+            "expected an immediate close for a rejected connection"
+        );
+    }
+
+    // The second connection attempt passes through normally.
+    let mut client = TcpStream::connect(proxy.addr()).expect("failed to connect to proxy");
+    client.write_all(b"PING\r\n").expect("write failed");
+    let mut buf = [0u8; 7];
+    client.read_exact(&mut buf).expect("read failed");
+    assert_eq!(&buf, b"+PONG\r\n");
+
+    let stats = proxy.stats();
+    assert_eq!(stats.connections_accepted, 2);
+    assert_eq!(stats.connections_rejected, 1);
+    assert!(stats.bytes_upstream_to_client > 0);
 }

--- a/tests/fault_proxy.rs
+++ b/tests/fault_proxy.rs
@@ -166,8 +166,21 @@ async fn stats_counts_a_fired_fault() {
     let mut buf = [0u8; 7];
     client.read_exact(&mut buf).await.unwrap();
 
-    let stats = proxy.stats();
     assert_eq!(&buf, b"delayed");
+
+    // Counter updates race the client's read (the reply can arrive before
+    // the forwarding task's increments land), so poll instead of asserting
+    // the byte and delay counters immediately.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let stats = loop {
+        let stats = proxy.stats();
+        if (stats.delays_upstream_to_client > 0 && stats.bytes_upstream_to_client >= 7)
+            || tokio::time::Instant::now() > deadline
+        {
+            break stats;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    };
     assert!(stats.connections_accepted >= 1);
     assert!(
         stats.delays_upstream_to_client > 0,

--- a/tests/fault_proxy.rs
+++ b/tests/fault_proxy.rs
@@ -1,4 +1,4 @@
-use redis_server_wrapper::{Delay, Direction, FaultProxy};
+use redis_server_wrapper::{CloseKind, Delay, Direction, FaultProxy};
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -151,4 +151,166 @@ async fn dropping_proxy_stops_accepting_new_connections() {
     // listening socket is gone -- new connections must be refused.
     tokio::time::sleep(Duration::from_millis(50)).await;
     assert!(TcpStream::connect(addr).await.is_err());
+}
+
+#[tokio::test]
+async fn stats_counts_a_fired_fault() {
+    let upstream = spawn_greeting_upstream(b"delayed").await;
+    let proxy = FaultProxy::spawn(upstream).await.unwrap();
+    proxy.set_delay(
+        Direction::UpstreamToClient,
+        Delay::Fixed(Duration::from_millis(20)),
+    );
+
+    let mut client = TcpStream::connect(proxy.addr()).await.unwrap();
+    let mut buf = [0u8; 7];
+    client.read_exact(&mut buf).await.unwrap();
+
+    let stats = proxy.stats();
+    assert_eq!(&buf, b"delayed");
+    assert!(stats.connections_accepted >= 1);
+    assert!(
+        stats.delays_upstream_to_client > 0,
+        "expected the configured delay to have fired at least once, got {stats:?}"
+    );
+    assert!(stats.bytes_upstream_to_client >= 7);
+}
+
+#[tokio::test]
+async fn stall_hangs_in_flight_read_then_deadline_closes() {
+    let upstream = spawn_greeting_upstream(b"should be held back").await;
+    let proxy = FaultProxy::spawn(upstream).await.unwrap();
+    proxy.stall_then_close(Duration::from_millis(200));
+
+    let mut client = TcpStream::connect(proxy.addr()).await.unwrap();
+    let mut buf = [0u8; 32];
+
+    // The response is held back by the stall: a short read attempt must not
+    // complete.
+    let quick = tokio::time::timeout(Duration::from_millis(80), client.read(&mut buf)).await;
+    assert!(
+        quick.is_err(),
+        "expected the stalled read to still be pending, got {quick:?}"
+    );
+
+    // After the deadline, the connection is severed and the pending read
+    // resolves one way or another (EOF or an error).
+    let eventual = tokio::time::timeout(Duration::from_secs(3), client.read(&mut buf)).await;
+    assert!(
+        eventual.is_ok(),
+        "expected the stalled connection to be closed after the deadline"
+    );
+}
+
+#[tokio::test]
+async fn rst_close_produces_econnreset() {
+    let upstream = spawn_greeting_upstream(b"RESETRESETRESET").await;
+    let proxy = FaultProxy::spawn(upstream).await.unwrap();
+    proxy.close_after_with(Direction::UpstreamToClient, 4, CloseKind::Rst);
+
+    let mut client = TcpStream::connect(proxy.addr()).await.unwrap();
+
+    let result = tokio::time::timeout(Duration::from_secs(2), async {
+        let mut buf = [0u8; 64];
+        loop {
+            match client.read(&mut buf).await {
+                Ok(0) => panic!("expected ECONNRESET, got a clean EOF instead"),
+                Ok(_) => continue,
+                Err(e) => return e,
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for the connection reset");
+
+    assert_eq!(result.kind(), std::io::ErrorKind::ConnectionReset);
+}
+
+#[tokio::test]
+async fn disable_refuses_connections_then_enable_restores_passthrough() {
+    let upstream = spawn_echo_upstream().await;
+    let proxy = FaultProxy::spawn(upstream).await.unwrap();
+    let addr = proxy.addr();
+
+    proxy.disable().await.unwrap();
+
+    let err = TcpStream::connect(addr)
+        .await
+        .expect_err("expected connect to fail while the proxy is disabled");
+    assert_eq!(err.kind(), std::io::ErrorKind::ConnectionRefused);
+
+    proxy.enable().await.unwrap();
+    assert_eq!(
+        proxy.addr(),
+        addr,
+        "addr() must stay stable across disable/enable"
+    );
+
+    let mut client = TcpStream::connect(addr).await.unwrap();
+    client.write_all(b"still works").await.unwrap();
+    let mut buf = [0u8; 11];
+    client.read_exact(&mut buf).await.unwrap();
+    assert_eq!(&buf, b"still works");
+}
+
+#[tokio::test]
+async fn chunk_delay_yields_multiple_distinct_reads() {
+    let payload = b"ABC";
+    let upstream = spawn_greeting_upstream(payload).await;
+    let proxy = FaultProxy::spawn(upstream).await.unwrap();
+    proxy.set_chunk_size(1);
+    proxy.set_chunk_delay(Duration::from_millis(80));
+
+    let mut client = TcpStream::connect(proxy.addr()).await.unwrap();
+    let mut reads: Vec<(Instant, Vec<u8>)> = Vec::new();
+    let mut buf = [0u8; 16];
+    loop {
+        match tokio::time::timeout(Duration::from_secs(2), client.read(&mut buf)).await {
+            Ok(Ok(0)) | Err(_) => break,
+            Ok(Ok(n)) => reads.push((Instant::now(), buf[..n].to_vec())),
+            Ok(Err(_)) => break,
+        }
+    }
+
+    assert!(
+        reads.len() >= 2,
+        "expected multiple distinct reads for a delayed chunked write, got {}",
+        reads.len()
+    );
+    let gap = reads[1].0.duration_since(reads[0].0);
+    assert!(
+        gap >= Duration::from_millis(40),
+        "expected a measurable inter-chunk delay, got {gap:?}"
+    );
+
+    let received: Vec<u8> = reads.into_iter().flat_map(|(_, bytes)| bytes).collect();
+    assert_eq!(received, payload);
+}
+
+#[tokio::test]
+async fn reject_next_fails_exactly_twice_then_succeeds() {
+    let upstream = spawn_echo_upstream().await;
+    let proxy = FaultProxy::spawn(upstream).await.unwrap();
+    proxy.reject_next(2, CloseKind::Fin);
+
+    for attempt in 0..2 {
+        let mut client = TcpStream::connect(proxy.addr()).await.unwrap();
+        let mut buf = [0u8; 8];
+        let n = tokio::time::timeout(Duration::from_secs(2), client.read(&mut buf))
+            .await
+            .unwrap_or_else(|_| panic!("attempt {attempt} timed out waiting for close"))
+            .unwrap();
+        assert_eq!(
+            n, 0,
+            "expected an immediate close for a rejected connection"
+        );
+    }
+
+    let mut client = TcpStream::connect(proxy.addr()).await.unwrap();
+    client.write_all(b"hello").await.unwrap();
+    let mut buf = [0u8; 5];
+    client.read_exact(&mut buf).await.unwrap();
+    assert_eq!(&buf, b"hello");
+
+    assert_eq!(proxy.stats().connections_rejected, 2);
 }


### PR DESCRIPTION
Closes #120.

## Plan

Implement the six verified FaultProxy items from the research audit (full sketches and verifier corrections in the issue):

- `stats()`: lock-free cumulative counters (per-direction bytes, connections, per-fault-kind applied counts) so tests can assert a fault actually fired.
- Live-connection stall with optional deadline close, fixing the `drop_all` accept-time-only divergence.
- RST closes (SO_LINGER=0) as a close variant; requires the borrowed-split refactor in handle_connection noted by the verifier (tokio owned halves do not expose set_linger).
- disable/enable: close the listener (ECONNREFUSED for new connects), sever live connections, rebind the same port on enable.
- Inter-chunk delay so chunked writes genuinely reach clients as separate reads (kernel coalescing defeats set_chunk_size today).
- reject-next-N connections (deterministic accept-then-close for reconnect tests).

Sync delegates on `blocking::FaultProxy` for every new control. Tests mirror the existing tests/fault_proxy.rs and tests/blocking_fault_proxy.rs styles.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] `cargo test --no-default-features --features blocking`
- [ ] `cargo doc --no-deps --all-features`