### PR TITLE
fix: fail closed on occupied ports instead of shutting down unowned Redis

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::cli::RedisCli;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::server::{
     AppendFsync, LogLevel, RedisServer, RedisServerHandle, ReplDisklessLoad, SavePolicy,
 };
@@ -668,6 +668,91 @@ impl RedisClusterBuilder {
         (0..total).map(move |i| base + i)
     }
 
+    /// Reject a topology that cannot be started, before anything is created.
+    ///
+    /// Checks the shape of the request rather than the state of the machine,
+    /// so the same builder is rejected identically on every host.
+    fn validate_topology(&self) -> Result<()> {
+        let invalid = |message: String| Err(Error::InvalidTopology { message });
+
+        if self.masters == 0 {
+            return invalid("a cluster needs at least 1 master, got 0".to_string());
+        }
+
+        // `redis-cli --cluster create` refuses fewer than 3 masters, so catch
+        // it here with an explanation rather than surfacing its error later.
+        if self.masters < 3 {
+            return invalid(format!(
+                "redis-cli --cluster create requires at least 3 masters, got {}",
+                self.masters
+            ));
+        }
+
+        let total = (self.masters as u32) * (1 + self.replicas_per_master as u32);
+        if total > u16::MAX as u32 {
+            return invalid(format!(
+                "{} masters with {} replicas each is more nodes than the port space allows",
+                self.masters, self.replicas_per_master
+            ));
+        }
+
+        // Every node needs a client port and a bus port, and neither range may
+        // run off the end of the port space.
+        let highest_client = (self.base_port as u32) + total - 1;
+        if highest_client > u16::MAX as u32 {
+            return invalid(format!(
+                "base port {} with {total} nodes runs past port {}",
+                self.base_port,
+                u16::MAX
+            ));
+        }
+        let highest_client = highest_client as u16;
+        if crate::preflight::bus_port(highest_client).is_none() {
+            return invalid(format!(
+                "node port {highest_client} has no bus port: Redis derives it as port + 10000, \
+                 which exceeds {}. Use a lower base port.",
+                u16::MAX
+            ));
+        }
+
+        // The bus range starts 10000 above the client range. They overlap when
+        // the cluster is large enough to span that gap.
+        if total > 10000 {
+            return invalid(format!(
+                "{total} nodes starting at {} makes the client and bus port ranges overlap: \
+                 Redis derives each bus port as its client port + 10000",
+                self.base_port
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Fail with the first occupied port rather than clearing it.
+    ///
+    /// Client ports are checked before bus ports so the error names the port
+    /// the caller actually chose.
+    fn ensure_ports_free(&self) -> Result<()> {
+        let mut wanted = Vec::new();
+        for port in self.ports() {
+            wanted.push((port, crate::preflight::PortRole::ClusterNode));
+        }
+
+        // Bus ports are only predictable while Redis derives them as client
+        // port + 10000. An explicit `cluster_port` replaces that rule, so skip
+        // the bus check rather than probe ports the nodes will not use.
+        if self.cluster_port.is_none() {
+            for port in self.ports() {
+                // `validate_topology` runs first and rejects the overflow.
+                if let Some(bus) = crate::preflight::bus_port(port) {
+                    wanted.push((bus, crate::preflight::PortRole::ClusterBus));
+                }
+            }
+        }
+
+        crate::preflight::ensure_ports_available(&self.bind, wanted)
+    }
+
     /// Whether TLS is configured (cert + key present).
     fn has_tls(&self) -> bool {
         self.tls_cert_file.is_some() && self.tls_key_file.is_some()
@@ -693,20 +778,15 @@ impl RedisClusterBuilder {
     }
 
     /// Start all nodes and form the cluster.
+    ///
+    /// Validates the topology and confirms every port it needs is free before
+    /// starting anything. An occupied port fails with [`Error::PortInUse`]
+    /// rather than being cleared: the wrapper cannot tell a leftover node of
+    /// its own from an unrelated Redis, and stopping the latter would lose
+    /// data it never owned.
     pub async fn start(mut self) -> Result<RedisClusterHandle> {
-        // Stop any leftover nodes from previous runs.
-        for port in self.ports() {
-            let mut cli = RedisCli::new()
-                .bin(&self.redis_cli_bin)
-                .host(&self.bind)
-                .port(port);
-            if let Some(ref password) = self.password {
-                cli = cli.password(password);
-            }
-            cli = self.apply_tls_to_cli(cli);
-            cli.shutdown();
-        }
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        self.validate_topology()?;
+        self.ensure_ports_free()?;
 
         // Start each node.
         let total_nodes = self.total_nodes();
@@ -1427,6 +1507,64 @@ mod tests {
             .extra("maxmemory", "10mb");
         assert_eq!(b.logfile.as_deref(), Some("/tmp/cluster.log"));
         assert_eq!(b.extra.get("maxmemory").map(String::as_str), Some("10mb"));
+    }
+
+    // -- topology validation (#137) --
+
+    fn cluster(masters: u16, replicas: u16, base_port: u16) -> RedisClusterBuilder {
+        RedisCluster::builder()
+            .masters(masters)
+            .replicas_per_master(replicas)
+            .base_port(base_port)
+    }
+
+    #[test]
+    fn valid_topology_is_accepted() {
+        assert!(cluster(3, 1, 7000).validate_topology().is_ok());
+        assert!(cluster(3, 0, 7000).validate_topology().is_ok());
+    }
+
+    #[test]
+    fn zero_masters_is_rejected() {
+        let err = cluster(0, 0, 7000)
+            .validate_topology()
+            .expect_err("0 masters must be rejected");
+        assert!(matches!(err, Error::InvalidTopology { .. }), "{err}");
+    }
+
+    #[test]
+    fn fewer_than_three_masters_is_rejected() {
+        // redis-cli --cluster create refuses these, so reject them with an
+        // explanation rather than surfacing its error after startup.
+        for masters in [1, 2] {
+            let err = cluster(masters, 0, 7000)
+                .validate_topology()
+                .expect_err("fewer than 3 masters must be rejected");
+            assert!(
+                format!("{err}").contains("at least 3 masters"),
+                "unexpected message: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn base_port_running_past_the_port_space_is_rejected() {
+        let err = cluster(3, 1, 65530)
+            .validate_topology()
+            .expect_err("a range past u16::MAX must be rejected");
+        assert!(matches!(err, Error::InvalidTopology { .. }), "{err}");
+    }
+
+    #[test]
+    fn node_port_without_a_bus_port_is_rejected() {
+        // Bus port is client port + 10000, so anything above 55535 has none.
+        let err = cluster(3, 0, 60000)
+            .validate_topology()
+            .expect_err("a node with no bus port must be rejected");
+        assert!(
+            format!("{err}").contains("bus port"),
+            "unexpected message: {err}"
+        );
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,6 +91,32 @@ pub enum Error {
         binary: String,
     },
 
+    /// A port the topology needs is already bound by another process.
+    ///
+    /// Startup fails rather than clearing the port: the wrapper cannot tell a
+    /// leftover node of its own from an unrelated Redis, and stopping the
+    /// latter would lose data it never owned. Free the port, or point the
+    /// builder at a different one.
+    #[error("{role} {host}:{port} is already in use")]
+    PortInUse {
+        /// The host the port was to be bound on.
+        host: String,
+        /// The occupied port.
+        port: u16,
+        /// What the port was needed for, e.g. "cluster bus port".
+        role: String,
+    },
+
+    /// A topology was described in a way that cannot be started.
+    ///
+    /// Returned before anything starts, so a rejected topology leaves no
+    /// processes or directories behind.
+    #[error("invalid topology: {message}")]
+    InvalidTopology {
+        /// What about the topology is unworkable.
+        message: String,
+    },
+
     /// An `extra()` directive collided with one the wrapper generates.
     ///
     /// The wrapper reuses these values after startup for readiness probing and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,7 @@ pub mod config_token;
 pub mod error;
 #[cfg(feature = "tokio")]
 pub mod fault_proxy;
+pub mod preflight;
 pub mod process;
 mod secure_file;
 #[cfg(feature = "tokio")]

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -10,9 +10,17 @@
 //! belongs to something else. These helpers check first and fail with the port
 //! named, leaving whatever holds it alone.
 
-use std::net::TcpListener;
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::time::Duration;
 
 use crate::error::{Error, Result};
+
+/// How long to wait for a connect probe before treating the port as free.
+///
+/// Probes are against loopback in the common case, where a live listener
+/// answers in well under a millisecond and a free port is refused just as
+/// fast. The bound only matters for an address that silently drops packets.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(250);
 
 /// What a port was needed for, used to make [`Error::PortInUse`] specific
 /// enough to act on.
@@ -46,25 +54,40 @@ impl std::fmt::Display for PortRole {
     }
 }
 
-/// Whether a port can be bound on `host`.
+/// Whether a port is free of a live listener on `host`.
 ///
-/// Rust sets `SO_REUSEADDR` on Unix, so a socket left in `TIME_WAIT` by a
-/// process that has already exited does not read as occupied, while a live
-/// listener does. That is the distinction we want: a port is "in use" only if
-/// something is actually accepting on it.
+/// Probes by connecting, not by binding. The question this needs to answer is
+/// "would starting here disturb a server that is already running", and only a
+/// process actually accepting connections can be disturbed.
 ///
-/// A host that does not resolve reads as available. Binding is not this
-/// function's job to diagnose, and the subsequent start will report the real
-/// failure.
+/// Binding is the obvious implementation and is wrong for this. A port whose
+/// previous listener has just exited can still refuse a bind with
+/// `AddrInUse` while the kernel tears the socket down, and sockets left in
+/// `TIME_WAIT` have no owning process at all. A bind probe reads both as
+/// occupied, which turns the normal case of reusing a port moments after
+/// stopping a server into a spurious failure. `SO_REUSEADDR` does not close
+/// this gap portably: Linux lets a listener bind over `TIME_WAIT`, BSD and
+/// macOS do not.
+///
+/// A refused connection means nothing is serving, so the port is available
+/// even if the kernel is still holding remnants: `redis-server` sets
+/// `SO_REUSEADDR` itself and binds it fine.
+///
+/// Anything other than a successful connection reads as available. If the
+/// address cannot be reached, this cannot disturb a server there either, and
+/// a genuine bind failure is reported by the start that follows.
 pub fn port_available(host: &str, port: u16) -> bool {
-    match TcpListener::bind((host, port)) {
-        Ok(listener) => {
-            drop(listener);
-            true
+    let Ok(addrs) = (host, port).to_socket_addrs() else {
+        return true;
+    };
+    let addrs: Vec<SocketAddr> = addrs.collect();
+
+    for addr in addrs {
+        if TcpStream::connect_timeout(&addr, PROBE_TIMEOUT).is_ok() {
+            return false;
         }
-        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => false,
-        Err(_) => true,
     }
+    true
 }
 
 /// Return an error naming the first occupied port, if any.
@@ -100,6 +123,9 @@ pub fn bus_port(client_port: u16) -> Option<u16> {
 mod tests {
     use super::*;
 
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
     #[test]
     fn unbound_port_is_available() {
         // Bind and release to get a port nothing is listening on.
@@ -110,11 +136,39 @@ mod tests {
     }
 
     #[test]
-    fn bound_port_is_not_available() {
+    fn listening_port_is_not_available() {
         let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
         let port = listener.local_addr().unwrap().port();
         assert!(!port_available("127.0.0.1", port));
         drop(listener);
+    }
+
+    #[test]
+    fn port_with_lingering_time_wait_is_available() {
+        // The regression this probe design exists for. A listener that has
+        // handled a connection and then exited can leave the port refusing a
+        // bind while nothing is serving on it. Starting there is fine, so it
+        // must not read as occupied.
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // Drive a real connection through so the socket has something to
+        // linger over, rather than closing an untouched listener.
+        let mut client = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        let (mut server, _) = listener.accept().unwrap();
+        client.write_all(b"ping").unwrap();
+        let mut buf = [0u8; 4];
+        server.read_exact(&mut buf).unwrap();
+
+        drop(client);
+        drop(server);
+        drop(listener);
+
+        assert!(
+            port_available("127.0.0.1", port),
+            "a port with no live listener must be available even while the \
+             kernel still holds socket remnants"
+        );
     }
 
     #[test]
@@ -123,7 +177,7 @@ mod tests {
         let port = listener.local_addr().unwrap().port();
 
         let err = ensure_ports_available("127.0.0.1", [(port, PortRole::ClusterNode)])
-            .expect_err("an occupied port must be reported");
+            .expect_err("a port with a live listener must be reported");
 
         match err {
             Error::PortInUse {

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -1,0 +1,181 @@
+//! Port availability checks run before a topology starts anything.
+//!
+//! The cluster and Sentinel builders used to clear the ports they wanted by
+//! sending `SHUTDOWN` to whatever was listening. Neither could distinguish a
+//! leftover node of its own from an unrelated Redis holding the port, so the
+//! cleanup could stop a server the wrapper never owned.
+//!
+//! Both builders create a uniquely named temp directory per start, so they
+//! never have a prior process of their own to reclaim: an occupied port always
+//! belongs to something else. These helpers check first and fail with the port
+//! named, leaving whatever holds it alone.
+
+use std::net::TcpListener;
+
+use crate::error::{Error, Result};
+
+/// What a port was needed for, used to make [`Error::PortInUse`] specific
+/// enough to act on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PortRole {
+    /// A standalone server's client port.
+    Server,
+    /// A cluster node's client port.
+    ClusterNode,
+    /// A cluster node's bus port (client port + 10000).
+    ClusterBus,
+    /// A Sentinel topology's master port.
+    SentinelMaster,
+    /// A Sentinel topology's replica port.
+    SentinelReplica,
+    /// A sentinel process's own port.
+    Sentinel,
+}
+
+impl std::fmt::Display for PortRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Server => "server port",
+            Self::ClusterNode => "cluster node port",
+            Self::ClusterBus => "cluster bus port",
+            Self::SentinelMaster => "sentinel master port",
+            Self::SentinelReplica => "sentinel replica port",
+            Self::Sentinel => "sentinel port",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Whether a port can be bound on `host`.
+///
+/// Rust sets `SO_REUSEADDR` on Unix, so a socket left in `TIME_WAIT` by a
+/// process that has already exited does not read as occupied, while a live
+/// listener does. That is the distinction we want: a port is "in use" only if
+/// something is actually accepting on it.
+///
+/// A host that does not resolve reads as available. Binding is not this
+/// function's job to diagnose, and the subsequent start will report the real
+/// failure.
+pub fn port_available(host: &str, port: u16) -> bool {
+    match TcpListener::bind((host, port)) {
+        Ok(listener) => {
+            drop(listener);
+            true
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => false,
+        Err(_) => true,
+    }
+}
+
+/// Return an error naming the first occupied port, if any.
+///
+/// Checked in the order given, so the error points at the first conflict a
+/// reader would look for.
+pub fn ensure_ports_available(
+    host: &str,
+    ports: impl IntoIterator<Item = (u16, PortRole)>,
+) -> Result<()> {
+    for (port, role) in ports {
+        if !port_available(host, port) {
+            return Err(Error::PortInUse {
+                host: host.to_string(),
+                port,
+                role: role.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// The cluster bus port Redis derives from a client port.
+///
+/// Redis uses client port + 10000 unless `cluster-port` overrides it. Returns
+/// `None` when that would exceed the port space, which is a topology error
+/// rather than something to discover at startup.
+pub fn bus_port(client_port: u16) -> Option<u16> {
+    client_port.checked_add(10000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unbound_port_is_available() {
+        // Bind and release to get a port nothing is listening on.
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        assert!(port_available("127.0.0.1", port));
+    }
+
+    #[test]
+    fn bound_port_is_not_available() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        assert!(!port_available("127.0.0.1", port));
+        drop(listener);
+    }
+
+    #[test]
+    fn ensure_reports_the_occupied_port_and_role() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let err = ensure_ports_available("127.0.0.1", [(port, PortRole::ClusterNode)])
+            .expect_err("an occupied port must be reported");
+
+        match err {
+            Error::PortInUse {
+                port: reported,
+                ref role,
+                ..
+            } => {
+                assert_eq!(reported, port);
+                assert_eq!(role, "cluster node port");
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+        drop(listener);
+    }
+
+    #[test]
+    fn ensure_passes_when_every_port_is_free() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        assert!(ensure_ports_available("127.0.0.1", [(port, PortRole::Server)]).is_ok());
+    }
+
+    #[test]
+    fn ensure_reports_the_first_conflict_in_order() {
+        let a = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let b = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let (pa, pb) = (
+            a.local_addr().unwrap().port(),
+            b.local_addr().unwrap().port(),
+        );
+
+        let err = ensure_ports_available(
+            "127.0.0.1",
+            [(pa, PortRole::ClusterNode), (pb, PortRole::ClusterBus)],
+        )
+        .expect_err("must report a conflict");
+        assert!(matches!(err, Error::PortInUse { port, .. } if port == pa));
+
+        drop(a);
+        drop(b);
+    }
+
+    #[test]
+    fn bus_port_is_client_port_plus_ten_thousand() {
+        assert_eq!(bus_port(7000), Some(17000));
+        assert_eq!(bus_port(6379), Some(16379));
+    }
+
+    #[test]
+    fn bus_port_rejects_overflow() {
+        assert_eq!(bus_port(60000), None);
+        assert_eq!(bus_port(u16::MAX), None);
+    }
+}

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -377,6 +377,80 @@ impl RedisSentinelBuilder {
         (0..n).map(move |i| base + i)
     }
 
+    /// Reject a topology that cannot be started, before anything is created.
+    fn validate_topology(&self) -> Result<()> {
+        let invalid = |message: String| Err(Error::InvalidTopology { message });
+
+        if self.num_sentinels == 0 {
+            return invalid("a Sentinel topology needs at least 1 sentinel, got 0".to_string());
+        }
+        if self.quorum == 0 {
+            return invalid("quorum must be at least 1, got 0".to_string());
+        }
+        if self.quorum > self.num_sentinels {
+            return invalid(format!(
+                "quorum {} exceeds the {} sentinel(s) in the topology, so a failover could \
+                 never be agreed",
+                self.quorum, self.num_sentinels
+            ));
+        }
+
+        // Port arithmetic must stay inside the port space.
+        let end = |base: u16, count: u16, what: &str| -> Result<u16> {
+            match base.checked_add(count.saturating_sub(1)) {
+                Some(end) => Ok(end),
+                None => Err(Error::InvalidTopology {
+                    message: format!(
+                        "{count} {what} starting at port {base} run past port {}",
+                        u16::MAX
+                    ),
+                }),
+            }
+        };
+        let replica_end = end(self.replica_base_port, self.num_replicas, "replicas")?;
+        let sentinel_end = end(self.sentinel_base_port, self.num_sentinels, "sentinels")?;
+
+        // Overlapping ranges would have two processes claim one port, which
+        // surfaces later as an unrelated bind failure.
+        let ranges: [(&str, u16, u16); 3] = [
+            ("master", self.master_port, self.master_port),
+            ("replica", self.replica_base_port, replica_end),
+            ("sentinel", self.sentinel_base_port, sentinel_end),
+        ];
+        for i in 0..ranges.len() {
+            for j in (i + 1)..ranges.len() {
+                let (a_name, a_lo, a_hi) = ranges[i];
+                let (b_name, b_lo, b_hi) = ranges[j];
+                // Skip ranges that hold no ports at all.
+                if (a_name == "replica" && self.num_replicas == 0)
+                    || (b_name == "replica" && self.num_replicas == 0)
+                {
+                    continue;
+                }
+                if a_lo <= b_hi && b_lo <= a_hi {
+                    return invalid(format!(
+                        "the {a_name} port range {a_lo}-{a_hi} overlaps the {b_name} range \
+                         {b_lo}-{b_hi}"
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Fail with the first occupied port rather than clearing it.
+    fn ensure_ports_free(&self) -> Result<()> {
+        let mut wanted = vec![(self.master_port, crate::preflight::PortRole::SentinelMaster)];
+        for port in self.replica_ports() {
+            wanted.push((port, crate::preflight::PortRole::SentinelReplica));
+        }
+        for port in self.sentinel_ports() {
+            wanted.push((port, crate::preflight::PortRole::Sentinel));
+        }
+        crate::preflight::ensure_ports_available(&self.bind, wanted)
+    }
+
     /// Start the full topology: master, replicas, sentinels.
     pub async fn start(self) -> Result<RedisSentinelHandle> {
         let mut monitored_masters = Vec::with_capacity(1 + self.monitored_masters.len());
@@ -388,27 +462,8 @@ impl RedisSentinelBuilder {
         });
         monitored_masters.extend(self.monitored_masters.iter().cloned());
 
-        // Kill leftover processes. Data nodes (master, replicas) may be
-        // password-protected from a previous run; sentinels never are.
-        let cli_for_shutdown = |port: u16, authed: bool| {
-            let mut cli = RedisCli::new()
-                .bin(&self.redis_cli_bin)
-                .host(&self.bind)
-                .port(port);
-            if authed && let Some(ref password) = self.password {
-                cli = cli.password(password);
-            }
-            cli = self.apply_tls_to_cli(cli);
-            cli.shutdown();
-        };
-        cli_for_shutdown(self.master_port, true);
-        for port in self.replica_ports() {
-            cli_for_shutdown(port, true);
-        }
-        for port in self.sentinel_ports() {
-            cli_for_shutdown(port, false);
-        }
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        self.validate_topology()?;
+        self.ensure_ports_free()?;
 
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -1095,6 +1150,110 @@ mod tests {
     fn builder_password() {
         let b = RedisSentinel::builder().password("secret");
         assert_eq!(b.password.as_deref(), Some("secret"));
+    }
+
+    // -- topology validation (#137) --
+
+    fn sentinel() -> RedisSentinelBuilder {
+        RedisSentinel::builder()
+            .master_port(6390)
+            .replica_base_port(6391)
+            .sentinel_base_port(26379)
+            .replicas(2)
+            .sentinels(3)
+            .quorum(2)
+    }
+
+    #[test]
+    fn valid_sentinel_topology_is_accepted() {
+        assert!(sentinel().validate_topology().is_ok());
+    }
+
+    #[test]
+    fn zero_replicas_is_accepted() {
+        assert!(sentinel().replicas(0).validate_topology().is_ok());
+    }
+
+    #[test]
+    fn quorum_above_sentinel_count_is_rejected() {
+        let err = sentinel()
+            .sentinels(3)
+            .quorum(4)
+            .validate_topology()
+            .expect_err("an unreachable quorum must be rejected");
+        assert!(
+            format!("{err}").contains("quorum"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn zero_quorum_is_rejected() {
+        let err = sentinel()
+            .quorum(0)
+            .validate_topology()
+            .expect_err("quorum 0 must be rejected");
+        assert!(matches!(err, Error::InvalidTopology { .. }), "{err}");
+    }
+
+    #[test]
+    fn zero_sentinels_is_rejected() {
+        let err = sentinel()
+            .sentinels(0)
+            .quorum(1)
+            .validate_topology()
+            .expect_err("a topology with no sentinels must be rejected");
+        assert!(matches!(err, Error::InvalidTopology { .. }), "{err}");
+    }
+
+    #[test]
+    fn overlapping_master_and_replica_ports_are_rejected() {
+        let err = sentinel()
+            .master_port(6390)
+            .replica_base_port(6390)
+            .validate_topology()
+            .expect_err("overlapping ranges must be rejected");
+        assert!(
+            format!("{err}").contains("overlaps"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn overlapping_replica_and_sentinel_ports_are_rejected() {
+        let err = sentinel()
+            .replicas(4)
+            .replica_base_port(26377)
+            .sentinel_base_port(26379)
+            .validate_topology()
+            .expect_err("overlapping ranges must be rejected");
+        assert!(
+            format!("{err}").contains("overlaps"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn zero_replicas_cannot_collide_with_the_master() {
+        // An empty replica range holds no ports, so it must not be treated as
+        // overlapping just because its base equals another port.
+        assert!(
+            sentinel()
+                .replicas(0)
+                .replica_base_port(6390)
+                .validate_topology()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn sentinel_ports_running_past_the_port_space_are_rejected() {
+        let err = sentinel()
+            .sentinels(10)
+            .sentinel_base_port(65530)
+            .validate_topology()
+            .expect_err("a range past u16::MAX must be rejected");
+        assert!(matches!(err, Error::InvalidTopology { .. }), "{err}");
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -2047,6 +2047,15 @@ impl RedisServer {
             crate::process::force_kill(stale_pid);
         }
 
+        // Anything still holding the port after that is not ours: the pidfile
+        // above is the only claim of ownership the wrapper has. Fail with the
+        // port named rather than letting redis-server fail to bind, which a
+        // daemonizing start would not even report.
+        crate::preflight::ensure_ports_available(
+            &self.config.bind,
+            [(self.config.port, crate::preflight::PortRole::Server)],
+        )?;
+
         crate::secure_file::create_dir_all(&node_dir)?;
 
         let (cli, pid) = launch_server(&self.config, &node_dir, Duration::from_secs(10)).await?;

--- a/tests/ownership_safety.rs
+++ b/tests/ownership_safety.rs
@@ -1,0 +1,156 @@
+//! Startup must never stop a Redis process the wrapper does not own.
+//!
+//! The cluster and Sentinel builders used to clear the ports they wanted by
+//! sending `SHUTDOWN` to whatever was listening. These tests stand an
+//! unrelated server on one of those ports and assert that startup fails
+//! instead, with the intruder still running afterwards.
+
+use redis_server_wrapper::{Error, RedisCluster, RedisSentinel, RedisServer};
+
+#[tokio::test]
+async fn cluster_start_does_not_shut_down_an_unowned_server() {
+    // A server that has nothing to do with the cluster, sitting on a port the
+    // cluster is about to want.
+    let bystander = RedisServer::new()
+        .port(18201)
+        .start()
+        .await
+        .expect("failed to start the bystander server");
+    bystander
+        .run(&["SET", "precious", "data"])
+        .await
+        .expect("failed to seed the bystander");
+
+    let result = RedisCluster::builder()
+        .masters(3)
+        .base_port(18200) // covers 18200, 18201, 18202
+        .start()
+        .await;
+
+    match result {
+        Err(Error::PortInUse { port, ref role, .. }) => {
+            assert_eq!(port, 18201);
+            assert_eq!(role, "cluster node port");
+        }
+        Err(other) => panic!("expected PortInUse, got: {other}"),
+        Ok(_) => panic!("cluster started despite an occupied port"),
+    }
+
+    // The bystander is still running and still has its data.
+    assert!(bystander.is_alive().await);
+    let value = bystander
+        .run(&["GET", "precious"])
+        .await
+        .expect("bystander should still answer");
+    assert_eq!(value.trim(), "data");
+}
+
+#[tokio::test]
+async fn cluster_start_checks_bus_ports_too() {
+    // Redis derives the bus port as client port + 10000. A cluster whose bus
+    // range is occupied cannot form, so that must fail before startup too.
+    let bystander = RedisServer::new()
+        .port(18311) // bus port for client port 8311, and 18310+1
+        .start()
+        .await
+        .expect("failed to start the bystander server");
+
+    let result = RedisCluster::builder()
+        .masters(3)
+        .base_port(8310) // bus ports 18310, 18311, 18312
+        .start()
+        .await;
+
+    match result {
+        Err(Error::PortInUse { port, ref role, .. }) => {
+            assert_eq!(port, 18311);
+            assert_eq!(role, "cluster bus port");
+        }
+        Err(other) => panic!("expected PortInUse for a bus port, got: {other}"),
+        Ok(_) => panic!("cluster started despite an occupied bus port"),
+    }
+
+    assert!(bystander.is_alive().await);
+}
+
+#[tokio::test]
+async fn sentinel_start_does_not_shut_down_an_unowned_server() {
+    let bystander = RedisServer::new()
+        .port(18410)
+        .start()
+        .await
+        .expect("failed to start the bystander server");
+    bystander
+        .run(&["SET", "precious", "data"])
+        .await
+        .expect("failed to seed the bystander");
+
+    let result = RedisSentinel::builder()
+        .master_port(18410)
+        .replica_base_port(18420)
+        .sentinel_base_port(18430)
+        .replicas(1)
+        .sentinels(3)
+        .quorum(2)
+        .start()
+        .await;
+
+    match result {
+        Err(Error::PortInUse { port, ref role, .. }) => {
+            assert_eq!(port, 18410);
+            assert_eq!(role, "sentinel master port");
+        }
+        Err(other) => panic!("expected PortInUse, got: {other}"),
+        Ok(_) => panic!("sentinel topology started despite an occupied port"),
+    }
+
+    assert!(bystander.is_alive().await);
+    let value = bystander
+        .run(&["GET", "precious"])
+        .await
+        .expect("bystander should still answer");
+    assert_eq!(value.trim(), "data");
+}
+
+#[tokio::test]
+async fn sentinel_start_checks_sentinel_ports() {
+    let bystander = RedisServer::new()
+        .port(18531)
+        .start()
+        .await
+        .expect("failed to start the bystander server");
+
+    let result = RedisSentinel::builder()
+        .master_port(18510)
+        .replica_base_port(18520)
+        .sentinel_base_port(18530)
+        .replicas(1)
+        .sentinels(3)
+        .quorum(2)
+        .start()
+        .await;
+
+    match result {
+        Err(Error::PortInUse { port, ref role, .. }) => {
+            assert_eq!(port, 18531);
+            assert_eq!(role, "sentinel port");
+        }
+        Err(other) => panic!("expected PortInUse, got: {other}"),
+        Ok(_) => panic!("sentinel topology started despite an occupied port"),
+    }
+
+    assert!(bystander.is_alive().await);
+}
+
+#[tokio::test]
+async fn a_free_topology_still_starts() {
+    // The preflight check must not reject a topology whose ports are free.
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .base_port(18600)
+        .start()
+        .await
+        .expect("a cluster on free ports must still start");
+
+    assert!(cluster.is_healthy().await);
+}

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -146,25 +146,30 @@ async fn bad_cli_binary_returns_binary_not_found() {
 
 #[tokio::test]
 async fn port_already_in_use_returns_server_start_error() {
-    let _first = RedisServer::new()
+    let first = RedisServer::new()
         .port(16409)
         .dir(std::env::temp_dir().join("rsw-port-conflict-a"))
         .start()
         .await
         .expect("first server should start");
 
-    // A daemonizing redis-server forks and its parent exits 0 before the
-    // child even attempts to bind, so a second daemonized start on the same
-    // port would falsely report success. Run the second attempt in the
-    // foreground so the bind failure surfaces synchronously.
+    // The preflight check catches this before redis-server is spawned, so the
+    // daemonize workaround this test used to need no longer applies: a
+    // daemonizing start would have forked and exited 0 before the child even
+    // attempted to bind.
     let result = RedisServer::new()
         .port(16409)
         .dir(std::env::temp_dir().join("rsw-port-conflict-b"))
-        .daemonize(false)
         .start()
         .await;
 
-    assert!(matches!(result, Err(Error::ServerStart { port: 16409 })));
+    assert!(
+        matches!(result, Err(Error::PortInUse { port: 16409, .. })),
+        "expected PortInUse for the occupied port"
+    );
+
+    // The server that already held the port is untouched.
+    assert!(first.is_alive().await);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #137.

## Problem

`RedisCluster::start` opened by sending `SHUTDOWN` to every port it was about
to use, and `RedisSentinel::start` did the same for its master, replica, and
sentinel ports. Neither could tell a leftover node from a previous run apart
from an unrelated Redis that happened to hold the port, so starting a cluster
on the default base port stopped a developer's own server and lost its data if
it had no persistence configured.

The cleanup could not have been ownership-aware as written: both builders
create a fresh, uniquely named temp directory per start, so the wrapper never
has a prior process of its own on those ports to reclaim. The SHUTDOWN loop
could only ever have been hitting something it did not own.

## Approach

Fail closed. Check every port the topology needs before starting anything, and
return an error naming the occupied port rather than clearing it. A crashed
previous run now requires the operator to clean up, which is the correct
trade against stopping an unrelated server.

The standalone `RedisServer` path is different and stays: it reclaims a stale
process by reading back the pidfile it wrote itself, which is genuine
ownership. It gains the same preflight check after that cleanup, so a port
held by someone else fails with a clear error rather than a generic start
failure.

## Plan

1. Add `Error::PortInUse { host, port, role }`, where role names what the port
   was needed for.
2. Add a preflight helper that probes a port with `TcpListener::bind`. Rust
   sets `SO_REUSEADDR` on Unix, so a socket in `TIME_WAIT` does not read as
   occupied while a live listener does.
3. Cluster: validate the topology, then preflight every data port and every
   cluster bus port, and drop the SHUTDOWN loop.
4. Sentinel: same for master, replica, and sentinel ports.
5. Validate topology before any mutation: master and replica counts, sentinel
   quorum against sentinel count, port arithmetic overflow, and overlap
   between the data, bus, and sentinel port ranges.

## Testing

- A cluster started on a port held by an unrelated server fails with
  `PortInUse` and leaves that server running.
- The same for Sentinel.
- Invalid topologies (quorum above sentinel count, overlapping port ranges,
  port arithmetic overflow) fail before anything starts.
- Existing cluster and Sentinel suites confirm normal startup is unaffected.