### PR TITLE
fix: surface Redis error replies as errors

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -170,7 +170,7 @@ impl RedisCli {
             stdin_tag_arg: false,
             multi_bulk_delimiter: None,
             output_delimiter: None,
-            exit_error_code: false,
+            exit_error_code: true,
             no_raw: false,
             quoted_input: false,
             show_pushes: None,
@@ -392,7 +392,17 @@ impl RedisCli {
         self
     }
 
-    /// Return exit error code on server errors (`-e`).
+    /// Return a non-zero exit code on Redis error replies (`-e`, default: on).
+    ///
+    /// Without this, redis-cli exits 0 whenever it successfully round-trips
+    /// with the server, whether the reply was a value or an error, so
+    /// [`run`](Self::run) cannot tell the two apart and returns the error text
+    /// as if it were data.
+    ///
+    /// A nil reply for a missing key is not an error and still exits 0, so
+    /// this does not turn an absent key into a failure.
+    ///
+    /// Disable it only when you specifically want the error text as a value.
     pub fn exit_error_code(mut self, enable: bool) -> Self {
         self.exit_error_code = enable;
         self
@@ -628,17 +638,36 @@ impl RedisCli {
     }
 
     /// Run a command and return stdout on success.
+    ///
+    /// A Redis error reply is a failure: with `-e` in force (the default, see
+    /// [`exit_error_code`](Self::exit_error_code)) redis-cli exits non-zero
+    /// for `NOAUTH`, `ERR`, `WRONGTYPE`, `MOVED`, and the rest, and this
+    /// returns [`Error::Cli`] carrying the error text.
     pub async fn run(&self, args: &[&str]) -> Result<String> {
         let output = self.raw_output(args).await?;
         if output.status.success() {
             Ok(String::from_utf8_lossy(&output.stdout).to_string())
         } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            Err(Error::Cli {
-                host: self.host.clone(),
-                port: self.port,
-                detail: stderr.into_owned(),
-            })
+            Err(self.cli_error(&output))
+        }
+    }
+
+    /// Build a [`Error::Cli`] from a failed invocation.
+    ///
+    /// redis-cli writes a Redis error reply to stdout, not stderr, and only
+    /// uses stderr for its own failures (a refused connection, a bad flag).
+    /// Prefer whichever carries the message.
+    fn cli_error(&self, output: &Output) -> Error {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let detail = if stderr.trim().is_empty() {
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        } else {
+            stderr.trim().to_string()
+        };
+        Error::Cli {
+            host: self.host.clone(),
+            port: self.port,
+            detail,
         }
     }
 
@@ -1010,12 +1039,7 @@ impl RedisCli {
         if output.status.success() {
             Ok(String::from_utf8_lossy(&output.stdout).to_string())
         } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            Err(Error::Cli {
-                host: self.host.clone(),
-                port: self.port,
-                detail: stderr.into_owned(),
-            })
+            Err(self.cli_error(&output))
         }
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,4 +1,4 @@
-use redis_server_wrapper::{RedisCli, RedisServer};
+use redis_server_wrapper::{Error, RedisCli, RedisServer};
 
 #[tokio::test]
 async fn cli_ping_running_server() {
@@ -39,4 +39,119 @@ async fn cli_wait_for_ready_timeout() {
         .wait_for_ready(std::time::Duration::from_millis(500))
         .await;
     assert!(result.is_err());
+}
+
+// -- Redis error replies (#143) --
+//
+// redis-cli exits 0 whenever it successfully round-trips with the server,
+// whether the reply was a value or an error. `-e` (on by default, see
+// `RedisCli::exit_error_code`) makes error replies exit non-zero so `run` can
+// tell them apart from data.
+
+#[tokio::test]
+async fn error_reply_is_an_error() {
+    let server = RedisServer::new()
+        .port(16920)
+        .password("secret")
+        .start()
+        .await
+        .expect("failed to start redis-server");
+
+    let unauthed = RedisCli::new().host(server.host()).port(server.port());
+    let result = unauthed.run(&["GET", "k"]).await;
+
+    match result {
+        Err(Error::Cli { detail, port, .. }) => {
+            assert!(detail.contains("NOAUTH"), "detail lost the reply: {detail}");
+            assert_eq!(port, 16920);
+        }
+        other => panic!("expected Error::Cli for a NOAUTH reply, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn wrongtype_reply_is_an_error() {
+    let server = RedisServer::new()
+        .port(16921)
+        .start()
+        .await
+        .expect("failed to start redis-server");
+
+    server.run(&["LPUSH", "list", "a"]).await.unwrap();
+    let result = server.run(&["GET", "list"]).await;
+
+    assert!(
+        matches!(result, Err(Error::Cli { ref detail, .. }) if detail.contains("WRONGTYPE")),
+        "expected WRONGTYPE to be an error, got: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn missing_key_is_not_an_error() {
+    // A nil reply is absence, not failure. This is the case that would break
+    // if error detection keyed on an empty reply rather than the exit code.
+    let server = RedisServer::new()
+        .port(16922)
+        .start()
+        .await
+        .expect("failed to start redis-server");
+
+    let value = server
+        .run(&["GET", "never-set"])
+        .await
+        .expect("a missing key must not be an error");
+    assert!(value.trim().is_empty(), "unexpected value: {value:?}");
+}
+
+#[tokio::test]
+async fn successful_command_still_returns_its_value() {
+    let server = RedisServer::new()
+        .port(16923)
+        .start()
+        .await
+        .expect("failed to start redis-server");
+
+    server.run(&["SET", "k", "v"]).await.unwrap();
+    let value = server.run(&["GET", "k"]).await.unwrap();
+    assert_eq!(value.trim(), "v");
+}
+
+#[tokio::test]
+async fn ping_is_false_when_unauthenticated() {
+    let server = RedisServer::new()
+        .port(16924)
+        .password("secret")
+        .start()
+        .await
+        .expect("failed to start redis-server");
+
+    let unauthed = RedisCli::new().host(server.host()).port(server.port());
+    assert!(!unauthed.ping().await);
+
+    let authed = RedisCli::new()
+        .host(server.host())
+        .port(server.port())
+        .password("secret");
+    assert!(authed.ping().await);
+}
+
+#[tokio::test]
+async fn exit_error_code_can_be_disabled() {
+    let server = RedisServer::new()
+        .port(16925)
+        .password("secret")
+        .start()
+        .await
+        .expect("failed to start redis-server");
+
+    let lenient = RedisCli::new()
+        .host(server.host())
+        .port(server.port())
+        .exit_error_code(false);
+
+    let reply = lenient
+        .run(&["GET", "k"])
+        .await
+        .expect("with -e disabled the error reply comes back as a value");
+    assert!(reply.contains("NOAUTH"), "unexpected reply: {reply:?}");
 }

--- a/tests/config_encoding.rs
+++ b/tests/config_encoding.rs
@@ -34,18 +34,13 @@ async fn awkward_passwords_round_trip() {
         // The password is actually in force: an unauthenticated client is
         // rejected. Without this the next assertion would pass on a server
         // that simply has no password set.
-        //
-        // The reply is checked by content rather than by `is_err`, because
-        // redis-cli exits 0 on a Redis error reply and `run` currently
-        // surfaces that as `Ok` (see issue #143).
         let unauthenticated = redis_server_wrapper::RedisCli::new()
             .host(server.host())
             .port(server.port())
             .run(&["PING"])
-            .await
-            .unwrap_or_default();
+            .await;
         assert!(
-            unauthenticated.contains("NOAUTH"),
+            matches!(unauthenticated, Err(Error::Cli { ref detail, .. }) if detail.contains("NOAUTH")),
             "password {password:?} was not enforced, got: {unauthenticated:?}"
         );
 

--- a/tests/sentinel.rs
+++ b/tests/sentinel.rs
@@ -1,5 +1,5 @@
 use redis_server_wrapper::chaos::SentinelCrashPoint;
-use redis_server_wrapper::{RedisCli, RedisSentinel, RedisServer, chaos};
+use redis_server_wrapper::{Error, RedisCli, RedisSentinel, RedisServer, chaos};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[tokio::test]
@@ -123,13 +123,10 @@ async fn sentinel_password_auth() {
 
     // The master rejects an unauthenticated command...
     let unauthed = RedisCli::new().host("127.0.0.1").port(17400);
-    let unauthed_reply = unauthed
-        .run(&["GET", "foo"])
-        .await
-        .expect("redis-cli itself should not fail even on a NOAUTH reply");
+    let unauthed_reply = unauthed.run(&["GET", "foo"]).await;
     assert!(
-        unauthed_reply.contains("NOAUTH"),
-        "expected a NOAUTH reply, got: {unauthed_reply}"
+        matches!(unauthed_reply, Err(Error::Cli { ref detail, .. }) if detail.contains("NOAUTH")),
+        "expected a NOAUTH error, got: {unauthed_reply:?}"
     );
 
     // ...and accepts the same command once authenticated.


### PR DESCRIPTION
Closes #143.

Prerequisite for the `MODULE LIST` assertion helper in #138: an assertion
built on `run` would otherwise report "module not loaded" when the command
itself failed.

## Problem

`RedisCli::run` decides success from the child exit status, and redis-cli
exits 0 on a Redis error reply. `NOAUTH`, `ERR`, `WRONGTYPE`, `MOVED`,
`CLUSTERDOWN`, and `NOSCRIPT` all arrive as `Ok`, carrying the error text
where a value is expected.

## Approach

redis-cli's `-e` / `--exit-error-code` makes it exit 1 on an error reply. A
nil reply for a missing key stays exit 0, so absent keys do not become
errors.

The builder already has `exit_error_code`, added in #48 but defaulting to off
and never set on the internal paths.

## Plan

1. Default `exit_error_code` to on, leaving the builder method as the opt-out.
2. Populate `Error::Cli { detail }` from stdout when stderr is empty, since
   redis-cli writes the error text to stdout.
3. Audit the internal callers that currently parse `run` output for places
   that relied on an error reply arriving as `Ok`, in particular the cluster
   and Sentinel health paths, where a probe against a node that is still
   converging returns an error reply.
4. Confirm `--cluster create` is unaffected.

## Testing

- Error replies (`NOAUTH`, `WRONGTYPE`) return `Err(Error::Cli)` with the
  error text in `detail`.
- A missing key still returns `Ok`.
- `ping()` on an unauthenticated connection returns false rather than
  panicking.
- The existing cluster and Sentinel suites confirm no health path regressed.