### PR TITLE
feat: observability and assertion primitives for fault testing

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -12,9 +12,36 @@ use std::time::Duration;
 use tokio::net::ToSocketAddrs;
 use tokio::runtime::Runtime;
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::server::{AppendFsync, LogLevel, ReplDisklessLoad};
 use crate::{cli, cluster, sentinel, server};
+
+// ── wait_for ──────────────────────────────────────────────────────────────────
+
+/// Synchronous mirror of [`crate::wait::wait_for`]: poll `check` until it
+/// returns `true`, or fail with `Error::Timeout` once `timeout` elapses.
+///
+/// Same ordering as the async version: check first (so a first-try success
+/// never sleeps), then compare elapsed time against `timeout`, then sleep
+/// for `interval` on the calling thread.
+pub fn wait_for(
+    mut check: impl FnMut() -> bool,
+    timeout: Duration,
+    interval: Duration,
+    message: impl Into<String>,
+) -> Result<()> {
+    let message = message.into();
+    let start = std::time::Instant::now();
+    loop {
+        if check() {
+            return Ok(());
+        }
+        if start.elapsed() > timeout {
+            return Err(Error::Timeout { message });
+        }
+        std::thread::sleep(interval);
+    }
+}
 
 // ── RedisCli ──────────────────────────────────────────────────────────────────
 
@@ -1734,6 +1761,50 @@ impl RedisServerHandle {
         self.rt.block_on(self.inner.run(args))
     }
 
+    /// `INFO [section]` parsed into a flat key/value map. See
+    /// [`crate::server::RedisServerHandle::info`].
+    pub fn info(&self, section: Option<&str>) -> Result<HashMap<String, String>> {
+        self.rt.block_on(self.inner.info(section))
+    }
+
+    /// Shorthand for `info(Some("replication"))["role"]`. See
+    /// [`crate::server::RedisServerHandle::role`].
+    pub fn role(&self) -> Result<String> {
+        self.rt.block_on(self.inner.role())
+    }
+
+    /// Block until [`Self::role`] returns `role`, or timeout. See
+    /// [`crate::server::RedisServerHandle::wait_until_role`].
+    pub fn wait_until_role(&self, role: &str, timeout: Duration) -> Result<()> {
+        self.rt.block_on(self.inner.wait_until_role(role, timeout))
+    }
+
+    /// Path to this node's log file. See
+    /// [`crate::server::RedisServerHandle::log_path`].
+    pub fn log_path(&self) -> PathBuf {
+        self.inner.log_path()
+    }
+
+    /// Current byte length of [`Self::log_path`]. See
+    /// [`crate::server::RedisServerHandle::log_len`].
+    pub fn log_len(&self) -> Result<u64> {
+        self.inner.log_len()
+    }
+
+    /// Poll the log file until a line past byte offset `from` contains
+    /// `pattern`, or timeout. See
+    /// [`crate::server::RedisServerHandle::wait_for_log`].
+    pub fn wait_for_log(&self, pattern: &str, from: u64, timeout: Duration) -> Result<String> {
+        self.rt
+            .block_on(self.inner.wait_for_log(pattern, from, timeout))
+    }
+
+    /// Number of keys in the current database, via `DBSIZE`. See
+    /// [`crate::server::RedisServerHandle::dbsize`].
+    pub fn dbsize(&self) -> Result<u64> {
+        self.rt.block_on(self.inner.dbsize())
+    }
+
     /// Consume the handle without stopping the server.
     pub fn detach(self) {
         self.inner.detach();
@@ -1748,6 +1819,21 @@ impl RedisServerHandle {
     pub fn wait_for_ready(&self, timeout: Duration) -> Result<()> {
         self.rt.block_on(self.inner.wait_for_ready(timeout))
     }
+}
+
+/// Block until `replica`'s replication link to `master` is up and caught up,
+/// or timeout. Blocks on `replica`'s runtime. See
+/// [`crate::server::wait_for_replica_sync`].
+pub fn wait_for_replica_sync(
+    replica: &RedisServerHandle,
+    master: &RedisServerHandle,
+    timeout: Duration,
+) -> Result<()> {
+    replica.rt.block_on(crate::server::wait_for_replica_sync(
+        &replica.inner,
+        &master.inner,
+        timeout,
+    ))
 }
 
 // ── RedisCluster ──────────────────────────────────────────────────────────────
@@ -2303,6 +2389,19 @@ impl RedisClusterHandle {
     pub fn wait_for_healthy(&self, timeout: Duration) -> Result<()> {
         self.rt.block_on(self.inner.wait_for_healthy(timeout))
     }
+
+    /// `CLUSTER INFO` on the node at `node_index`, parsed into a flat
+    /// key/value map. See
+    /// [`crate::cluster::RedisClusterHandle::cluster_info`].
+    pub fn cluster_info(&self, node_index: usize) -> Result<HashMap<String, String>> {
+        self.rt.block_on(self.inner.cluster_info(node_index))
+    }
+
+    /// Wait until every node reports the cluster as healthy, or timeout.
+    /// See [`crate::cluster::RedisClusterHandle::wait_for_all_healthy`].
+    pub fn wait_for_all_healthy(&self, timeout: Duration) -> Result<()> {
+        self.rt.block_on(self.inner.wait_for_all_healthy(timeout))
+    }
 }
 
 // ── RedisSentinel ─────────────────────────────────────────────────────────────
@@ -2777,6 +2876,49 @@ pub mod chaos {
             cluster.inner.node(from),
             cluster.inner.node(to),
         ))
+    }
+
+    /// Compute the hash slot for a key via `CLUSTER KEYSLOT`. Blocks on the
+    /// cluster's runtime. See [`crate::chaos::keyslot`].
+    pub fn keyslot(cluster: &RedisClusterHandle, key: &str) -> Result<u16> {
+        cluster
+            .rt
+            .block_on(crate::chaos::keyslot(&cluster.inner, key))
+    }
+
+    /// The port of the master node that currently owns `slot`. Blocks on
+    /// the cluster's runtime. See [`crate::chaos::slot_owner`].
+    pub fn slot_owner(cluster: &RedisClusterHandle, slot: u16) -> Result<u16> {
+        cluster
+            .rt
+            .block_on(crate::chaos::slot_owner(&cluster.inner, slot))
+    }
+
+    /// Poll until `slot` is owned by a port different from `old_port`, or
+    /// timeout. Returns the new owner's port. Blocks on the cluster's
+    /// runtime. See [`crate::chaos::wait_for_slot_owner_change`].
+    pub fn wait_for_slot_owner_change(
+        cluster: &RedisClusterHandle,
+        slot: u16,
+        old_port: u16,
+        timeout: Duration,
+    ) -> Result<u16> {
+        cluster
+            .rt
+            .block_on(crate::chaos::wait_for_slot_owner_change(
+                &cluster.inner,
+                slot,
+                old_port,
+                timeout,
+            ))
+    }
+
+    /// Number of keys currently stored in `slot`. Blocks on the cluster's
+    /// runtime. See [`crate::chaos::count_keys_in_slot`].
+    pub fn count_keys_in_slot(cluster: &RedisClusterHandle, slot: u16) -> Result<usize> {
+        cluster
+            .rt
+            .block_on(crate::chaos::count_keys_in_slot(&cluster.inner, slot))
     }
 }
 

--- a/src/chaos.rs
+++ b/src/chaos.rs
@@ -544,7 +544,7 @@ async fn get_keys_in_slot(
 
 /// Compute the hash slot for a key via `CLUSTER KEYSLOT`.
 #[cfg(feature = "tokio")]
-async fn keyslot(cluster: &RedisClusterHandle, key: &str) -> Result<u16> {
+pub async fn keyslot(cluster: &RedisClusterHandle, key: &str) -> Result<u16> {
     let output = cluster.cli().run(&["CLUSTER", "KEYSLOT", key]).await?;
     let slot: u16 = output
         .trim()
@@ -553,6 +553,74 @@ async fn keyslot(cluster: &RedisClusterHandle, key: &str) -> Result<u16> {
             message: format!("could not parse CLUSTER KEYSLOT response: {output}"),
         })?;
     Ok(slot)
+}
+
+/// The port of the master node that currently owns `slot`.
+///
+/// Thin public wrapper around the same `CLUSTER NODES` lookup
+/// [`kill_master_by_slot`] and friends use internally. Returns the owner's
+/// port rather than a borrowed node handle, since `CLUSTER FAILOVER` is
+/// asynchronous (redis.io: "does not execute a failover synchronously...
+/// only schedules a manual failover") and the topology can change out from
+/// under a borrowed reference; a plain port value is what
+/// [`wait_for_slot_owner_change`] polls for and what callers can compare or
+/// store.
+#[cfg(feature = "tokio")]
+pub async fn slot_owner(cluster: &RedisClusterHandle, slot: u16) -> Result<u16> {
+    find_slot_owner(cluster, slot).await.map(|node| node.port())
+}
+
+/// Poll [`slot_owner`] until `slot` is owned by a port different from
+/// `old_port`, or timeout. Returns the new owner's port.
+///
+/// The assertion twin of [`trigger_failover`] / [`kill_master_by_slot`] /
+/// [`freeze_master_by_slot`]: since `CLUSTER FAILOVER` completes
+/// asynchronously, those functions return before the topology has actually
+/// settled, leaving tests to either sleep blindly or poll `CLUSTER NODES`
+/// themselves. Each poll is bounded so a frozen former-owner node can't hang
+/// the wait.
+#[cfg(feature = "tokio")]
+pub async fn wait_for_slot_owner_change(
+    cluster: &RedisClusterHandle,
+    slot: u16,
+    old_port: u16,
+    timeout: Duration,
+) -> Result<u16> {
+    // A `Cell` avoids the closure needing a unique (`&mut`) capture of
+    // `new_owner` across separate invocations, which the borrow checker
+    // otherwise rejects for an `FnMut` closure returning a future.
+    let new_owner = std::cell::Cell::new(old_port);
+    crate::wait::wait_for(
+        || async {
+            match tokio::time::timeout(crate::cli::HEALTH_CHECK_TIMEOUT, slot_owner(cluster, slot))
+                .await
+            {
+                Ok(Ok(port)) if port != old_port => {
+                    new_owner.set(port);
+                    true
+                }
+                _ => false,
+            }
+        },
+        timeout,
+        Duration::from_millis(250),
+        format!("slot {slot} owner did not change from port {old_port} in time"),
+    )
+    .await?;
+    Ok(new_owner.get())
+}
+
+/// Number of keys currently stored in `slot`, via `CLUSTER COUNTKEYSINSLOT`
+/// on the slot's current owner (see [`slot_owner`]).
+#[cfg(feature = "tokio")]
+pub async fn count_keys_in_slot(cluster: &RedisClusterHandle, slot: u16) -> Result<usize> {
+    let owner = find_slot_owner(cluster, slot).await?;
+    let raw = owner
+        .run(&["CLUSTER", "COUNTKEYSINSLOT", &slot.to_string()])
+        .await?;
+    raw.trim().parse().map_err(|_| Error::Timeout {
+        message: format!("could not parse CLUSTER COUNTKEYSINSLOT response: {raw}"),
+    })
 }
 
 /// Find the cluster node that owns a given slot by querying CLUSTER SLOTS.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -670,21 +670,16 @@ impl RedisCli {
 
     /// Wait until the server responds to PING or timeout expires.
     pub async fn wait_for_ready(&self, timeout: std::time::Duration) -> Result<()> {
-        let start = std::time::Instant::now();
-        loop {
-            if self.ping().await {
-                return Ok(());
-            }
-            if start.elapsed() > timeout {
-                return Err(Error::Timeout {
-                    message: format!(
-                        "{}:{} did not respond within {timeout:?}",
-                        self.host, self.port
-                    ),
-                });
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
-        }
+        crate::wait::wait_for(
+            || self.ping(),
+            timeout,
+            Duration::from_millis(250),
+            format!(
+                "{}:{} did not respond within {timeout:?}",
+                self.host, self.port
+            ),
+        )
+        .await
     }
 
     /// Run `redis-cli --cluster create ...` to form a cluster.

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::cli::RedisCli;
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::server::{
     AppendFsync, LogLevel, RedisServer, RedisServerHandle, ReplDisklessLoad, SavePolicy,
 };
@@ -1120,6 +1120,14 @@ impl RedisClusterHandle {
     /// Bounded by a modest internal timeout (not the general
     /// [`RedisServerHandle::run`] path) so a frozen node can't hang
     /// [`Self::wait_for_healthy`] forever.
+    ///
+    /// Returns healthy as soon as *any single* node reports
+    /// `cluster_state:ok` with all slots assigned -- a cheap liveness probe
+    /// against the cluster's own view of itself, not a convergence check.
+    /// This can pass while a just-recovered node still reports
+    /// `cluster_state:fail`; use [`Self::wait_for_all_healthy`] when every
+    /// node needs to independently agree the cluster has converged (e.g.
+    /// after healing a partition).
     pub async fn is_healthy(&self) -> bool {
         for node in &self.nodes {
             if let Ok(info) = node
@@ -1137,18 +1145,73 @@ impl RedisClusterHandle {
 
     /// Wait until the cluster is healthy or timeout.
     pub async fn wait_for_healthy(&self, timeout: Duration) -> Result<()> {
-        let start = std::time::Instant::now();
-        loop {
-            if self.is_healthy().await {
-                return Ok(());
-            }
-            if start.elapsed() > timeout {
-                return Err(Error::Timeout {
-                    message: "cluster did not become healthy in time".into(),
-                });
-            }
-            tokio::time::sleep(Duration::from_millis(500)).await;
-        }
+        crate::wait::wait_for(
+            || self.is_healthy(),
+            timeout,
+            Duration::from_millis(500),
+            "cluster did not become healthy in time",
+        )
+        .await
+    }
+
+    /// `CLUSTER INFO` on the node at `node_index`, parsed into a flat
+    /// key/value map (the same `key:value` line shape [`RedisServerHandle::info`]
+    /// parses).
+    ///
+    /// Common keys: `cluster_state` (`"ok"` or `"fail"`),
+    /// `cluster_slots_assigned`, `cluster_slots_ok`, `cluster_slots_pfail`,
+    /// `cluster_slots_fail`, `cluster_known_nodes`, `cluster_size`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `node_index >= total_nodes`, matching [`Self::node`].
+    pub async fn cluster_info(&self, node_index: usize) -> Result<HashMap<String, String>> {
+        let raw = self.nodes[node_index].run(&["CLUSTER", "INFO"]).await?;
+        Ok(crate::server::parse_info(&raw))
+    }
+
+    /// Wait until *every* node reports `cluster_state:ok` with
+    /// `cluster_slots_ok` equal to `cluster_slots_assigned`, or timeout.
+    ///
+    /// Unlike [`Self::is_healthy`], which returns healthy as soon as any
+    /// single node agrees, this is the convergence check partition/recover
+    /// tests need: a node that just healed from a partition can still
+    /// report `cluster_state:fail` for a window after other nodes have
+    /// already moved on. Each per-node query is bounded so an unresponsive
+    /// node counts as not-yet-healthy rather than hanging the whole wait.
+    pub async fn wait_for_all_healthy(&self, timeout: Duration) -> Result<()> {
+        crate::wait::wait_for(
+            || async {
+                for node in &self.nodes {
+                    let Ok(Ok(raw)) = tokio::time::timeout(
+                        crate::cli::HEALTH_CHECK_TIMEOUT,
+                        node.run(&["CLUSTER", "INFO"]),
+                    )
+                    .await
+                    else {
+                        return false;
+                    };
+                    let info = crate::server::parse_info(&raw);
+                    let state_ok = info.get("cluster_state").map(String::as_str) == Some("ok");
+                    let slots_assigned: u32 = info
+                        .get("cluster_slots_assigned")
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(0);
+                    let slots_ok: u32 = info
+                        .get("cluster_slots_ok")
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(0);
+                    if !state_ok || slots_ok != slots_assigned {
+                        return false;
+                    }
+                }
+                true
+            },
+            timeout,
+            Duration::from_millis(500),
+            "cluster did not converge to all-nodes-healthy in time",
+        )
+        .await
     }
 
     /// Access a specific node by index.
@@ -1446,5 +1509,33 @@ mod tests {
         assert_eq!(b.include, vec![PathBuf::from("/etc/redis/shared.conf")]);
         assert_eq!(b.tls_key_file_pass.as_deref(), Some("hunter2"));
         assert_eq!(b.tls_protocols.as_deref(), Some("TLSv1.2 TLSv1.3"));
+    }
+
+    #[test]
+    fn cluster_info_parsing_shape() {
+        // CLUSTER INFO uses the same key:value line shape INFO does; reuse
+        // the shared parser and check the fields wait_for_all_healthy reads.
+        let raw = "cluster_state:ok\r\n\
+                   cluster_slots_assigned:16384\r\n\
+                   cluster_slots_ok:16384\r\n\
+                   cluster_slots_pfail:0\r\n\
+                   cluster_slots_fail:0\r\n\
+                   cluster_known_nodes:6\r\n\
+                   cluster_size:3\r\n";
+        let map = crate::server::parse_info(raw);
+        assert_eq!(map.get("cluster_state").map(String::as_str), Some("ok"));
+        assert_eq!(
+            map.get("cluster_slots_assigned").map(String::as_str),
+            Some("16384")
+        );
+        assert_eq!(
+            map.get("cluster_slots_ok").map(String::as_str),
+            Some("16384")
+        );
+        assert_eq!(
+            map.get("cluster_known_nodes").map(String::as_str),
+            Some("6")
+        );
+        assert_eq!(map.get("cluster_size").map(String::as_str), Some("3"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,8 @@ pub mod sentinel;
 #[cfg(feature = "tokio")]
 pub mod server;
 pub mod stack;
+#[cfg(feature = "tokio")]
+pub mod wait;
 
 #[cfg(feature = "blocking")]
 pub mod blocking;

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -883,18 +883,13 @@ impl RedisSentinelHandle {
 
     /// Wait until the topology is healthy or timeout.
     pub async fn wait_for_healthy(&self, timeout: Duration) -> Result<()> {
-        let start = std::time::Instant::now();
-        loop {
-            if self.is_healthy().await {
-                return Ok(());
-            }
-            if start.elapsed() > timeout {
-                return Err(Error::Timeout {
-                    message: "sentinel topology did not become healthy in time".into(),
-                });
-            }
-            tokio::time::sleep(Duration::from_millis(500)).await;
-        }
+        crate::wait::wait_for(
+            || self.is_healthy(),
+            timeout,
+            Duration::from_millis(500),
+            "sentinel topology did not become healthy in time",
+        )
+        .await
     }
 
     /// Stop everything via an escalating shutdown strategy.

--- a/src/server.rs
+++ b/src/server.rs
@@ -2783,6 +2783,131 @@ impl RedisServerHandle {
         self.cli.run(args).await
     }
 
+    /// `INFO [section]` parsed into a flat key/value map.
+    ///
+    /// Lines are split on the first `:` since values may themselves contain
+    /// colons (e.g. `slave0:ip=127.0.0.1,port=6380,state=online,offset=1,lag=0`).
+    /// `# Section` header lines and blank lines are skipped, and a trailing
+    /// `\r` is trimmed from each line (the INFO payload is CRLF-terminated).
+    ///
+    /// Deliberately returns a flat map rather than per-section typed structs:
+    /// INFO's fields vary across Redis versions, and a flat map lets callers
+    /// pick out exactly the fields they need without this crate chasing
+    /// every field across every version.
+    pub async fn info(&self, section: Option<&str>) -> Result<HashMap<String, String>> {
+        let raw = match section {
+            Some(s) => self.run(&["INFO", s]).await?,
+            None => self.run(&["INFO"]).await?,
+        };
+        Ok(parse_info(&raw))
+    }
+
+    /// Shorthand for `info(Some("replication"))["role"]` (`"master"` or
+    /// `"slave"`).
+    pub async fn role(&self) -> Result<String> {
+        let info = self.info(Some("replication")).await?;
+        info.get("role").cloned().ok_or_else(|| Error::Timeout {
+            message: "INFO replication response did not contain a role field".into(),
+        })
+    }
+
+    /// Block until [`Self::role`] returns `role` (`"master"` or `"slave"`),
+    /// or timeout.
+    ///
+    /// Each poll is bounded by a short internal timeout so a frozen
+    /// (`SIGSTOP`ped) node can't hang the wait -- `RedisCli::run` has no read
+    /// timeout of its own. Built on [`crate::wait::wait_for`].
+    pub async fn wait_until_role(&self, role: &str, timeout: Duration) -> Result<()> {
+        crate::wait::wait_for(
+            || async {
+                matches!(
+                    tokio::time::timeout(crate::cli::HEALTH_CHECK_TIMEOUT, self.role()).await,
+                    Ok(Ok(actual)) if actual == role
+                )
+            },
+            timeout,
+            Duration::from_millis(250),
+            format!("node did not report role {role:?} within {timeout:?}"),
+        )
+        .await
+    }
+
+    /// Path to this node's log file.
+    ///
+    /// Returns `config.logfile` if the builder set one -- resolved against
+    /// the node's working directory if it was a relative path, since Redis
+    /// `chdir`s to `dir` before opening a relative `logfile` -- else the
+    /// default `{node_dir}/redis.log` the generated config pins when no
+    /// `logfile` is configured.
+    pub fn log_path(&self) -> PathBuf {
+        let node_dir = self.config.dir.join(format!("node-{}", self.config.port));
+        match self.config.logfile.as_deref() {
+            Some(logfile) => {
+                let path = PathBuf::from(logfile);
+                if path.is_absolute() {
+                    path
+                } else {
+                    node_dir.join(path)
+                }
+            }
+            None => node_dir.join("redis.log"),
+        }
+    }
+
+    /// Current byte length of [`Self::log_path`].
+    ///
+    /// Capture this before triggering a chaos operation, then pass it as
+    /// `from` to [`Self::wait_for_log`] to scope the wait to lines written
+    /// after that point -- patterns like `"Background saving terminated with
+    /// success"` can already be present in the log from startup, so waiting
+    /// from byte `0` risks matching a stale line instead of the one the
+    /// triggering call produced.
+    pub fn log_len(&self) -> Result<u64> {
+        Ok(fs::metadata(self.log_path())?.len())
+    }
+
+    /// Poll the log file until a line past byte offset `from` contains
+    /// `pattern` (plain substring match, no regex dependency), or timeout.
+    /// Returns the matching line.
+    ///
+    /// Use `from = 0` to scan the whole file from the start, or
+    /// [`Self::log_len`] captured before the triggering call to scan only
+    /// lines written afterward.
+    pub async fn wait_for_log(
+        &self,
+        pattern: &str,
+        from: u64,
+        timeout: Duration,
+    ) -> Result<String> {
+        let path = self.log_path();
+        let start = std::time::Instant::now();
+        loop {
+            if let Ok(contents) = fs::read_to_string(&path) {
+                let from = (from as usize).min(contents.len());
+                if let Some(line) = contents[from..].lines().find(|line| line.contains(pattern)) {
+                    return Ok(line.to_string());
+                }
+            }
+            if start.elapsed() > timeout {
+                return Err(Error::Timeout {
+                    message: format!(
+                        "log at {} did not contain {pattern:?} within {timeout:?}",
+                        path.display()
+                    ),
+                });
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+    }
+
+    /// Number of keys in the current database, via `DBSIZE`.
+    pub async fn dbsize(&self) -> Result<u64> {
+        let raw = self.run(&["DBSIZE"]).await?;
+        raw.trim().parse().map_err(|_| Error::Timeout {
+            message: format!("could not parse DBSIZE response: {raw}"),
+        })
+    }
+
     /// Consume the handle without stopping the server.
     pub fn detach(mut self) {
         self.detached = true;
@@ -2819,6 +2944,82 @@ impl Drop for RedisServerHandle {
             self.stop();
         }
     }
+}
+
+/// Parse `INFO`-shaped output (also used by `CLUSTER INFO`) into a flat
+/// key/value map.
+///
+/// Lines are split on the first `:` since values may themselves contain
+/// colons (e.g. `slave0:ip=127.0.0.1,port=6380,state=online,offset=1,lag=0`).
+/// `# Section` header lines and blank lines are skipped, and a trailing `\r`
+/// is trimmed from each line (the payload is CRLF-terminated).
+pub(crate) fn parse_info(raw: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for line in raw.lines() {
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once(':') {
+            map.insert(key.to_string(), value.to_string());
+        }
+    }
+    map
+}
+
+/// Block until `replica`'s replication link to `master` is up and its
+/// `slave_repl_offset` has caught up to `master`'s current
+/// `master_repl_offset`, or timeout.
+///
+/// `master`'s offset is re-sampled fresh on every poll (rather than sampled
+/// once up front) so writes that land on `master` after the wait begins are
+/// also accounted for; the offset comparison always uses a value the
+/// replica can plausibly have already replicated, which is what makes this
+/// more than a "sleep and hope" check. Each per-node query is bounded by a
+/// short internal timeout so a frozen node (e.g. one mid-partition) can't
+/// hang the wait.
+pub async fn wait_for_replica_sync(
+    replica: &RedisServerHandle,
+    master: &RedisServerHandle,
+    timeout: Duration,
+) -> Result<()> {
+    crate::wait::wait_for(
+        || async {
+            let Ok(Ok(master_info)) = tokio::time::timeout(
+                crate::cli::HEALTH_CHECK_TIMEOUT,
+                master.info(Some("replication")),
+            )
+            .await
+            else {
+                return false;
+            };
+            let Ok(Ok(replica_info)) = tokio::time::timeout(
+                crate::cli::HEALTH_CHECK_TIMEOUT,
+                replica.info(Some("replication")),
+            )
+            .await
+            else {
+                return false;
+            };
+            let master_offset: u64 = master_info
+                .get("master_repl_offset")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0);
+            let link_up = replica_info
+                .get("master_link_status")
+                .map(|s| s.as_str() == "up")
+                .unwrap_or(false);
+            let replica_offset: u64 = replica_info
+                .get("slave_repl_offset")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0);
+            link_up && replica_offset >= master_offset
+        },
+        timeout,
+        Duration::from_millis(250),
+        "replica did not catch up to master offset in time",
+    )
+    .await
 }
 
 #[cfg(test)]
@@ -3172,5 +3373,87 @@ mod tests {
             .loadmodule_with_args("/x/mod.so", ["stream-prefix", "ks:", "events"]);
         let config = s.generate_config(std::path::Path::new("/tmp/rsw-test"));
         assert!(config.contains("loadmodule \"/x/mod.so\" stream-prefix ks: events\n"));
+    }
+
+    #[test]
+    fn parse_info_splits_on_first_colon_and_skips_sections() {
+        let raw = "# Replication\r\n\
+                   role:master\r\n\
+                   connected_slaves:1\r\n\
+                   slave0:ip=127.0.0.1,port=6380,state=online,offset=100,lag=0\r\n\
+                   \r\n\
+                   # Keyspace\r\n\
+                   db0:keys=5,expires=0,avg_ttl=0\r\n";
+        let map = parse_info(raw);
+        assert_eq!(map.get("role").map(String::as_str), Some("master"));
+        assert_eq!(map.get("connected_slaves").map(String::as_str), Some("1"));
+        assert_eq!(
+            map.get("slave0").map(String::as_str),
+            Some("ip=127.0.0.1,port=6380,state=online,offset=100,lag=0")
+        );
+        assert_eq!(
+            map.get("db0").map(String::as_str),
+            Some("keys=5,expires=0,avg_ttl=0")
+        );
+        assert!(!map.contains_key("# Replication"));
+        assert_eq!(map.len(), 4);
+    }
+
+    #[test]
+    fn parse_info_ignores_blank_lines() {
+        let map = parse_info("\r\n\r\nrole:master\r\n\r\n");
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get("role").map(String::as_str), Some("master"));
+    }
+
+    fn handle_with_config(config: RedisServerConfig) -> RedisServerHandle {
+        RedisServerHandle {
+            config,
+            cli: RedisCli::new(),
+            pid: 0,
+            // Never a real process; avoid Drop trying to stop it.
+            detached: true,
+        }
+    }
+
+    #[test]
+    fn log_path_defaults_to_node_dir_redis_log() {
+        let config = RedisServerConfig {
+            port: 6400,
+            dir: PathBuf::from("/tmp/rsw-test"),
+            ..RedisServerConfig::default()
+        };
+        let handle = handle_with_config(config);
+        assert_eq!(
+            handle.log_path(),
+            PathBuf::from("/tmp/rsw-test/node-6400/redis.log")
+        );
+    }
+
+    #[test]
+    fn log_path_absolute_logfile_used_as_is() {
+        let config = RedisServerConfig {
+            port: 6400,
+            dir: PathBuf::from("/tmp/rsw-test"),
+            logfile: Some("/var/log/redis.log".to_string()),
+            ..RedisServerConfig::default()
+        };
+        let handle = handle_with_config(config);
+        assert_eq!(handle.log_path(), PathBuf::from("/var/log/redis.log"));
+    }
+
+    #[test]
+    fn log_path_relative_logfile_resolves_against_node_dir() {
+        let config = RedisServerConfig {
+            port: 6400,
+            dir: PathBuf::from("/tmp/rsw-test"),
+            logfile: Some("custom.log".to_string()),
+            ..RedisServerConfig::default()
+        };
+        let handle = handle_with_config(config);
+        assert_eq!(
+            handle.log_path(),
+            PathBuf::from("/tmp/rsw-test/node-6400/custom.log")
+        );
     }
 }

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -1,0 +1,128 @@
+//! Generic poll-until-condition combinator.
+//!
+//! [`wait_for`] is the primitive every `wait_for_*` helper in this crate
+//! (`RedisCli::wait_for_ready`, `RedisClusterHandle::wait_for_healthy`,
+//! `RedisSentinelHandle::wait_for_healthy`, and the observability waits added
+//! alongside it) is built on. It's also exported directly for test authors
+//! who need to wait on a custom predicate without writing their own sleep
+//! loop.
+
+use std::future::Future;
+use std::time::{Duration, Instant};
+
+use crate::error::{Error, Result};
+
+/// Poll `check` until it returns `true`, or fail with [`Error::Timeout`] once
+/// `timeout` has elapsed.
+///
+/// Each iteration: run `check`; if it returns `true`, return `Ok(())`
+/// immediately -- a first-try success never sleeps. Otherwise, if the
+/// elapsed time since the call began exceeds `timeout`, return
+/// `Err(Error::Timeout { message })`. Otherwise sleep for `interval` and try
+/// again.
+///
+/// `message` is preserved verbatim in the returned timeout error, so callers
+/// keep their existing, specific error text (e.g. "cluster did not become
+/// healthy in time") instead of a generic one.
+///
+/// # Example
+///
+/// ```no_run
+/// use redis_server_wrapper::wait::wait_for;
+/// use std::time::Duration;
+///
+/// # async fn example() {
+/// let mut attempts = 0;
+/// wait_for(
+///     || {
+///         attempts += 1;
+///         async move { attempts >= 3 }
+///     },
+///     Duration::from_secs(5),
+///     Duration::from_millis(100),
+///     "condition never became true",
+/// )
+/// .await
+/// .unwrap();
+/// # }
+/// ```
+pub async fn wait_for<F, Fut>(
+    mut check: F,
+    timeout: Duration,
+    interval: Duration,
+    message: impl Into<String>,
+) -> Result<()>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = bool>,
+{
+    let message = message.into();
+    let start = Instant::now();
+    loop {
+        if check().await {
+            return Ok(());
+        }
+        if start.elapsed() > timeout {
+            return Err(Error::Timeout { message });
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[tokio::test]
+    async fn succeeds_immediately_without_sleeping() {
+        let calls = AtomicU32::new(0);
+        let start = Instant::now();
+        wait_for(
+            || {
+                calls.fetch_add(1, Ordering::SeqCst);
+                async { true }
+            },
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            "should not time out",
+        )
+        .await
+        .unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(start.elapsed() < Duration::from_millis(500));
+    }
+
+    #[tokio::test]
+    async fn retries_until_true() {
+        let calls = AtomicU32::new(0);
+        wait_for(
+            || {
+                let n = calls.fetch_add(1, Ordering::SeqCst) + 1;
+                async move { n >= 3 }
+            },
+            Duration::from_secs(5),
+            Duration::from_millis(10),
+            "never became true",
+        )
+        .await
+        .unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn times_out_with_preserved_message() {
+        let err = wait_for(
+            || async { false },
+            Duration::from_millis(50),
+            Duration::from_millis(10),
+            "custom timeout message",
+        )
+        .await
+        .unwrap_err();
+        match err {
+            Error::Timeout { message } => assert_eq!(message, "custom timeout message"),
+            other => panic!("expected Error::Timeout, got {other:?}"),
+        }
+    }
+}

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -1,6 +1,9 @@
 #![cfg(feature = "blocking")]
 
-use redis_server_wrapper::blocking::{RedisCluster, RedisSentinel, RedisServer};
+use redis_server_wrapper::blocking::{
+    RedisCluster, RedisSentinel, RedisServer, chaos, wait_for, wait_for_replica_sync,
+};
+use std::time::Duration;
 
 #[test]
 fn blocking_server_start_and_ping() {
@@ -290,4 +293,97 @@ fn blocking_sentinel_monitors_multiple_masters() {
 
     drop(sentinel);
     drop(external_master);
+}
+
+#[test]
+fn blocking_wait_for_combinator() {
+    let mut calls = 0;
+    wait_for(
+        || {
+            calls += 1;
+            calls >= 3
+        },
+        Duration::from_secs(5),
+        Duration::from_millis(10),
+        "never became true",
+    )
+    .expect("wait_for should succeed once the check passes");
+    assert_eq!(calls, 3);
+
+    let err = wait_for(
+        || false,
+        Duration::from_millis(50),
+        Duration::from_millis(10),
+        "custom timeout message",
+    )
+    .expect_err("wait_for should time out when check never passes");
+    assert_eq!(err.to_string(), "custom timeout message");
+}
+
+#[test]
+fn blocking_info_role_wait_until_role_dbsize() {
+    let server = RedisServer::new()
+        .port(17940)
+        .start()
+        .expect("failed to start redis-server");
+
+    let full = server.info(None).expect("INFO failed");
+    assert!(full.contains_key("redis_version"));
+
+    assert_eq!(server.role().unwrap(), "master");
+    server
+        .wait_until_role("master", Duration::from_secs(5))
+        .expect("a freshly started standalone server should already be master");
+
+    chaos::fill_memory(&server, "k:", 42).expect("fill_memory failed");
+    assert_eq!(server.dbsize().unwrap(), 42);
+}
+
+#[test]
+fn blocking_wait_for_replica_sync_after_write() {
+    let master = RedisServer::new()
+        .port(17941)
+        .start()
+        .expect("failed to start master");
+
+    let replica = RedisServer::new()
+        .port(17942)
+        .replicaof("127.0.0.1", 17941)
+        .start()
+        .expect("failed to start replica");
+
+    replica
+        .wait_until_role("slave", Duration::from_secs(10))
+        .expect("replica did not report role slave");
+
+    master
+        .run(&["SET", "sync-key", "sync-value"])
+        .expect("SET on master failed");
+
+    wait_for_replica_sync(&replica, &master, Duration::from_secs(10))
+        .expect("replica did not catch up to master");
+
+    let val = replica.run(&["GET", "sync-key"]).expect("GET failed");
+    assert_eq!(val.trim(), "sync-value");
+}
+
+#[test]
+fn blocking_wait_for_log_after_bgsave() {
+    let server = RedisServer::new()
+        .port(17943)
+        .start()
+        .expect("failed to start redis-server");
+
+    let from = server.log_len().expect("log_len failed");
+
+    chaos::trigger_save(&server).expect("BGSAVE failed");
+
+    let line = server
+        .wait_for_log(
+            "Background saving terminated with success",
+            from,
+            Duration::from_secs(10),
+        )
+        .expect("wait_for_log did not find the bgsave completion line");
+    assert!(line.contains("Background saving terminated with success"));
 }

--- a/tests/blocking_chaos.rs
+++ b/tests/blocking_chaos.rs
@@ -82,3 +82,117 @@ fn partition_and_recover_cluster() {
         .expect("node 0 did not respond after recover");
     assert_eq!(pong.trim(), "PONG");
 }
+
+#[test]
+fn cluster_wait_for_all_healthy_and_cluster_info() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(1)
+        .base_port(17950)
+        .start()
+        .expect("failed to start cluster");
+
+    cluster
+        .wait_for_healthy(Duration::from_secs(30))
+        .expect("cluster did not become healthy");
+    cluster
+        .wait_for_all_healthy(Duration::from_secs(30))
+        .expect("cluster did not converge to all-nodes-healthy");
+
+    for index in 0..cluster.node_addrs().len() {
+        let info = cluster.cluster_info(index).expect("cluster_info failed");
+        assert_eq!(info.get("cluster_state").map(String::as_str), Some("ok"));
+    }
+}
+
+#[test]
+fn chaos_slot_helpers_and_key_count() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(0)
+        .base_port(17960)
+        .start()
+        .expect("failed to start cluster");
+
+    cluster
+        .wait_for_healthy(Duration::from_secs(30))
+        .expect("cluster did not become healthy");
+
+    let slot = chaos::keyslot(&cluster, "count-key").expect("keyslot failed");
+    assert!(slot < 16384);
+
+    let owner_port = chaos::slot_owner(&cluster, slot).expect("slot_owner failed");
+    assert!(
+        cluster
+            .node_addrs()
+            .iter()
+            .any(|a| a.ends_with(&format!(":{owner_port}")))
+    );
+
+    cluster
+        .node_run(
+            cluster
+                .node_addrs()
+                .iter()
+                .position(|a| a.ends_with(&format!(":{owner_port}")))
+                .expect("owner port not found among cluster nodes"),
+            &["SET", "count-key", "count-value"],
+        )
+        .expect("SET on slot owner failed");
+
+    let count = chaos::count_keys_in_slot(&cluster, slot).expect("count_keys_in_slot failed");
+    assert_eq!(count, 1);
+}
+
+#[test]
+fn chaos_wait_for_slot_owner_change_after_failover() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(1)
+        .base_port(17970)
+        .start()
+        .expect("failed to start cluster");
+
+    cluster
+        .wait_for_healthy(Duration::from_secs(30))
+        .expect("cluster did not become healthy");
+
+    let slot = chaos::keyslot(&cluster, "failover-slot-key").expect("keyslot failed");
+    let old_owner_port = chaos::slot_owner(&cluster, slot).expect("slot_owner failed");
+
+    let masters = cluster.num_masters() as usize;
+    let total = cluster.node_addrs().len();
+    let mut replica_index = None;
+    for index in masters..total {
+        let repl_info = cluster
+            .node_run(index, &["INFO", "replication"])
+            .expect("INFO replication failed");
+        let master_port_line = repl_info
+            .lines()
+            .find(|l| l.starts_with("master_port:"))
+            .map(|l| l.trim_end_matches('\r'));
+        if master_port_line == Some(&format!("master_port:{old_owner_port}")) {
+            replica_index = Some(index);
+            break;
+        }
+    }
+    let replica_index = replica_index.expect("no replica found for the slot's current owner");
+
+    let replica_addr = &cluster.node_addrs()[replica_index];
+    let replica_port: u16 = replica_addr
+        .rsplit(':')
+        .next()
+        .and_then(|p| p.parse().ok())
+        .expect("could not parse replica port");
+
+    cluster
+        .node_run(replica_index, &["CLUSTER", "FAILOVER"])
+        .expect("trigger_failover failed");
+
+    let new_owner_port =
+        chaos::wait_for_slot_owner_change(&cluster, slot, old_owner_port, Duration::from_secs(30))
+            .expect("wait_for_slot_owner_change failed");
+
+    assert_ne!(new_owner_port, old_owner_port);
+    assert_eq!(new_owner_port, replica_port);
+}

--- a/tests/chaos.rs
+++ b/tests/chaos.rs
@@ -191,3 +191,98 @@ async fn kill_master_by_slot_removes_node() {
         .expect("killed node not found among cluster nodes");
     assert!(!killed_node.is_alive().await);
 }
+
+#[tokio::test]
+async fn public_slot_helpers_and_key_count() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(0)
+        .base_port(17920)
+        .start()
+        .await
+        .expect("failed to start cluster");
+
+    cluster
+        .wait_for_healthy(Duration::from_secs(30))
+        .await
+        .expect("cluster did not become healthy");
+
+    let slot = chaos::keyslot(&cluster, "count-key")
+        .await
+        .expect("keyslot failed");
+    assert!(slot < 16384);
+
+    let owner_port = chaos::slot_owner(&cluster, slot)
+        .await
+        .expect("slot_owner failed");
+    let owner = cluster
+        .nodes()
+        .iter()
+        .find(|n| n.port() == owner_port)
+        .expect("slot owner port did not match any cluster node");
+    owner
+        .run(&["SET", "count-key", "count-value"])
+        .await
+        .expect("SET on slot owner failed");
+
+    let count = chaos::count_keys_in_slot(&cluster, slot)
+        .await
+        .expect("count_keys_in_slot failed");
+    assert_eq!(count, 1);
+}
+
+#[tokio::test]
+async fn wait_for_slot_owner_change_after_failover() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(1)
+        .base_port(17930)
+        .start()
+        .await
+        .expect("failed to start cluster");
+
+    cluster
+        .wait_for_healthy(Duration::from_secs(30))
+        .await
+        .expect("cluster did not become healthy");
+
+    let slot = chaos::keyslot(&cluster, "failover-slot-key")
+        .await
+        .expect("keyslot failed");
+    let old_owner_port = chaos::slot_owner(&cluster, slot)
+        .await
+        .expect("slot_owner failed");
+
+    // Find the replica that replicates the slot's current owner, via its
+    // own INFO replication view rather than assuming an index pairing --
+    // `redis-cli --cluster create` doesn't guarantee replica i replicates
+    // master i.
+    let mut target_replica = None;
+    for replica in cluster.replica_nodes() {
+        let repl_info = replica
+            .info(Some("replication"))
+            .await
+            .expect("INFO replication failed");
+        let master_port: u16 = repl_info
+            .get("master_port")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        if master_port == old_owner_port {
+            target_replica = Some(replica);
+            break;
+        }
+    }
+    let replica = target_replica.expect("no replica found for the slot's current owner");
+
+    chaos::trigger_failover(replica)
+        .await
+        .expect("trigger_failover failed");
+
+    let new_owner_port =
+        chaos::wait_for_slot_owner_change(&cluster, slot, old_owner_port, Duration::from_secs(30))
+            .await
+            .expect("wait_for_slot_owner_change failed");
+
+    assert_ne!(new_owner_port, old_owner_port);
+    assert_eq!(new_owner_port, replica.port());
+}

--- a/tests/cluster.rs
+++ b/tests/cluster.rs
@@ -1,5 +1,5 @@
 use redis_server_wrapper::RedisCluster;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[tokio::test]
 async fn cluster_start_and_health() {
@@ -264,6 +264,44 @@ async fn cluster_config_directives() {
         assert!(
             debug.to_uppercase().contains("OK"),
             "DEBUG SET-ACTIVE-EXPIRE should succeed, got: {debug}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn wait_for_all_healthy_and_cluster_info() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(1)
+        .base_port(17910)
+        .start()
+        .await
+        .expect("failed to start cluster");
+
+    // wait_for_healthy only requires one node to agree; wait_for_all_healthy
+    // additionally requires every node to independently converge.
+    cluster
+        .wait_for_healthy(Duration::from_secs(30))
+        .await
+        .expect("cluster did not become healthy");
+    cluster
+        .wait_for_all_healthy(Duration::from_secs(30))
+        .await
+        .expect("cluster did not converge to all-nodes-healthy");
+
+    for index in 0..cluster.nodes().len() {
+        let info = cluster
+            .cluster_info(index)
+            .await
+            .expect("cluster_info failed");
+        assert_eq!(info.get("cluster_state").map(String::as_str), Some("ok"));
+        assert_eq!(
+            info.get("cluster_slots_assigned").map(String::as_str),
+            Some("16384")
+        );
+        assert_eq!(
+            info.get("cluster_slots_ok").map(String::as_str),
+            Some("16384")
         );
     }
 }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,5 +1,6 @@
-use redis_server_wrapper::{Error, LogLevel, RedisServer};
+use redis_server_wrapper::{Error, LogLevel, RedisServer, chaos, server};
 use std::fs;
+use std::time::Duration;
 
 #[tokio::test]
 async fn start_and_ping() {
@@ -164,4 +165,116 @@ async fn port_already_in_use_returns_server_start_error() {
         .await;
 
     assert!(matches!(result, Err(Error::ServerStart { port: 16409 })));
+}
+
+#[tokio::test]
+async fn info_and_role_report_replication_fields() {
+    let server = RedisServer::new()
+        .port(17900)
+        .start()
+        .await
+        .expect("failed to start redis-server");
+
+    let full = server.info(None).await.expect("INFO failed");
+    assert!(full.contains_key("redis_version"));
+
+    let repl = server
+        .info(Some("replication"))
+        .await
+        .expect("INFO replication failed");
+    assert_eq!(repl.get("role").map(String::as_str), Some("master"));
+
+    assert_eq!(server.role().await.expect("role failed"), "master");
+}
+
+#[tokio::test]
+async fn wait_until_role_master_immediately() {
+    let server = RedisServer::new()
+        .port(17901)
+        .start()
+        .await
+        .expect("failed to start redis-server");
+
+    server
+        .wait_until_role("master", Duration::from_secs(5))
+        .await
+        .expect("a freshly started standalone server should already be master");
+}
+
+#[tokio::test]
+async fn wait_for_replica_sync_after_write() {
+    let master = RedisServer::new()
+        .port(17902)
+        .start()
+        .await
+        .expect("failed to start master");
+
+    let replica = RedisServer::new()
+        .port(17903)
+        .replicaof("127.0.0.1", 17902)
+        .start()
+        .await
+        .expect("failed to start replica");
+
+    replica
+        .wait_until_role("slave", Duration::from_secs(10))
+        .await
+        .expect("replica did not report role slave");
+
+    master
+        .run(&["SET", "sync-key", "sync-value"])
+        .await
+        .expect("SET on master failed");
+
+    server::wait_for_replica_sync(&replica, &master, Duration::from_secs(10))
+        .await
+        .expect("replica did not catch up to master");
+
+    let val = replica
+        .run(&["GET", "sync-key"])
+        .await
+        .expect("GET on replica failed");
+    assert_eq!(val.trim(), "sync-value");
+}
+
+#[tokio::test]
+async fn dbsize_exact_count() {
+    let server = RedisServer::new()
+        .port(17904)
+        .start()
+        .await
+        .expect("failed to start redis-server");
+
+    // fill_memory writes exactly `count` keys; DBSIZE should match exactly,
+    // not just contain the count as a substring (150 also contains "50").
+    chaos::fill_memory(&server, "k:", 150)
+        .await
+        .expect("fill_memory failed");
+
+    let size = server.dbsize().await.expect("dbsize failed");
+    assert_eq!(size, 150);
+}
+
+#[tokio::test]
+async fn wait_for_log_after_bgsave() {
+    let server = RedisServer::new()
+        .port(17905)
+        .loglevel(LogLevel::Notice)
+        .start()
+        .await
+        .expect("failed to start redis-server");
+
+    let from = server.log_len().expect("log_len failed");
+
+    chaos::trigger_save(&server).await.expect("BGSAVE failed");
+
+    let line = server
+        .wait_for_log(
+            "Background saving terminated with success",
+            from,
+            Duration::from_secs(10),
+        )
+        .await
+        .expect("wait_for_log did not find the bgsave completion line");
+    assert!(line.contains("Background saving terminated with success"));
 }


### PR DESCRIPTION
Closes #117.

## Plan

Implement the eight audited observability items (full sketches and verifier corrections in the issue), layered bottom-up:

1. Public `wait_for` poll combinator (new `src/wait.rs`), refactoring the three identical in-src loops (cli wait_for_ready, cluster and sentinel wait_for_healthy) onto it with their timeout messages preserved.
2. `info(section)` flat-map parsing and `role()` on `RedisServerHandle` (splitn(2, ':'), skip # headers; deliberately no per-section typed structs).
3. `wait_until_role` and `wait_for_replica_sync` (link up plus offset caught up).
4. Typed CLUSTER INFO parsing and `wait_for_all_healthy` on `RedisClusterHandle`: every node must report ok, closing the any-node weakness of `is_healthy`.
5. Publicize `keyslot` and the slot-owner lookup in `chaos`, plus a wait-for-owner-change helper.
6. `log_path()`, `log_len()`, and offset-scoped `wait_for_log` on `RedisServerHandle` (plain substring, no new deps).
7. `dbsize()` and `count_keys_in_slot` typed counters.
8. Blocking mirrors for every new public item; tests per item.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] `cargo test --no-default-features --features blocking`
- [ ] `cargo doc --no-deps --all-features`