### PR TITLE
feat: additional chaos primitives for process, connection, and persistence faults

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -2724,6 +2724,9 @@ pub mod chaos {
     use super::{RedisClusterHandle, RedisServerHandle};
     use crate::error::Result;
     use std::time::Duration;
+    use tokio::runtime::Runtime;
+
+    pub use crate::chaos::{ClientKillFilter, ClientType, FlapGuard};
 
     /// Kill a node immediately with SIGKILL. See [`crate::chaos::kill_node`].
     pub fn kill_node(handle: &RedisServerHandle) -> Result<()> {
@@ -2919,6 +2922,138 @@ pub mod chaos {
         cluster
             .rt
             .block_on(crate::chaos::count_keys_in_slot(&cluster.inner, slot))
+    }
+
+    /// Relaunch `redis-server` from this node's existing on-disk
+    /// `redis.conf`, refreshing the handle's pid. Blocks on the handle's
+    /// runtime. See [`crate::chaos::restart_node`].
+    pub fn restart_node(handle: &mut RedisServerHandle, timeout: Duration) -> Result<()> {
+        let RedisServerHandle { inner, rt } = handle;
+        rt.block_on(crate::chaos::restart_node(inner, timeout))
+    }
+
+    /// Sever client connections matching `filter` via `CLIENT KILL`,
+    /// returning the number killed. Blocks on the handle's runtime. See
+    /// [`crate::chaos::kill_client_connections`].
+    pub fn kill_client_connections(
+        handle: &RedisServerHandle,
+        filter: ClientKillFilter,
+    ) -> Result<u64> {
+        handle
+            .rt
+            .block_on(crate::chaos::kill_client_connections(&handle.inner, filter))
+    }
+
+    /// Block the server's event loop for `duration` via `DEBUG SLEEP`.
+    ///
+    /// Enters `handle`'s runtime (via [`Runtime::enter`]) before delegating,
+    /// so the background task [`crate::chaos::block_event_loop`] spawns
+    /// internally lands on that runtime instead of panicking for lack of a
+    /// runtime context -- the same reason [`pause_node`] does this. See
+    /// [`crate::chaos::block_event_loop`].
+    pub fn block_event_loop(handle: &RedisServerHandle, duration: Duration) -> Result<()> {
+        let _guard = handle.rt.enter();
+        crate::chaos::block_event_loop(&handle.inner, duration)
+    }
+
+    /// Force the next replica reconnect on `master` to be a full resync
+    /// instead of a partial one. Blocks on the master's runtime. See
+    /// [`crate::chaos::force_full_resync`].
+    pub fn force_full_resync(master: &RedisServerHandle) -> Result<()> {
+        master
+            .rt
+            .block_on(crate::chaos::force_full_resync(&master.inner))
+    }
+
+    /// Synchronous wrapper for [`crate::chaos::PersistenceGuard`]. Restores
+    /// write access to the node's data directory and confirms persistence
+    /// has recovered.
+    pub struct PersistenceGuard<'a> {
+        inner: Option<crate::chaos::PersistenceGuard<'a>>,
+        rt: &'a Runtime,
+    }
+
+    /// Make a node's data directory unwritable so `BGSAVE` fails and
+    /// subsequent writes are rejected with `-MISCONF`. Blocks on the
+    /// handle's runtime. See [`crate::chaos::break_persistence`].
+    pub fn break_persistence(
+        handle: &RedisServerHandle,
+        timeout: Duration,
+    ) -> Result<PersistenceGuard<'_>> {
+        let inner = handle
+            .rt
+            .block_on(crate::chaos::break_persistence(&handle.inner, timeout))?;
+        Ok(PersistenceGuard {
+            inner: Some(inner),
+            rt: &handle.rt,
+        })
+    }
+
+    impl<'a> PersistenceGuard<'a> {
+        /// Restore write access and confirm persistence has recovered.
+        /// Blocks on the handle's runtime. See
+        /// [`crate::chaos::PersistenceGuard::restore`].
+        pub fn restore(mut self, timeout: Duration) -> Result<()> {
+            let inner = self
+                .inner
+                .take()
+                .expect("PersistenceGuard::restore called twice");
+            self.rt.block_on(inner.restore(timeout))
+        }
+    }
+
+    /// Synchronous wrapper for [`crate::chaos::ClientFloodGuard`]. Holds
+    /// every TCP connection opened to fill the server's `maxclients` limit.
+    pub struct ClientFloodGuard<'a> {
+        inner: Option<crate::chaos::ClientFloodGuard<'a>>,
+        rt: &'a Runtime,
+    }
+
+    /// Open and hold connections until the server's `maxclients` limit is
+    /// reached. Blocks on the handle's runtime. See
+    /// [`crate::chaos::exhaust_maxclients`].
+    pub fn exhaust_maxclients(
+        handle: &RedisServerHandle,
+        maxclients: Option<u32>,
+    ) -> Result<ClientFloodGuard<'_>> {
+        let inner = handle
+            .rt
+            .block_on(crate::chaos::exhaust_maxclients(&handle.inner, maxclients))?;
+        Ok(ClientFloodGuard {
+            inner: Some(inner),
+            rt: &handle.rt,
+        })
+    }
+
+    impl<'a> ClientFloodGuard<'a> {
+        /// Free the held sockets, then restore `maxclients` to its previous
+        /// value. Blocks on the handle's runtime. See
+        /// [`crate::chaos::ClientFloodGuard::release`].
+        pub fn release(mut self) -> Result<()> {
+            let inner = self
+                .inner
+                .take()
+                .expect("ClientFloodGuard::release called twice");
+            self.rt.block_on(inner.release())
+        }
+    }
+
+    /// Cycle a node down (`SIGSTOP`) and up (`SIGCONT`) on a timer in a
+    /// background task.
+    ///
+    /// Sends the first `SIGSTOP` synchronously (surfacing a dead target as
+    /// an error immediately), then enters `handle`'s runtime (via
+    /// [`Runtime::enter`]) before delegating, so the background flap task
+    /// [`crate::chaos::flap_node`] spawns internally lands on that runtime
+    /// instead of panicking for lack of a runtime context -- the same
+    /// reason [`pause_node`] does this. See [`crate::chaos::flap_node`].
+    pub fn flap_node(
+        handle: &RedisServerHandle,
+        down: Duration,
+        up: Duration,
+    ) -> Result<FlapGuard> {
+        let _guard = handle.rt.enter();
+        crate::chaos::flap_node(&handle.inner, down, up)
     }
 }
 

--- a/src/chaos.rs
+++ b/src/chaos.rs
@@ -40,9 +40,19 @@ use crate::error::{Error, Result};
 #[cfg(feature = "tokio")]
 use crate::server::RedisServerHandle;
 
+#[cfg(feature = "tokio")]
+use std::os::unix::fs::PermissionsExt;
+#[cfg(feature = "tokio")]
+use std::path::PathBuf;
 use std::process::Command;
 #[cfg(feature = "tokio")]
+use std::sync::Arc;
+#[cfg(feature = "tokio")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "tokio")]
 use std::time::Duration;
+#[cfg(feature = "tokio")]
+use tokio::io::AsyncReadExt;
 
 /// Send a POSIX signal to `pid` via `kill <signal_flag> <pid>`.
 ///
@@ -193,6 +203,515 @@ pub async fn fill_memory(handle: &RedisServerHandle, prefix: &str, count: usize)
         ])
         .await?;
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Process / connection / persistence fault primitives
+// ---------------------------------------------------------------------------
+
+/// Relaunch a node killed with [`kill_node`] from its existing on-disk
+/// `redis.conf`.
+///
+/// Completes the crash-recovery loop `kill_node` starts: without this, a
+/// killed node is a one-way door and tests cannot exercise client
+/// reconnect-after-crash. The config file and data directory both survive
+/// `SIGKILL`, so this replays the exact same launch path the server used the
+/// first time it started, then refreshes `handle`'s pid.
+///
+/// This proves the process comes back and answers `PING`, not that any
+/// particular key survived -- that depends entirely on the save/`appendonly`
+/// configuration the node was started with, not on this call.
+#[cfg(feature = "tokio")]
+pub async fn restart_node(handle: &mut RedisServerHandle, timeout: Duration) -> Result<()> {
+    handle.restart(timeout).await
+}
+
+/// Connection-type filter used by `CLIENT KILL TYPE`, matching the values
+/// Redis accepts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClientType {
+    /// A normal (non-replication, non-pubsub) client connection.
+    Normal,
+    /// This server's connection to its own master (i.e. this server is a
+    /// replica).
+    Master,
+    /// A connection from a replica of this server.
+    Replica,
+    /// A client subscribed via `SUBSCRIBE`/`PSUBSCRIBE`.
+    PubSub,
+}
+
+impl ClientType {
+    fn as_redis_arg(self) -> &'static str {
+        match self {
+            ClientType::Normal => "normal",
+            ClientType::Master => "master",
+            ClientType::Replica => "replica",
+            ClientType::PubSub => "pubsub",
+        }
+    }
+}
+
+/// Filter selecting which connections [`kill_client_connections`] closes.
+///
+/// At least one of `ty` / `addr` should be set: an empty filter is sent to
+/// Redis as a bare `CLIENT KILL` with no filter arguments, which Redis
+/// rejects as a syntax error. Build one directly, or use
+/// [`ClientKillFilter::of_type`] / [`ClientKillFilter::by_addr`].
+#[derive(Debug, Clone, Default)]
+pub struct ClientKillFilter {
+    /// Restrict to this connection type (`CLIENT KILL TYPE <ty>`).
+    pub ty: Option<ClientType>,
+    /// Restrict to this remote address (`CLIENT KILL ADDR <ip:port>`).
+    pub addr: Option<String>,
+}
+
+impl ClientKillFilter {
+    /// Filter by connection type only.
+    pub fn of_type(ty: ClientType) -> Self {
+        Self {
+            ty: Some(ty),
+            addr: None,
+        }
+    }
+
+    /// Filter by remote address only.
+    pub fn by_addr(addr: impl Into<String>) -> Self {
+        Self {
+            ty: None,
+            addr: Some(addr.into()),
+        }
+    }
+}
+
+/// Sever client connections matching `filter` via `CLIENT KILL`, returning
+/// the number of connections killed.
+///
+/// `SKIPME` defaults to `yes` (Redis's own default), so the `redis-cli`
+/// connection this call runs over is never counted or killed -- the harness
+/// can't accidentally cut off its own control channel.
+///
+/// This is the mechanism Redis Sentinel itself uses to force clients to
+/// reconnect after a reconfiguration: killing [`ClientType::Replica`]
+/// connections on a master forces every replica to reconnect and resync
+/// (see [`force_full_resync`] for pairing this with a full resync), and
+/// killing [`ClientType::Normal`] connections (optionally narrowed with
+/// `addr`) simulates a server-side connection reset that a client's own
+/// reconnect logic must handle. The client only notices the connection is
+/// gone the next time it sends a command.
+#[cfg(feature = "tokio")]
+pub async fn kill_client_connections(
+    handle: &RedisServerHandle,
+    filter: ClientKillFilter,
+) -> Result<u64> {
+    let mut args: Vec<String> = vec!["CLIENT".into(), "KILL".into()];
+    if let Some(ty) = filter.ty {
+        args.push("TYPE".into());
+        args.push(ty.as_redis_arg().into());
+    }
+    if let Some(addr) = filter.addr {
+        args.push("ADDR".into());
+        args.push(addr);
+    }
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let out = handle.run(&arg_refs).await?;
+    out.trim().parse::<u64>().map_err(|_| Error::Timeout {
+        message: format!("could not parse CLIENT KILL response: {out}"),
+    })
+}
+
+/// Block the server's event loop for `duration` via `DEBUG SLEEP`.
+///
+/// Requires the server to have been started with
+/// `.enable_debug_command("yes")` (Redis 7+ gates `DEBUG` behind that
+/// setting); otherwise the spawned `DEBUG SLEEP` call fails with an unknown
+/// command error that this function has no way to report back, since it
+/// returns before that reply comes in.
+///
+/// Spawns a background tokio task that issues `DEBUG SLEEP <seconds>` and
+/// returns to the caller immediately. A direct
+/// `handle.run(&["DEBUG", "SLEEP", ..])` call would block the calling task
+/// for the full duration instead: `redis-cli` doesn't get a reply until the
+/// server wakes back up, so awaiting it directly would defeat the point of a
+/// fire-and-forget fault -- the caller wants to keep running other
+/// assertions (e.g. against a *different* node, or the client under test)
+/// while this node is wedged.
+///
+/// Distinct from [`slow_down`] (`CLIENT PAUSE`, which keeps the event loop
+/// and replication alive) and [`freeze_node`] (`SIGSTOP`, which suspends the
+/// whole process): `DEBUG SLEEP` keeps the process running and connections
+/// accepted by the kernel, but the single command-processing thread never
+/// answers anything until the sleep ends -- the same shape a runaway Lua
+/// script or a large O(N) command produces in a real incident.
+#[cfg(feature = "tokio")]
+pub fn block_event_loop(handle: &RedisServerHandle, duration: Duration) -> Result<()> {
+    let cli = handle.cli().clone();
+    tokio::spawn(async move {
+        let secs = duration.as_secs_f64().to_string();
+        let _ = cli.run(&["DEBUG", "SLEEP", &secs]).await;
+    });
+    Ok(())
+}
+
+/// Force the next replica reconnect on `master` to be a full resync instead
+/// of a partial one.
+///
+/// Runs `DEBUG CHANGE-REPL-ID` to invalidate the master's replication
+/// history, then `CLIENT KILL TYPE replica` to drop the existing replica
+/// links -- when they reconnect, `PSYNC` no longer recognizes the
+/// replication ID they last saw and falls back to a full sync. Requires the
+/// server to have been started with `.enable_debug_command("yes")` (Redis 7+
+/// gates `DEBUG` behind that setting).
+///
+/// Useful for testing client and application behavior during the full-sync
+/// window: the master forking/`BGSAVE`-ing to build the snapshot, the
+/// replica flushing its dataset and reloading, and stale reads on the
+/// replica while that happens.
+#[cfg(feature = "tokio")]
+pub async fn force_full_resync(master: &RedisServerHandle) -> Result<()> {
+    master.run(&["DEBUG", "CHANGE-REPL-ID"]).await?;
+    master.run(&["CLIENT", "KILL", "TYPE", "replica"]).await?;
+    Ok(())
+}
+
+/// Returns `true` if the current process is running as root (`id -u` == 0).
+///
+/// Used to short-circuit [`break_persistence`]: chmod permission bits are
+/// ignored for root, and CI containers commonly run as root, so without this
+/// check the function would silently fail to break anything instead of
+/// erroring out.
+#[cfg(feature = "tokio")]
+fn running_as_root() -> bool {
+    Command::new("id")
+        .arg("-u")
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .map(|s| s.trim() == "0")
+        .unwrap_or(false)
+}
+
+/// Get a single scalar config value via `CONFIG GET <key>`. `redis-cli`'s
+/// raw output for `CONFIG GET` is the key name on one line followed by the
+/// value on the next; this returns just the value.
+#[cfg(feature = "tokio")]
+async fn config_get_single(handle: &RedisServerHandle, key: &str) -> Result<String> {
+    let raw = handle.run(&["CONFIG", "GET", key]).await?;
+    let mut lines = raw.lines();
+    lines.next(); // the key itself, echoed back
+    let value = lines.next().ok_or_else(|| Error::Timeout {
+        message: format!("CONFIG GET {key} returned unexpected output: {raw}"),
+    })?;
+    Ok(value.trim().to_string())
+}
+
+/// Guard returned by [`break_persistence`]. Restores write access to the
+/// node's data directory and confirms persistence has recovered.
+///
+/// If dropped without calling [`PersistenceGuard::restore`], makes a
+/// best-effort synchronous attempt to restore the directory's original
+/// permissions -- matching [`ReshardGuard`]'s Drop behavior -- but cannot
+/// run the confirming `BGSAVE`/poll since `Drop` cannot `await`. Call
+/// [`PersistenceGuard::restore`] explicitly whenever the test needs writes
+/// working again afterward.
+#[cfg(feature = "tokio")]
+pub struct PersistenceGuard<'a> {
+    handle: &'a RedisServerHandle,
+    dir: PathBuf,
+    original_mode: u32,
+    resolved: bool,
+}
+
+/// Make a node's data directory unwritable so `BGSAVE` fails and, with the
+/// default `stop-writes-on-bgsave-error yes`, subsequent writes are rejected
+/// with `-MISCONF` until [`PersistenceGuard::restore`] is called.
+///
+/// Reproduces one of the most common real Redis production incidents:
+/// clients must surface a failed-persistence `-MISCONF` correctly rather
+/// than treating it like any other error.
+///
+/// Errors immediately if the current process is running as root
+/// ([`Error::PrivilegeRequired`]): chmod permission bits are ignored for
+/// root, so nothing would actually break, and CI containers commonly run as
+/// root.
+#[cfg(feature = "tokio")]
+pub async fn break_persistence(
+    handle: &RedisServerHandle,
+    timeout: Duration,
+) -> Result<PersistenceGuard<'_>> {
+    if running_as_root() {
+        return Err(Error::PrivilegeRequired {
+            message: "break_persistence cannot chmod the data directory unwritable while \
+                      running as root (permission bits are ignored for root); refusing rather \
+                      than silently failing to break anything"
+                .to_string(),
+        });
+    }
+
+    let dir = PathBuf::from(config_get_single(handle, "dir").await?);
+    let metadata = std::fs::metadata(&dir)?;
+    let original_mode = metadata.permissions().mode();
+
+    let mut perms = metadata.permissions();
+    perms.set_mode(0o500);
+    std::fs::set_permissions(&dir, perms)?;
+
+    handle.run(&["BGSAVE"]).await?;
+
+    crate::wait::wait_for(
+        || async {
+            matches!(
+                handle.info(Some("persistence")).await,
+                Ok(info) if info.get("rdb_last_bgsave_status").map(String::as_str) == Some("err")
+            )
+        },
+        timeout,
+        Duration::from_millis(250),
+        "BGSAVE did not report a failed status after breaking persistence",
+    )
+    .await?;
+
+    Ok(PersistenceGuard {
+        handle,
+        dir,
+        original_mode,
+        resolved: false,
+    })
+}
+
+#[cfg(feature = "tokio")]
+impl<'a> PersistenceGuard<'a> {
+    /// Restore write access to the data directory, then confirm persistence
+    /// has recovered by triggering a `BGSAVE` and polling `INFO persistence`
+    /// for `rdb_last_bgsave_status:ok`.
+    ///
+    /// Writes stay rejected with `-MISCONF` until a save actually succeeds,
+    /// so restoring permissions alone is not enough to undo
+    /// [`break_persistence`].
+    pub async fn restore(mut self, timeout: Duration) -> Result<()> {
+        let mut perms = std::fs::metadata(&self.dir)?.permissions();
+        perms.set_mode(self.original_mode);
+        std::fs::set_permissions(&self.dir, perms)?;
+
+        self.handle.run(&["BGSAVE"]).await?;
+
+        crate::wait::wait_for(
+            || async {
+                matches!(
+                    self.handle.info(Some("persistence")).await,
+                    Ok(info) if info.get("rdb_last_bgsave_status").map(String::as_str) == Some("ok")
+                )
+            },
+            timeout,
+            Duration::from_millis(250),
+            "BGSAVE did not report success after restoring persistence",
+        )
+        .await?;
+
+        self.resolved = true;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl Drop for PersistenceGuard<'_> {
+    fn drop(&mut self) {
+        if self.resolved {
+            return;
+        }
+        // Best-effort: at least restore write access synchronously so the
+        // node's data directory isn't left unwritable if the test never
+        // calls `restore`. Can't await here, so this doesn't confirm BGSAVE
+        // has recovered -- call `restore` explicitly to be sure.
+        if let Ok(metadata) = std::fs::metadata(&self.dir) {
+            let mut perms = metadata.permissions();
+            perms.set_mode(self.original_mode);
+            let _ = std::fs::set_permissions(&self.dir, perms);
+        }
+    }
+}
+
+/// Guard returned by [`exhaust_maxclients`]. Holds every TCP connection
+/// opened to fill the server's `maxclients` limit, plus the previous
+/// `maxclients` value if this call lowered it.
+///
+/// Dropping the guard without calling [`ClientFloodGuard::release`] closes
+/// the held sockets (freeing up client slots) but leaves `maxclients` at the
+/// lowered value -- restoring it needs a live connection, which `Drop`
+/// cannot obtain since it cannot `await`. Call
+/// [`ClientFloodGuard::release`] explicitly to restore the limit too.
+#[cfg(feature = "tokio")]
+pub struct ClientFloodGuard<'a> {
+    handle: &'a RedisServerHandle,
+    sockets: Vec<tokio::net::TcpStream>,
+    previous_maxclients: Option<String>,
+}
+
+/// Open and hold connections until the server's `maxclients` limit is
+/// reached, so the next connection attempt is rejected with `-ERR max
+/// number of clients reached`.
+///
+/// If `maxclients` is `Some(n)`, first runs `CONFIG SET maxclients n` to
+/// lower the ceiling (remembering the previous value so
+/// [`ClientFloodGuard::release`] can restore it) -- this makes exhaustion
+/// cheap and deterministic instead of opening potentially thousands of
+/// connections. If `None`, opens connections against whatever `maxclients`
+/// is already configured.
+///
+/// Detects exhaustion by reading the reply on each newly opened connection
+/// (bounded by a short per-connection read timeout) rather than by counting
+/// connects: the kernel accept backlog completes the TCP handshake
+/// regardless of whether Redis itself has a free client slot, so only the
+/// application-level `-ERR max number of clients reached` reply (sent
+/// immediately, unprompted, before the connection is closed) tells rejection
+/// apart from a live slot.
+///
+/// While the guard is held, `handle.run()` / `handle.is_alive()` and any
+/// other new connection to this node are also rejected -- the harness's own
+/// control connections are not exempt. Call [`ClientFloodGuard::release`] to
+/// free the held sockets and restore `maxclients`.
+#[cfg(feature = "tokio")]
+pub async fn exhaust_maxclients(
+    handle: &RedisServerHandle,
+    maxclients: Option<u32>,
+) -> Result<ClientFloodGuard<'_>> {
+    let previous_maxclients = if let Some(n) = maxclients {
+        let previous = config_get_single(handle, "maxclients").await?;
+        handle
+            .run(&["CONFIG", "SET", "maxclients", &n.to_string()])
+            .await?;
+        Some(previous)
+    } else {
+        None
+    };
+
+    let effective_maxclients: usize = config_get_single(handle, "maxclients")
+        .await?
+        .parse()
+        .unwrap_or(10_000);
+    // Safety cap so a detection mismatch (e.g. an unexpected error string)
+    // can't spin this loop forever instead of returning an error.
+    let attempt_cap = effective_maxclients + 8;
+
+    let host = handle.host().to_string();
+    let port = handle.port();
+    let mut sockets = Vec::new();
+    let mut exhausted = false;
+    for _ in 0..attempt_cap {
+        let mut stream = tokio::net::TcpStream::connect((host.as_str(), port)).await?;
+        let mut buf = [0u8; 128];
+        match tokio::time::timeout(Duration::from_millis(200), stream.read(&mut buf)).await {
+            Ok(Ok(0)) => {
+                // Connection closed immediately with no data: exhausted.
+                exhausted = true;
+                break;
+            }
+            Ok(Ok(n))
+                if String::from_utf8_lossy(&buf[..n]).contains("max number of clients reached") =>
+            {
+                exhausted = true;
+                break;
+            }
+            _ => sockets.push(stream),
+        }
+    }
+
+    if !exhausted {
+        return Err(Error::Timeout {
+            message: format!(
+                "did not observe \"max number of clients reached\" within {attempt_cap} connection attempts"
+            ),
+        });
+    }
+
+    Ok(ClientFloodGuard {
+        handle,
+        sockets,
+        previous_maxclients,
+    })
+}
+
+#[cfg(feature = "tokio")]
+impl<'a> ClientFloodGuard<'a> {
+    /// Free the held sockets, then restore `maxclients` to its value before
+    /// [`exhaust_maxclients`] was called (if it lowered one).
+    ///
+    /// Order matters: sockets must close *before* the `CONFIG SET` call --
+    /// while the server is exhausted, even the harness's own `redis-cli`
+    /// invocations are rejected the same way external clients are, so there
+    /// is no free slot to run `CONFIG SET` on until connections are freed
+    /// first.
+    pub async fn release(mut self) -> Result<()> {
+        self.sockets.clear();
+        if let Some(previous) = self.previous_maxclients.take() {
+            self.handle
+                .run(&["CONFIG", "SET", "maxclients", &previous])
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+/// Guard returned by [`flap_node`]. Stops the flap loop and guarantees the
+/// node is left running (a final `SIGCONT`) when dropped.
+#[cfg(feature = "tokio")]
+pub struct FlapGuard {
+    pid: u32,
+    stop: Arc<AtomicBool>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+/// Cycle a node down (`SIGSTOP`) and up (`SIGCONT`) on a timer in a
+/// background tokio task, simulating a flapping host that repeatedly enters
+/// and leaves failure-detection windows (`cluster-node-timeout`, Sentinel's
+/// `down-after-milliseconds`). Stresses client retry/backoff logic and
+/// half-triggered failovers in a way a single [`pause_node`] does not.
+///
+/// Sends the first `SIGSTOP` immediately and returns once that signal is
+/// confirmed delivered -- the same convention [`pause_node`] uses -- so a
+/// dead target process surfaces as an error right away instead of a guard
+/// that silently never flaps. The rest of the cycle (the deferred
+/// `SIGCONT`/`SIGSTOP` pairs) runs in a background task and is best-effort,
+/// same as [`pause_node`]'s deferred resume.
+///
+/// Drop the returned [`FlapGuard`] to stop the loop; it always sends a final
+/// `SIGCONT` on drop (harmless if the node is already running), so the node
+/// is never left frozen.
+#[cfg(feature = "tokio")]
+pub fn flap_node(handle: &RedisServerHandle, down: Duration, up: Duration) -> Result<FlapGuard> {
+    let pid = handle.pid();
+    send_signal(pid, "-STOP")?;
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let task = {
+        let stop = stop.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(down).await;
+                if stop.load(Ordering::Relaxed) {
+                    break;
+                }
+                let _ = send_signal(pid, "-CONT");
+                tokio::time::sleep(up).await;
+                if stop.load(Ordering::Relaxed) {
+                    break;
+                }
+                let _ = send_signal(pid, "-STOP");
+            }
+        })
+    };
+
+    Ok(FlapGuard { pid, stop, task })
+}
+
+#[cfg(feature = "tokio")]
+impl Drop for FlapGuard {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        self.task.abort();
+        let _ = send_signal(self.pid, "-CONT");
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,6 +63,18 @@ pub enum Error {
     #[error("no reachable sentinel")]
     NoReachableSentinel,
 
+    /// A chaos primitive refused to run because doing so under the current
+    /// process privileges would have no effect.
+    ///
+    /// Currently only returned by [`crate::chaos::break_persistence`]: chmod
+    /// permission bits are ignored for the root user, so it refuses to run
+    /// as root rather than silently failing to break anything.
+    #[error("{message}")]
+    PrivilegeRequired {
+        /// Human-readable description of the refused operation and why.
+        message: String,
+    },
+
     /// A required binary was not found on PATH.
     #[error("{binary} not found on PATH")]
     BinaryNotFound {

--- a/src/server.rs
+++ b/src/server.rs
@@ -2013,80 +2013,7 @@ impl RedisServer {
 
         fs::create_dir_all(&node_dir)?;
 
-        let conf_path = node_dir.join("redis.conf");
-        let conf_content = self.generate_config(&node_dir);
-        fs::write(&conf_path, conf_content)?;
-
-        let module_args = if self.config.no_stack_modules {
-            Vec::new()
-        } else {
-            crate::stack::detect_stack_modules(&self.config.redis_server_bin)
-        };
-        let status = Command::new(&self.config.redis_server_bin)
-            .arg(&conf_path)
-            .args(&module_args)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .await?;
-
-        if !status.success() {
-            return Err(Error::ServerStart {
-                port: self.config.port,
-            });
-        }
-
-        // The plain `port` always speaks unencrypted Redis protocol; `tls-port`
-        // is the only listener that speaks TLS. When the plain port is
-        // disabled (0), the server is only reachable over `tls-port`, so the
-        // admin CLI must connect there with TLS enabled instead.
-        let tls_only = self.config.port == 0;
-        let admin_port = if tls_only {
-            self.config.tls_port.unwrap_or(self.config.port)
-        } else {
-            self.config.port
-        };
-        let mut cli = RedisCli::new()
-            .bin(&self.config.redis_cli_bin)
-            .host(&self.config.bind)
-            .port(admin_port);
-        if let Some(ref pw) = self.config.password {
-            cli = cli.password(pw);
-        }
-        if tls_only && self.config.tls_cert_file.is_some() && self.config.tls_key_file.is_some() {
-            cli = cli.tls(true);
-            if let Some(ref ca) = self.config.tls_ca_cert_file {
-                cli = cli.cacert(ca);
-            } else {
-                cli = cli.insecure(true);
-            }
-            if let Some(ref cert) = self.config.tls_cert_file {
-                cli = cli.cert(cert);
-            }
-            if let Some(ref key) = self.config.tls_key_file {
-                cli = cli.key(key);
-            }
-        }
-
-        cli.wait_for_ready(Duration::from_secs(10)).await?;
-
-        let pid_path = node_dir.join("redis.pid");
-        let pid: u32 = {
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
-            loop {
-                if let Ok(s) = fs::read_to_string(&pid_path)
-                    && let Ok(p) = s.trim().parse::<u32>()
-                {
-                    break p;
-                }
-                if std::time::Instant::now() >= deadline {
-                    return Err(Error::ServerStart {
-                        port: self.config.port,
-                    });
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-            }
-        };
+        let (cli, pid) = launch_server(&self.config, &node_dir, Duration::from_secs(10)).await?;
 
         Ok(RedisServerHandle {
             config: self.config,
@@ -2739,6 +2666,95 @@ impl Default for RedisServer {
     }
 }
 
+/// Write `config`'s conf file into `node_dir`, launch `redis-server` against
+/// it, wait for it to answer `PING`, and return a [`RedisCli`] wired up for
+/// it plus the pid it wrote to `redis.pid`.
+///
+/// Shared by [`RedisServer::start`] and [`RedisServerHandle::restart`] so a
+/// restart relaunches through the exact same path a fresh start does instead
+/// of a parallel, easily-divergent implementation.
+async fn launch_server(
+    config: &RedisServerConfig,
+    node_dir: &std::path::Path,
+    ready_timeout: Duration,
+) -> Result<(RedisCli, u32)> {
+    let conf_path = node_dir.join("redis.conf");
+    let conf_content = RedisServer {
+        config: config.clone(),
+    }
+    .generate_config(node_dir);
+    fs::write(&conf_path, conf_content)?;
+
+    let module_args = if config.no_stack_modules {
+        Vec::new()
+    } else {
+        crate::stack::detect_stack_modules(&config.redis_server_bin)
+    };
+    let status = Command::new(&config.redis_server_bin)
+        .arg(&conf_path)
+        .args(&module_args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await?;
+
+    if !status.success() {
+        return Err(Error::ServerStart { port: config.port });
+    }
+
+    // The plain `port` always speaks unencrypted Redis protocol; `tls-port`
+    // is the only listener that speaks TLS. When the plain port is
+    // disabled (0), the server is only reachable over `tls-port`, so the
+    // admin CLI must connect there with TLS enabled instead.
+    let tls_only = config.port == 0;
+    let admin_port = if tls_only {
+        config.tls_port.unwrap_or(config.port)
+    } else {
+        config.port
+    };
+    let mut cli = RedisCli::new()
+        .bin(&config.redis_cli_bin)
+        .host(&config.bind)
+        .port(admin_port);
+    if let Some(ref pw) = config.password {
+        cli = cli.password(pw);
+    }
+    if tls_only && config.tls_cert_file.is_some() && config.tls_key_file.is_some() {
+        cli = cli.tls(true);
+        if let Some(ref ca) = config.tls_ca_cert_file {
+            cli = cli.cacert(ca);
+        } else {
+            cli = cli.insecure(true);
+        }
+        if let Some(ref cert) = config.tls_cert_file {
+            cli = cli.cert(cert);
+        }
+        if let Some(ref key) = config.tls_key_file {
+            cli = cli.key(key);
+        }
+    }
+
+    cli.wait_for_ready(ready_timeout).await?;
+
+    let pid_path = node_dir.join("redis.pid");
+    let pid: u32 = {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+        loop {
+            if let Ok(s) = fs::read_to_string(&pid_path)
+                && let Ok(p) = s.trim().parse::<u32>()
+            {
+                break p;
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(Error::ServerStart { port: config.port });
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    };
+
+    Ok((cli, pid))
+}
+
 /// Handle to a running Redis server. Stops the server on Drop.
 pub struct RedisServerHandle {
     config: RedisServerConfig,
@@ -2935,6 +2951,32 @@ impl RedisServerHandle {
     /// Wait until the server is ready (PING -> PONG).
     pub async fn wait_for_ready(&self, timeout: Duration) -> Result<()> {
         self.cli.wait_for_ready(timeout).await
+    }
+
+    /// Relaunch `redis-server` from this node's existing on-disk
+    /// `redis.conf`, refreshing [`Self::pid`] from the new process.
+    ///
+    /// Backs [`crate::chaos::restart_node`], which completes the
+    /// crash-recovery loop after [`crate::chaos::kill_node`]: the config
+    /// file and data directory both survive `SIGKILL`, so this replays the
+    /// same launch path [`RedisServer::start`] uses (via [`launch_server`])
+    /// rather than a parallel implementation.
+    ///
+    /// Deletes the stale pidfile before relaunching -- after `SIGKILL` it
+    /// still holds the dead process's pid, and the pid-poll loop
+    /// [`launch_server`] runs would otherwise read it back immediately
+    /// instead of waiting for the new process's pid. Module arguments are
+    /// re-detected as part of [`launch_server`] too, since Redis Stack
+    /// modules are passed on the command line rather than baked into the
+    /// config file.
+    pub(crate) async fn restart(&mut self, timeout: Duration) -> Result<()> {
+        let node_dir = self.config.dir.join(format!("node-{}", self.config.port));
+        let _ = fs::remove_file(node_dir.join("redis.pid"));
+
+        let (cli, pid) = launch_server(&self.config, &node_dir, timeout).await?;
+        self.cli = cli;
+        self.pid = pid;
+        Ok(())
     }
 }
 

--- a/tests/blocking_chaos.rs
+++ b/tests/blocking_chaos.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "blocking")]
 
+use redis_server_wrapper::blocking::chaos::{ClientKillFilter, ClientType};
 use redis_server_wrapper::blocking::{RedisCluster, RedisServer, chaos};
 use std::time::Duration;
 
@@ -195,4 +196,139 @@ fn chaos_wait_for_slot_owner_change_after_failover() {
 
     assert_ne!(new_owner_port, old_owner_port);
     assert_eq!(new_owner_port, replica_port);
+}
+
+#[cfg_attr(not(unix), ignore)]
+#[test]
+fn restart_node_after_kill() {
+    let mut server = RedisServer::new()
+        .port(18100)
+        .start()
+        .expect("failed to start server");
+
+    assert!(server.is_alive());
+    let old_pid = server.pid();
+
+    chaos::kill_node(&server).expect("kill_node failed");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while server.is_alive() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "killed node never stopped responding"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    chaos::restart_node(&mut server, Duration::from_secs(10)).expect("restart_node failed");
+
+    assert!(server.is_alive());
+    assert_ne!(server.pid(), old_pid);
+}
+
+#[test]
+fn kill_client_connections_by_type() {
+    use std::io::Read;
+
+    let server = RedisServer::new()
+        .port(18110)
+        .start()
+        .expect("failed to start server");
+
+    let mut extra =
+        std::net::TcpStream::connect((server.host(), server.port())).expect("connect failed");
+    extra
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("set_read_timeout failed");
+
+    let killed =
+        chaos::kill_client_connections(&server, ClientKillFilter::of_type(ClientType::Normal))
+            .expect("kill_client_connections failed");
+    assert!(killed >= 1, "expected at least one client killed");
+
+    let mut buf = [0u8; 8];
+    let n = extra.read(&mut buf).expect("read failed");
+    assert_eq!(n, 0, "expected the killed connection to observe EOF");
+}
+
+#[test]
+fn break_persistence_rejects_writes_then_restores() {
+    let server = RedisServer::new()
+        .port(18120)
+        .save(true)
+        .start()
+        .expect("failed to start server");
+
+    let guard = match chaos::break_persistence(&server, Duration::from_secs(10)) {
+        Ok(guard) => guard,
+        Err(redis_server_wrapper::Error::PrivilegeRequired { message }) => {
+            eprintln!("skipping break_persistence_rejects_writes_then_restores: {message}");
+            return;
+        }
+        Err(e) => panic!("break_persistence failed: {e}"),
+    };
+
+    let result = server.run(&["SET", "k", "v"]);
+    let saw_miscount = match &result {
+        Err(e) => e.to_string().to_uppercase().contains("MISCONF"),
+        Ok(s) => s.to_uppercase().contains("MISCONF"),
+    };
+    assert!(saw_miscount, "expected a MISCONF error, got: {result:?}");
+
+    guard
+        .restore(Duration::from_secs(10))
+        .expect("restore failed");
+
+    server
+        .run(&["SET", "k", "v"])
+        .expect("SET after restore failed");
+}
+
+#[cfg_attr(not(unix), ignore)]
+#[test]
+fn flap_node_cycles_and_leaves_running_on_drop() {
+    let server = RedisServer::new()
+        .port(18130)
+        .start()
+        .expect("failed to start server");
+
+    assert!(server.is_alive());
+
+    let down = Duration::from_millis(300);
+    let up = Duration::from_millis(150);
+    let guard = chaos::flap_node(&server, down, up).expect("flap_node failed");
+
+    // `run` has no internal timeout (unlike `is_alive`), so a call that
+    // starts while the node is `SIGSTOP`ped simply waits in the kernel
+    // accept queue until the node resumes and answers: its elapsed time
+    // reveals whether it caught a down window. Repeat until one call takes
+    // a large enough chunk of the down window to prove it did.
+    let mut saw_down = false;
+    let test_deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while std::time::Instant::now() < test_deadline {
+        let start = std::time::Instant::now();
+        let _ = server.run(&["PING"]);
+        if start.elapsed() >= down / 2 {
+            saw_down = true;
+            break;
+        }
+    }
+    assert!(
+        saw_down,
+        "expected to observe at least one down window while flapping"
+    );
+
+    drop(guard);
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if server.is_alive() {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "node did not resume running after dropping FlapGuard"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
 }

--- a/tests/chaos.rs
+++ b/tests/chaos.rs
@@ -1,5 +1,7 @@
-use redis_server_wrapper::{RedisCluster, RedisServer, chaos};
+use redis_server_wrapper::chaos::{ClientKillFilter, ClientType};
+use redis_server_wrapper::{RedisCluster, RedisServer, chaos, server};
 use std::time::Duration;
+use tokio::io::AsyncReadExt;
 
 #[cfg_attr(not(unix), ignore)]
 #[tokio::test]
@@ -285,4 +287,329 @@ async fn wait_for_slot_owner_change_after_failover() {
 
     assert_ne!(new_owner_port, old_owner_port);
     assert_eq!(new_owner_port, replica.port());
+}
+
+#[cfg_attr(not(unix), ignore)]
+#[tokio::test]
+async fn restart_node_after_kill() {
+    let mut server = RedisServer::new()
+        .port(18000)
+        .start()
+        .await
+        .expect("failed to start server");
+
+    assert!(server.is_alive().await);
+    let old_pid = server.pid();
+
+    chaos::kill_node(&server).expect("kill_node failed");
+
+    // Poll until the process is confirmed dead before restarting.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while server.is_alive().await {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "killed node never stopped responding"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    chaos::restart_node(&mut server, Duration::from_secs(10))
+        .await
+        .expect("restart_node failed");
+
+    assert!(server.is_alive().await);
+    assert_ne!(server.pid(), old_pid);
+}
+
+#[tokio::test]
+async fn kill_client_connections_by_type() {
+    let server = RedisServer::new()
+        .port(18010)
+        .start()
+        .await
+        .expect("failed to start server");
+
+    // A raw connection with no command sent still registers as a `normal`
+    // client the moment Redis accepts it.
+    let mut extra = tokio::net::TcpStream::connect((server.host(), server.port()))
+        .await
+        .expect("connect failed");
+
+    let killed =
+        chaos::kill_client_connections(&server, ClientKillFilter::of_type(ClientType::Normal))
+            .await
+            .expect("kill_client_connections failed");
+    assert!(killed >= 1, "expected at least one client killed");
+
+    // The killed connection observes the close (EOF) on its next read --
+    // bounded so a wrong-filter bug can't hang the test.
+    let mut buf = [0u8; 8];
+    let n = tokio::time::timeout(Duration::from_secs(2), extra.read(&mut buf))
+        .await
+        .expect("read timed out")
+        .expect("read failed");
+    assert_eq!(n, 0, "expected the killed connection to observe EOF");
+}
+
+#[tokio::test]
+async fn kill_client_connections_by_addr() {
+    let server = RedisServer::new()
+        .port(18011)
+        .start()
+        .await
+        .expect("failed to start server");
+
+    let mut extra = tokio::net::TcpStream::connect((server.host(), server.port()))
+        .await
+        .expect("connect failed");
+    let local_addr = extra.local_addr().expect("local_addr failed");
+
+    let killed =
+        chaos::kill_client_connections(&server, ClientKillFilter::by_addr(local_addr.to_string()))
+            .await
+            .expect("kill_client_connections failed");
+    assert_eq!(killed, 1);
+
+    let mut buf = [0u8; 8];
+    let n = tokio::time::timeout(Duration::from_secs(2), extra.read(&mut buf))
+        .await
+        .expect("read timed out")
+        .expect("read failed");
+    assert_eq!(n, 0, "expected the killed connection to observe EOF");
+}
+
+#[tokio::test]
+async fn block_event_loop_blocks_then_recovers() {
+    let server = RedisServer::new()
+        .port(18020)
+        .enable_debug_command("yes")
+        .start()
+        .await
+        .expect("failed to start server");
+
+    assert!(server.is_alive().await);
+
+    chaos::block_event_loop(&server, Duration::from_secs(1)).expect("block_event_loop failed");
+
+    // Give the spawned task a moment to actually issue DEBUG SLEEP, then
+    // confirm the server is unresponsive while the sleep is in effect: a
+    // short bounded PING should time out rather than return quickly.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    let blocked = tokio::time::timeout(Duration::from_millis(200), server.run(&["PING"])).await;
+    assert!(
+        blocked.is_err(),
+        "expected PING to be blocked while DEBUG SLEEP is in effect"
+    );
+
+    // Poll until the server recovers -- bounded so a real failure doesn't
+    // hang the suite.
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if server.is_alive().await {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "server did not recover after block_event_loop"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[tokio::test]
+async fn force_full_resync_triggers_replica_full_sync() {
+    let master = RedisServer::new()
+        .port(18030)
+        .enable_debug_command("yes")
+        .start()
+        .await
+        .expect("failed to start master");
+
+    let replica = RedisServer::new()
+        .port(18031)
+        .replicaof("127.0.0.1", 18030)
+        .start()
+        .await
+        .expect("failed to start replica");
+
+    replica
+        .wait_until_role("slave", Duration::from_secs(10))
+        .await
+        .expect("replica did not report role slave");
+
+    server::wait_for_replica_sync(&replica, &master, Duration::from_secs(10))
+        .await
+        .expect("replica did not catch up initially");
+
+    // `sync_full` lives in the `# Stats` section of `INFO`, not `#
+    // Replication`.
+    let sync_full_before: u64 = master
+        .info(Some("stats"))
+        .await
+        .expect("INFO stats failed")
+        .get("sync_full")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    chaos::force_full_resync(&master)
+        .await
+        .expect("force_full_resync failed");
+
+    // Poll until the master counts a new full resync -- proves the replica
+    // reconnected via a full SYNC rather than a partial one.
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        let sync_full: u64 = master
+            .info(Some("stats"))
+            .await
+            .expect("INFO stats failed")
+            .get("sync_full")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        if sync_full > sync_full_before {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "master did not record a new full resync after force_full_resync"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // The replica should be healthy again afterward.
+    master
+        .run(&["SET", "resync-key", "resync-value"])
+        .await
+        .expect("SET on master failed");
+    server::wait_for_replica_sync(&replica, &master, Duration::from_secs(10))
+        .await
+        .expect("replica did not resync after force_full_resync");
+    let val = replica
+        .run(&["GET", "resync-key"])
+        .await
+        .expect("GET on replica failed");
+    assert_eq!(val.trim(), "resync-value");
+}
+
+#[tokio::test]
+async fn break_persistence_rejects_writes_then_restores() {
+    let server = RedisServer::new()
+        .port(18040)
+        .save(true)
+        .start()
+        .await
+        .expect("failed to start server");
+
+    let guard = match chaos::break_persistence(&server, Duration::from_secs(10)).await {
+        Ok(guard) => guard,
+        Err(redis_server_wrapper::Error::PrivilegeRequired { message }) => {
+            eprintln!("skipping break_persistence_rejects_writes_then_restores: {message}");
+            return;
+        }
+        Err(e) => panic!("break_persistence failed: {e}"),
+    };
+
+    let result = server.run(&["SET", "k", "v"]).await;
+    let saw_miscount = match &result {
+        Err(e) => e.to_string().to_uppercase().contains("MISCONF"),
+        Ok(s) => s.to_uppercase().contains("MISCONF"),
+    };
+    assert!(saw_miscount, "expected a MISCONF error, got: {result:?}");
+
+    guard
+        .restore(Duration::from_secs(10))
+        .await
+        .expect("restore failed");
+
+    server
+        .run(&["SET", "k", "v"])
+        .await
+        .expect("SET after restore failed");
+}
+
+#[tokio::test]
+async fn exhaust_maxclients_rejects_new_connections() {
+    let server = RedisServer::new()
+        .port(18050)
+        .start()
+        .await
+        .expect("failed to start server");
+
+    let guard = chaos::exhaust_maxclients(&server, Some(5))
+        .await
+        .expect("exhaust_maxclients failed");
+
+    // While exhausted, a fresh connection should be rejected immediately.
+    let mut extra = tokio::net::TcpStream::connect((server.host(), server.port()))
+        .await
+        .expect("connect failed");
+    let mut buf = [0u8; 128];
+    let n = tokio::time::timeout(Duration::from_secs(2), extra.read(&mut buf))
+        .await
+        .expect("read timed out")
+        .expect("read failed");
+    assert!(
+        String::from_utf8_lossy(&buf[..n]).contains("max number of clients reached"),
+        "expected a max-clients rejection"
+    );
+
+    guard.release().await.expect("release failed");
+
+    // After release, the server accepts and answers commands again.
+    let pong = server
+        .run(&["PING"])
+        .await
+        .expect("PING failed after release");
+    assert_eq!(pong.trim(), "PONG");
+}
+
+#[cfg_attr(not(unix), ignore)]
+#[tokio::test]
+async fn flap_node_cycles_and_leaves_running_on_drop() {
+    let server = RedisServer::new()
+        .port(18060)
+        .start()
+        .await
+        .expect("failed to start server");
+
+    assert!(server.is_alive().await);
+
+    let guard = chaos::flap_node(
+        &server,
+        Duration::from_millis(150),
+        Duration::from_millis(150),
+    )
+    .expect("flap_node failed");
+
+    // Poll-based: expect to observe at least one "down" window within a few
+    // cycles.
+    let mut saw_down = false;
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        let ping = tokio::time::timeout(Duration::from_millis(80), server.is_alive()).await;
+        if !matches!(ping, Ok(true)) {
+            saw_down = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(30)).await;
+    }
+    assert!(
+        saw_down,
+        "expected to observe at least one down window while flapping"
+    );
+
+    drop(guard);
+
+    // Poll until the node is confirmed running again after the guard drops.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if server.is_alive().await {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "node did not resume running after dropping FlapGuard"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 }


### PR DESCRIPTION
Closes #118.

## Plan

Implement the seven verified primitives from the audit (sketches, evidence, and verifier corrections in the issue), reusing the post-#122 `send_signal` helper and the `Result`-returning chaos convention:

- `restart_node(&mut RedisServerHandle, timeout)`: relaunch a killed node from its on-disk `redis.conf`, refreshing the stored pid. Reuses `start()`'s node-dir/conf/pidfile internals; handles the stale-pidfile race noted by the verifier.
- `kill_client_connections`: CLIENT KILL with TYPE/ADDR filters, returning the count killed.
- `block_event_loop`: DEBUG SLEEP (fire-and-forget; requires `enable_debug_command`, documented).
- `force_full_resync`: DEBUG CHANGE-REPL-ID + CLIENT KILL TYPE replica.
- `break_persistence`: repoint/chmod the data dir so BGSAVE fails and writes hit -MISCONF, with a restore path.
- `exhaust_maxclients`: hold idle sockets to the maxclients limit, returning a guard.
- `flap_node`: cycle SIGSTOP/SIGCONT on a timer via a spawned task, returning a guard.

Blocking mirrors in `blocking::chaos`; new `Error` variants only where nothing fits; tests per primitive.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] `cargo test --no-default-features --features blocking`
- [ ] `cargo doc --no-deps --all-features`