### PR TITLE
feat: sentinel builder password and module support with tier-aware config

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -2239,6 +2239,12 @@ impl RedisSentinelBuilder {
         self
     }
 
+    /// Set a password for the data-node tier of the topology.
+    pub fn password(mut self, password: impl Into<String>) -> Self {
+        self.inner = self.inner.password(password);
+        self
+    }
+
     /// Set the log file path for all processes in the topology.
     pub fn logfile(mut self, path: impl Into<String>) -> Self {
         self.inner = self.inner.logfile(path);
@@ -2336,6 +2342,31 @@ impl RedisSentinelBuilder {
     /// Use TLS for replication traffic between nodes.
     pub fn tls_replication(mut self, enable: bool) -> Self {
         self.inner = self.inner.tls_replication(enable);
+        self
+    }
+
+    // -- modules --
+
+    /// Load a Redis module at startup on the master and every replica data node.
+    pub fn loadmodule(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.loadmodule(path);
+        self
+    }
+
+    /// Load a Redis module at startup on the master and every replica data
+    /// node, with load-time arguments.
+    pub fn loadmodule_with_args(
+        mut self,
+        path: impl Into<PathBuf>,
+        args: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.inner = self.inner.loadmodule_with_args(path, args);
+        self
+    }
+
+    /// Enable the MODULE command on the master and every replica data node.
+    pub fn enable_module_command(mut self, mode: impl Into<String>) -> Self {
+        self.inner = self.inner.enable_module_command(mode);
         self
     }
 

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -41,6 +41,7 @@ pub struct RedisSentinelBuilder {
     sentinel_base_port: u16,
     quorum: u16,
     bind: String,
+    password: Option<String>,
     logfile: Option<String>,
     save: Option<SavePolicy>,
     appendonly: Option<bool>,
@@ -53,6 +54,8 @@ pub struct RedisSentinelBuilder {
     tls_ca_cert_dir: Option<PathBuf>,
     tls_auth_clients: Option<bool>,
     tls_replication: Option<bool>,
+    loadmodule: Vec<(PathBuf, Vec<String>)>,
+    enable_module_command: Option<String>,
     extra: HashMap<String, String>,
     redis_server_bin: String,
     redis_cli_bin: String,
@@ -117,6 +120,23 @@ impl RedisSentinelBuilder {
     /// Set the bind address for all processes in the topology (default: `"127.0.0.1"`).
     pub fn bind(mut self, bind: impl Into<String>) -> Self {
         self.bind = bind.into();
+        self
+    }
+
+    /// Set a password for the data-node tier of the topology.
+    ///
+    /// The master and every replica get `requirepass` (so clients must
+    /// authenticate) and `masterauth` (so a demoted master can re-sync as a
+    /// replica, and replicas can sync from a newly promoted master). Every
+    /// sentinel conf gets `sentinel auth-pass <master-name> <pass>` for the
+    /// primary monitored master so sentinels can keep talking to it.
+    ///
+    /// Sentinel processes themselves do not get `requirepass`: the handle's
+    /// [`RedisSentinelHandle::poke`], [`RedisSentinelHandle::poke_master`],
+    /// and [`RedisSentinelHandle::is_healthy`] talk to sentinels
+    /// unauthenticated and must keep working unchanged.
+    pub fn password(mut self, password: impl Into<String>) -> Self {
+        self.password = Some(password.into());
         self
     }
 
@@ -209,6 +229,39 @@ impl RedisSentinelBuilder {
     /// Use TLS for replication traffic between nodes.
     pub fn tls_replication(mut self, enable: bool) -> Self {
         self.tls_replication = Some(enable);
+        self
+    }
+
+    // -- modules --
+
+    /// Load a Redis module at startup on the master and every replica data node.
+    ///
+    /// Sentinel processes do not load modules.
+    pub fn loadmodule(mut self, path: impl Into<PathBuf>) -> Self {
+        self.loadmodule.push((path.into(), Vec::new()));
+        self
+    }
+
+    /// Load a Redis module at startup on the master and every replica data
+    /// node, with load-time arguments.
+    ///
+    /// Sentinel processes do not load modules.
+    pub fn loadmodule_with_args(
+        mut self,
+        path: impl Into<PathBuf>,
+        args: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.loadmodule
+            .push((path.into(), args.into_iter().map(Into::into).collect()));
+        self
+    }
+
+    /// Enable the MODULE command (`"yes"`, `"local"`, or `"no"`) on the
+    /// master and every replica data node.
+    ///
+    /// Sentinel processes are unaffected.
+    pub fn enable_module_command(mut self, mode: impl Into<String>) -> Self {
+        self.enable_module_command = Some(mode.into());
         self
     }
 
@@ -335,22 +388,25 @@ impl RedisSentinelBuilder {
         });
         monitored_masters.extend(self.monitored_masters.iter().cloned());
 
-        // Kill leftover processes.
-        let cli_for_shutdown = |port: u16| {
-            let cli = self.apply_tls_to_cli(
-                RedisCli::new()
-                    .bin(&self.redis_cli_bin)
-                    .host(&self.bind)
-                    .port(port),
-            );
+        // Kill leftover processes. Data nodes (master, replicas) may be
+        // password-protected from a previous run; sentinels never are.
+        let cli_for_shutdown = |port: u16, authed: bool| {
+            let mut cli = RedisCli::new()
+                .bin(&self.redis_cli_bin)
+                .host(&self.bind)
+                .port(port);
+            if authed && let Some(ref password) = self.password {
+                cli = cli.password(password);
+            }
+            cli = self.apply_tls_to_cli(cli);
             cli.shutdown();
         };
-        cli_for_shutdown(self.master_port);
+        cli_for_shutdown(self.master_port, true);
         for port in self.replica_ports() {
-            cli_for_shutdown(port);
+            cli_for_shutdown(port, true);
         }
         for port in self.sentinel_ports() {
-            cli_for_shutdown(port);
+            cli_for_shutdown(port, false);
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -385,6 +441,17 @@ impl RedisSentinelBuilder {
                 SavePolicy::Custom(pairs) => master = master.save_schedule(pairs.clone()),
             }
         }
+        if let Some(ref password) = self.password {
+            // `masterauth` lets the master re-sync as a replica after a
+            // failover demotes it.
+            master = master.password(password).masterauth(password);
+        }
+        for (path, args) in &self.loadmodule {
+            master = master.loadmodule_with_args(path.clone(), args.iter().cloned());
+        }
+        if let Some(ref mode) = self.enable_module_command {
+            master = master.enable_module_command(mode.clone());
+        }
         for (key, value) in &self.extra {
             master = master.extra(key.clone(), value.clone());
         }
@@ -413,6 +480,18 @@ impl RedisSentinelBuilder {
                         replica = replica.save_schedule(pairs.clone());
                     }
                 }
+            }
+            if let Some(ref password) = self.password {
+                // `requirepass` so the replica can be promoted to master and
+                // still enforce auth; `masterauth` so it can sync from the
+                // (also password-protected) master.
+                replica = replica.password(password).masterauth(password);
+            }
+            for (path, args) in &self.loadmodule {
+                replica = replica.loadmodule_with_args(path.clone(), args.iter().cloned());
+            }
+            if let Some(ref mode) = self.enable_module_command {
+                replica = replica.enable_module_command(mode.clone());
             }
             for (key, value) in &self.extra {
                 replica = replica.extra(key.clone(), value.clone());
@@ -460,6 +539,17 @@ impl RedisSentinelBuilder {
                     down_after = self.down_after_ms,
                     failover_timeout = self.failover_timeout_ms,
                 ));
+                // `sentinel auth-pass` must follow the `sentinel monitor`
+                // line for the same master name; only the primary,
+                // builder-managed master is password-protected here.
+                if let Some(ref password) = self.password
+                    && master.name == self.master_name
+                {
+                    conf.push_str(&format!(
+                        "sentinel auth-pass {name} {password}\n",
+                        name = master.name,
+                    ));
+                }
             }
             // TLS directives for sentinels.
             if let Some(ref path) = self.tls_cert_file {
@@ -620,6 +710,7 @@ impl RedisSentinel {
             sentinel_base_port: 26389,
             quorum: 2,
             bind: "127.0.0.1".into(),
+            password: None,
             logfile: None,
             save: None,
             appendonly: None,
@@ -632,6 +723,8 @@ impl RedisSentinel {
             tls_ca_cert_dir: None,
             tls_auth_clients: None,
             tls_replication: None,
+            loadmodule: Vec::new(),
+            enable_module_command: None,
             extra: HashMap::new(),
             redis_server_bin: "redis-server".into(),
             redis_cli_bin: "redis-cli".into(),
@@ -871,6 +964,9 @@ mod tests {
         assert_eq!(b.num_sentinels, 3);
         assert_eq!(b.quorum, 2);
         assert!(b.logfile.is_none());
+        assert!(b.password.is_none());
+        assert!(b.loadmodule.is_empty());
+        assert!(b.enable_module_command.is_none());
         assert!(b.extra.is_empty());
         assert!(b.monitored_masters.is_empty());
     }
@@ -903,6 +999,31 @@ mod tests {
                 expected_replicas: 0,
             }
         );
+    }
+
+    #[test]
+    fn builder_password() {
+        let b = RedisSentinel::builder().password("secret");
+        assert_eq!(b.password.as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn builder_modules() {
+        let b = RedisSentinel::builder()
+            .loadmodule("/x/mod.so")
+            .loadmodule_with_args("/y/mod.so", ["a", "b"])
+            .enable_module_command("yes");
+        assert_eq!(
+            b.loadmodule,
+            vec![
+                (PathBuf::from("/x/mod.so"), Vec::<String>::new()),
+                (
+                    PathBuf::from("/y/mod.so"),
+                    vec!["a".to_string(), "b".to_string()]
+                ),
+            ]
+        );
+        assert_eq!(b.enable_module_command.as_deref(), Some("yes"));
     }
 
     #[test]

--- a/tests/sentinel.rs
+++ b/tests/sentinel.rs
@@ -89,3 +89,85 @@ async fn sentinel_monitors_multiple_masters() {
     drop(sentinel);
     drop(external_master);
 }
+
+#[tokio::test]
+async fn sentinel_password_auth() {
+    let sentinel = RedisSentinel::builder()
+        .master_port(17400)
+        .replicas(1)
+        .replica_base_port(17401)
+        .sentinels(3)
+        .sentinel_base_port(27400)
+        .password("testpass")
+        .start()
+        .await
+        .expect("failed to start sentinel topology");
+
+    sentinel
+        .wait_for_healthy(std::time::Duration::from_secs(30))
+        .await
+        .expect("sentinel topology did not become healthy");
+
+    // is_healthy() still works: it only ever talks to the (unauthenticated)
+    // sentinel processes, never the password-protected data nodes.
+    assert!(sentinel.is_healthy().await);
+
+    // A sentinel still discovers the master via the handle's existing
+    // discovery path.
+    let master_info = sentinel
+        .poke()
+        .await
+        .expect("failed to query master via sentinel");
+    assert_eq!(master_info.get("port").map(String::as_str), Some("17400"));
+
+    // The master rejects an unauthenticated command...
+    let unauthed = RedisCli::new().host("127.0.0.1").port(17400);
+    let unauthed_reply = unauthed
+        .run(&["GET", "foo"])
+        .await
+        .expect("redis-cli itself should not fail even on a NOAUTH reply");
+    assert!(
+        unauthed_reply.contains("NOAUTH"),
+        "expected a NOAUTH reply, got: {unauthed_reply}"
+    );
+
+    // ...and accepts the same command once authenticated.
+    let authed = RedisCli::new()
+        .host("127.0.0.1")
+        .port(17400)
+        .password("testpass");
+    authed
+        .run(&["SET", "foo", "bar"])
+        .await
+        .expect("authenticated SET should succeed");
+    let value = authed
+        .run(&["GET", "foo"])
+        .await
+        .expect("authenticated GET should succeed");
+    assert_eq!(value.trim(), "bar");
+}
+
+#[tokio::test]
+async fn sentinel_enable_module_command() {
+    let sentinel = RedisSentinel::builder()
+        .master_port(17410)
+        .replicas(1)
+        .replica_base_port(17411)
+        .sentinels(3)
+        .sentinel_base_port(27410)
+        .enable_module_command("yes")
+        .start()
+        .await
+        .expect("failed to start sentinel topology");
+
+    sentinel
+        .wait_for_healthy(std::time::Duration::from_secs(30))
+        .await
+        .expect("sentinel topology did not become healthy");
+
+    let master_cli = RedisCli::new().host("127.0.0.1").port(17410);
+    master_cli
+        .run(&["MODULE", "LIST"])
+        .await
+        .expect("MODULE LIST should succeed on the master");
+}


### PR DESCRIPTION
Closes #128.

## Plan

Implement the two audited sentinel-builder additions (ground truth and rationale in the issue):

- `password(pass)`: tier-aware emission verified against how config flows to the three process tiers: `requirepass` + `masterauth` on the master and replica data nodes, `sentinel auth-pass <master-name> <pass>` in every sentinel conf, and sentinels themselves stay unauthenticated so the handle's `poke()`/`is_healthy()` paths keep working.
- `loadmodule` / `loadmodule_with_args` / `enable_module_command`: applied to the master and replica data nodes only, mirroring what #124 added to the cluster builder.

Blocking mirrors for all four. The per-replica config hook question (replica_priority etc.) stays open in the issue and is not part of this PR.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] `cargo test --no-default-features --features blocking`
- [ ] `cargo doc --no-deps --all-features`