### PR TITLE
feat: sentinel chaos support with node access and failover observation

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -2630,6 +2630,22 @@ impl RedisSentinelBuilder {
 }
 
 /// Handle to a running Redis Sentinel topology. Stops everything on Drop.
+///
+/// Unlike [`RedisClusterHandle`] (which exposes cluster-level chaos helpers
+/// that resolve node indices internally, e.g. [`chaos::kill_master_by_slot`]),
+/// this handle does not mirror
+/// [`crate::sentinel::RedisSentinelHandle::master`] or
+/// [`crate::sentinel::RedisSentinelHandle::replicas`]. Each async
+/// `RedisServerHandle` those return is not on this handle's [`Runtime`], and
+/// wrapping one would need its own dedicated runtime the way top-level
+/// blocking handles do -- awkward for a borrowed reference into an existing
+/// topology. Node-targeted chaos against sentinel data nodes (e.g.
+/// `chaos::kill_node` on the master) is therefore async-only; use
+/// [`crate::sentinel::RedisSentinelHandle`] directly for that. What *is*
+/// mirrored here -- [`Self::wait_for_new_master`] and
+/// [`chaos::crash_sentinel_during_failover`] -- is self-contained: both work
+/// entirely through `redis-cli` calls driven by this handle's own runtime,
+/// with no node handle to bridge.
 pub struct RedisSentinelHandle {
     inner: sentinel::RedisSentinelHandle,
     rt: Runtime,
@@ -2699,6 +2715,14 @@ impl RedisSentinelHandle {
         self.rt.block_on(self.inner.wait_for_healthy(timeout))
     }
 
+    /// Poll until sentinel reports a healthy master at an address different
+    /// from `old_addr`, or timeout. Returns the new master's `"ip:port"`.
+    /// See [`crate::sentinel::RedisSentinelHandle::wait_for_new_master`].
+    pub fn wait_for_new_master(&self, old_addr: &str, timeout: Duration) -> Result<String> {
+        self.rt
+            .block_on(self.inner.wait_for_new_master(old_addr, timeout))
+    }
+
     /// Stop everything.
     pub fn stop(&self) {
         self.inner.stop();
@@ -2721,12 +2745,14 @@ impl RedisSentinelHandle {
 /// natural blocking shape. Use the async API directly if you need deterministic
 /// control over an in-flight slot migration.
 pub mod chaos {
-    use super::{RedisClusterHandle, RedisServerHandle};
+    use super::{RedisClusterHandle, RedisSentinelHandle, RedisServerHandle};
     use crate::error::Result;
     use std::time::Duration;
     use tokio::runtime::Runtime;
 
     pub use crate::chaos::{ClientKillFilter, ClientType, FlapGuard};
+
+    pub use crate::chaos::SentinelCrashPoint;
 
     /// Kill a node immediately with SIGKILL. See [`crate::chaos::kill_node`].
     pub fn kill_node(handle: &RedisServerHandle) -> Result<()> {
@@ -3054,6 +3080,23 @@ pub mod chaos {
     ) -> Result<FlapGuard> {
         let _guard = handle.rt.enter();
         crate::chaos::flap_node(&handle.inner, down, up)
+    }
+
+    /// Arm a sentinel to crash mid-failover, then trigger the failover on
+    /// that same sentinel. Blocks on the handle's runtime. See
+    /// [`crate::chaos::crash_sentinel_during_failover`].
+    pub fn crash_sentinel_during_failover(
+        handle: &RedisSentinelHandle,
+        sentinel_idx: usize,
+        point: SentinelCrashPoint,
+    ) -> Result<()> {
+        handle
+            .rt
+            .block_on(crate::chaos::crash_sentinel_during_failover(
+                &handle.inner,
+                sentinel_idx,
+                point,
+            ))
     }
 }
 

--- a/src/chaos.rs
+++ b/src/chaos.rs
@@ -38,6 +38,8 @@ use crate::cluster::RedisClusterHandle;
 #[cfg(feature = "tokio")]
 use crate::error::{Error, Result};
 #[cfg(feature = "tokio")]
+use crate::sentinel::RedisSentinelHandle;
+#[cfg(feature = "tokio")]
 use crate::server::RedisServerHandle;
 
 #[cfg(feature = "tokio")]
@@ -809,6 +811,60 @@ pub fn recover(cluster: &RedisClusterHandle) -> Result<()> {
         Some(e) => Err(e),
         None => Ok(()),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Sentinel-level operations
+// ---------------------------------------------------------------------------
+
+/// Which point in a failover to crash a sentinel at, via `SENTINEL
+/// SIMULATE-FAILURE`.
+///
+/// Both points are implemented in Redis's `sentinel.c` (since Redis 3.2),
+/// purpose-built for testing an interrupted failover: the armed sentinel
+/// crashes immediately after reaching the chosen point, leaving another
+/// sentinel to notice and finish the job.
+#[cfg(feature = "tokio")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SentinelCrashPoint {
+    /// Crash immediately after winning the leader election, before
+    /// promoting the replica.
+    AfterElection,
+    /// Crash immediately after promoting the replica to master.
+    AfterPromotion,
+}
+
+/// Arm a sentinel to crash mid-failover, then trigger the failover on that
+/// same sentinel.
+///
+/// `SENTINEL FAILOVER` is executed by the sentinel that receives it, so the
+/// sentinel armed via `SENTINEL SIMULATE-FAILURE` must also be the one that
+/// triggers the failover -- arming one sentinel and triggering on another
+/// would never exercise the crash at all.
+///
+/// Both `SIMULATE-FAILURE` and `FAILOVER` reply `+OK` before the process
+/// actually crashes, so a successful `Ok(())` here means the crash was armed
+/// and the failover requested, not that the crash has already happened. The
+/// targeted sentinel process crashes and is left down afterward -- this
+/// crate does not restart it; [`RedisSentinelHandle`]'s `stop()`/`Drop`
+/// already tolerate a dead sentinel PID. The topology is intentionally left
+/// with one fewer sentinel for the remaining sentinels to finish the
+/// failover.
+#[cfg(feature = "tokio")]
+pub async fn crash_sentinel_during_failover(
+    handle: &RedisSentinelHandle,
+    sentinel_idx: usize,
+    point: SentinelCrashPoint,
+) -> Result<()> {
+    let cli = handle.sentinel_cli(sentinel_idx)?;
+    let mode = match point {
+        SentinelCrashPoint::AfterElection => "crash-after-election",
+        SentinelCrashPoint::AfterPromotion => "crash-after-promotion",
+    };
+    cli.run(&["SENTINEL", "SIMULATE-FAILURE", mode]).await?;
+    cli.run(&["SENTINEL", "FAILOVER", handle.master_name()])
+        .await?;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,15 @@ pub enum Error {
         message: String,
     },
 
+    /// A sentinel index passed to a per-sentinel operation was out of range.
+    #[error("sentinel index {index} out of range (topology has {len} sentinels)")]
+    SentinelIndex {
+        /// The requested index.
+        index: usize,
+        /// The number of sentinels actually running.
+        len: usize,
+    },
+
     /// A required binary was not found on PATH.
     #[error("{binary} not found on PATH")]
     BinaryNotFound {

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -680,7 +680,6 @@ impl TlsConfig {
 /// A running Redis Sentinel topology. Stops everything on Drop.
 pub struct RedisSentinelHandle {
     master: RedisServerHandle,
-    #[allow(dead_code)] // Kept alive for Drop cleanup
     replicas: Vec<RedisServerHandle>,
     sentinel_ports: Vec<u16>,
     sentinel_pids: Vec<u32>,
@@ -754,6 +753,56 @@ impl RedisSentinelHandle {
                 .host(&self.bind)
                 .port(self.sentinel_ports[0]),
         )
+    }
+
+    /// Build a `RedisCli` targeting the sentinel at `index` (applies TLS and
+    /// the configured `redis-cli` binary, the same way [`Self::cli`] does for
+    /// the seed sentinel).
+    ///
+    /// Internal: used by [`crate::chaos::crash_sentinel_during_failover`] to
+    /// reach an arbitrary sentinel by index. Not exposed publicly because a
+    /// caller composing this externally from [`Self::sentinel_addrs`] would
+    /// silently lose the TLS settings and custom `redis-cli` binary applied
+    /// here.
+    pub(crate) fn sentinel_cli(&self, index: usize) -> Result<RedisCli> {
+        let port = self
+            .sentinel_ports
+            .get(index)
+            .copied()
+            .ok_or(Error::SentinelIndex {
+                index,
+                len: self.sentinel_ports.len(),
+            })?;
+        Ok(self.tls.apply(
+            RedisCli::new()
+                .bin(&self.redis_cli_bin)
+                .host(&self.bind)
+                .port(port),
+        ))
+    }
+
+    /// The initially-started master data node.
+    ///
+    /// Does **not** track failover: after sentinel promotes a replica, this
+    /// handle still points at the original master process, which is now
+    /// demoted (or dead, if it was killed to trigger the failover). Pass it
+    /// to [`crate::chaos`] functions -- e.g. [`crate::chaos::kill_node`] or
+    /// [`crate::chaos::freeze_node`] -- to inject a real fault against the
+    /// master and drive an actual sentinel-managed failover; pair with
+    /// [`Self::wait_for_new_master`] to observe the promotion completing.
+    pub fn master(&self) -> &RedisServerHandle {
+        &self.master
+    }
+
+    /// The initially-started replica data nodes (same caveat as
+    /// [`Self::master`]: after a failover, roles may no longer match this
+    /// startup ordering).
+    ///
+    /// Pass individual entries to [`crate::chaos`] functions to fault a
+    /// specific replica, e.g. to test how the topology reacts to a replica
+    /// going down independently of the master.
+    pub fn replicas(&self) -> &[RedisServerHandle] {
+        &self.replicas
     }
 
     /// All monitored master names.
@@ -890,6 +939,52 @@ impl RedisSentinelHandle {
             "sentinel topology did not become healthy in time",
         )
         .await
+    }
+
+    /// Poll `SENTINEL MASTER <name>` (via [`Self::poke_master`]'s underlying
+    /// discovery path) until it reports a healthy `master` (no `o_down` /
+    /// `s_down`) at an address different from `old_addr`, or timeout. Returns
+    /// the new master's `"ip:port"`.
+    ///
+    /// The assertion twin of faulting the master directly through
+    /// [`Self::master`] and [`crate::chaos`] (e.g. `chaos::kill_node`): those
+    /// calls return as soon as the signal is delivered, well before sentinel
+    /// has actually elected and promoted a replacement. This polls the
+    /// sentinels' own view of the topology until the promotion has actually
+    /// completed, rather than sleeping a fixed, guessed duration.
+    ///
+    /// Requiring `flags == "master"` -- not just a changed address -- avoids
+    /// returning during the subjective-down window before a replacement has
+    /// actually been elected, where sentinel may still report the old
+    /// address with a down flag.
+    pub async fn wait_for_new_master(&self, old_addr: &str, timeout: Duration) -> Result<String> {
+        let found = std::cell::Cell::new(String::new());
+        crate::wait::wait_for(
+            || async {
+                let Ok(info) = self
+                    .poke_master_bounded(&self.master_name, Some(crate::cli::HEALTH_CHECK_TIMEOUT))
+                    .await
+                else {
+                    return false;
+                };
+                let flags = info.get("flags").map(String::as_str).unwrap_or("");
+                let (Some(ip), Some(port)) = (info.get("ip"), info.get("port")) else {
+                    return false;
+                };
+                let addr = format!("{ip}:{port}");
+                if flags == "master" && addr != old_addr {
+                    found.set(addr);
+                    true
+                } else {
+                    false
+                }
+            },
+            timeout,
+            Duration::from_millis(500),
+            format!("no new master (differing from {old_addr}) reported in time"),
+        )
+        .await?;
+        Ok(found.into_inner())
     }
 
     /// Stop everything via an escalating shutdown strategy.

--- a/tests/sentinel.rs
+++ b/tests/sentinel.rs
@@ -1,5 +1,6 @@
-use redis_server_wrapper::{RedisCli, RedisSentinel, RedisServer};
-use std::time::{SystemTime, UNIX_EPOCH};
+use redis_server_wrapper::chaos::SentinelCrashPoint;
+use redis_server_wrapper::{RedisCli, RedisSentinel, RedisServer, chaos};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[tokio::test]
 async fn sentinel_start_and_health() {
@@ -170,4 +171,114 @@ async fn sentinel_enable_module_command() {
         .run(&["MODULE", "LIST"])
         .await
         .expect("MODULE LIST should succeed on the master");
+}
+
+#[tokio::test]
+async fn sentinel_node_access() {
+    let sentinel = RedisSentinel::builder()
+        .master_port(18100)
+        .replicas(2)
+        .replica_base_port(18101)
+        .sentinels(3)
+        .sentinel_base_port(28100)
+        .start()
+        .await
+        .expect("failed to start sentinel topology");
+
+    sentinel
+        .wait_for_healthy(Duration::from_secs(30))
+        .await
+        .expect("sentinel topology did not become healthy");
+
+    let master = sentinel.master();
+    assert_eq!(master.port(), 18100);
+    assert!(
+        master.is_alive().await,
+        "master should respond to PING through its handle"
+    );
+
+    let replicas = sentinel.replicas();
+    assert_eq!(replicas.len(), 2, "expected exactly 2 replica handles");
+    for replica in replicas {
+        assert!(
+            replica.is_alive().await,
+            "each replica should respond to PING through its handle"
+        );
+    }
+}
+
+#[tokio::test]
+async fn sentinel_kill_master_triggers_promotion() {
+    let sentinel = RedisSentinel::builder()
+        .master_port(18110)
+        .replicas(1)
+        .replica_base_port(18111)
+        .sentinels(3)
+        .sentinel_base_port(28110)
+        .down_after_ms(2000)
+        .failover_timeout_ms(10000)
+        .start()
+        .await
+        .expect("failed to start sentinel topology");
+
+    sentinel
+        .wait_for_healthy(Duration::from_secs(30))
+        .await
+        .expect("sentinel topology did not become healthy");
+
+    let old_addr = sentinel.master_addr();
+
+    // Kill the master directly via its exposed handle -- this is the whole
+    // point of `master()`: chaos functions that only ever took
+    // `&RedisServerHandle` now reach sentinel-managed data nodes.
+    chaos::kill_node(sentinel.master()).expect("failed to send SIGKILL to the master");
+
+    let new_addr = sentinel
+        .wait_for_new_master(&old_addr, Duration::from_secs(30))
+        .await
+        .expect("sentinel did not promote a new master in time");
+
+    assert_ne!(
+        new_addr, old_addr,
+        "sentinel should have promoted a different node as master"
+    );
+}
+
+#[tokio::test]
+async fn sentinel_simulate_failure_crash_after_election() {
+    let sentinel = RedisSentinel::builder()
+        .master_port(18120)
+        .replicas(1)
+        .replica_base_port(18121)
+        .sentinels(3)
+        .sentinel_base_port(28120)
+        .start()
+        .await
+        .expect("failed to start sentinel topology");
+
+    sentinel
+        .wait_for_healthy(Duration::from_secs(30))
+        .await
+        .expect("sentinel topology did not become healthy");
+
+    // Arm sentinel index 0 (port 28120) to crash right after it wins the
+    // failover election, then trigger the failover on that same sentinel.
+    // Both commands reply +OK before the process actually dies, so success
+    // here means the crash was armed and the failover requested.
+    chaos::crash_sentinel_during_failover(&sentinel, 0, SentinelCrashPoint::AfterElection)
+        .await
+        .expect("SENTINEL SIMULATE-FAILURE + FAILOVER should succeed");
+
+    // Optionally confirm the effect: the armed sentinel should stop
+    // responding once it actually crashes. Bounded, poll-based -- not a
+    // fixed sleep -- so it can't hang if the crash is slow to land.
+    let armed_sentinel = RedisCli::new().host("127.0.0.1").port(28120);
+    redis_server_wrapper::wait::wait_for(
+        || async { !armed_sentinel.ping().await },
+        Duration::from_secs(30),
+        Duration::from_millis(250),
+        "armed sentinel did not crash after simulated failure in time",
+    )
+    .await
+    .expect("armed sentinel should stop responding after crashing");
 }


### PR DESCRIPTION
Closes #119.

## Plan

Unlock sentinel topologies for the chaos module (they are unreachable today because `RedisSentinelHandle` hides its data-node handles):

- `master()` and `replicas()` accessors on `RedisSentinelHandle` returning `&RedisServerHandle` / `&[RedisServerHandle]`, so the existing `chaos::` functions and the new observability helpers work on sentinel data nodes. Removes the `#[allow(dead_code)]` on the `replicas` field.
- A promotion wait: block until a new master is elected after the current one is killed, built on the handle's existing `poke_master` discovery and the `wait::wait_for` combinator.
- `sentinel-crash-during-failover` via `SENTINEL SIMULATE-FAILURE crash-after-election` / `crash-after-promotion`, reaching each sentinel (not just the seed) through the handle's sentinel port list.

Blocking mirrors on the blocking sentinel handle. This PR does not add the per-replica config hook (recorded as an open question in the issue).

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] `cargo test --no-default-features --features blocking`
- [ ] `cargo doc --no-deps --all-features`