### PR TITLE
fix: replace fixed startup sleeps with bounded convergence polling

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1023,10 +1023,7 @@ impl RedisClusterBuilder {
         cli.cluster_create(&node_addrs, self.replicas_per_master)
             .await?;
 
-        // Wait for convergence.
-        tokio::time::sleep(Duration::from_secs(2)).await;
-
-        Ok(RedisClusterHandle {
+        let handle = RedisClusterHandle {
             nodes,
             num_masters: self.masters,
             bind: self.bind,
@@ -1039,9 +1036,27 @@ impl RedisClusterBuilder {
                 ca_cert_file: self.tls_ca_cert_file,
             },
             cluster_base,
-        })
+        };
+
+        // `CLUSTER CREATE` returns once the nodes have been told about each
+        // other, not once they agree. Wait for the formed cluster rather than
+        // guessing at how long that takes: returning early hands back a
+        // cluster whose first command can fail, and a fixed sleep is wasted
+        // time on the common path where convergence is immediate.
+        //
+        // On timeout the handle drops, which stops the nodes it started.
+        handle.wait_for_formation(FORMATION_TIMEOUT).await?;
+
+        Ok(handle)
     }
 }
+
+/// How long [`RedisClusterBuilder::start`] waits for a freshly created cluster
+/// to agree on its slot assignment.
+///
+/// Generous because it only bounds the failure case: a converged cluster
+/// returns on the first poll.
+const FORMATION_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// TLS configuration snapshot stored in the handle for building CLI instances.
 #[derive(Clone, Debug, Default)]
@@ -1290,6 +1305,47 @@ impl RedisClusterHandle {
             timeout,
             Duration::from_millis(500),
             "cluster did not converge to all-nodes-healthy in time",
+        )
+        .await
+    }
+
+    /// Wait until the cluster has finished forming: every node reporting
+    /// `cluster_state:ok` with the full 16384-slot space assigned and healthy.
+    ///
+    /// Stricter than [`Self::wait_for_all_healthy`], which accepts any
+    /// consistent slot count. Immediately after `CLUSTER CREATE` a node can
+    /// report `cluster_state:ok` while it still holds no slots, so formation
+    /// has to check coverage explicitly.
+    async fn wait_for_formation(&self, timeout: Duration) -> Result<()> {
+        const TOTAL_SLOTS: u32 = 16384;
+
+        crate::wait::wait_for(
+            || async {
+                for node in &self.nodes {
+                    let Ok(Ok(raw)) = tokio::time::timeout(
+                        crate::cli::HEALTH_CHECK_TIMEOUT,
+                        node.run(&["CLUSTER", "INFO"]),
+                    )
+                    .await
+                    else {
+                        return false;
+                    };
+                    let info = crate::server::parse_info(&raw);
+                    let field = |key: &str| -> u32 {
+                        info.get(key).and_then(|v| v.parse().ok()).unwrap_or(0)
+                    };
+                    if info.get("cluster_state").map(String::as_str) != Some("ok")
+                        || field("cluster_slots_assigned") != TOTAL_SLOTS
+                        || field("cluster_slots_ok") != TOTAL_SLOTS
+                    {
+                        return false;
+                    }
+                }
+                true
+            },
+            timeout,
+            Duration::from_millis(100),
+            "cluster did not finish forming: nodes never agreed on a full slot assignment",
         )
         .await
     }

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1309,15 +1309,24 @@ impl RedisClusterHandle {
         .await
     }
 
-    /// Wait until the cluster has finished forming: every node reporting
-    /// `cluster_state:ok` with the full 16384-slot space assigned and healthy.
+    /// Wait until the cluster has finished forming and is actually usable.
     ///
-    /// Stricter than [`Self::wait_for_all_healthy`], which accepts any
-    /// consistent slot count. Immediately after `CLUSTER CREATE` a node can
-    /// report `cluster_state:ok` while it still holds no slots, so formation
-    /// has to check coverage explicitly.
+    /// Three conditions, all of which have to hold on every node:
+    ///
+    /// - `cluster_state:ok` with the full 16384-slot space assigned and healthy.
+    ///   Stricter than [`Self::wait_for_all_healthy`], which accepts any
+    ///   consistent slot count: immediately after `CLUSTER CREATE` a node can
+    ///   report `cluster_state:ok` while it still holds no slots.
+    /// - every node knowing about every other, so gossip has settled rather
+    ///   than each node having only seen part of the topology.
+    /// - every replica reporting `master_link_status:up`. A replica that has
+    ///   not finished its initial sync cannot be failed over to, so returning
+    ///   before then hands back a cluster whose replicas are not yet usable.
+    ///   Role is read from `INFO replication` rather than assumed from node
+    ///   ordering, since `redis-cli --cluster create` decides the pairing.
     async fn wait_for_formation(&self, timeout: Duration) -> Result<()> {
         const TOTAL_SLOTS: u32 = 16384;
+        let total_nodes = self.nodes.len() as u32;
 
         crate::wait::wait_for(
             || async {
@@ -1337,6 +1346,21 @@ impl RedisClusterHandle {
                     if info.get("cluster_state").map(String::as_str) != Some("ok")
                         || field("cluster_slots_assigned") != TOTAL_SLOTS
                         || field("cluster_slots_ok") != TOTAL_SLOTS
+                        || field("cluster_known_nodes") != total_nodes
+                    {
+                        return false;
+                    }
+
+                    let Ok(Ok(repl)) = tokio::time::timeout(
+                        crate::cli::HEALTH_CHECK_TIMEOUT,
+                        node.info(Some("replication")),
+                    )
+                    .await
+                    else {
+                        return false;
+                    };
+                    if repl.get("role").map(String::as_str) == Some("slave")
+                        && repl.get("master_link_status").map(String::as_str) != Some("up")
                     {
                         return false;
                     }
@@ -1345,7 +1369,8 @@ impl RedisClusterHandle {
             },
             timeout,
             Duration::from_millis(100),
-            "cluster did not finish forming: nodes never agreed on a full slot assignment",
+            "cluster did not finish forming: nodes never agreed on a full slot assignment \
+             with every replica synced",
         )
         .await
     }

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -555,8 +555,26 @@ impl RedisSentinelBuilder {
             replicas.push(replica);
         }
 
-        // Let replication link up.
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        // Sentinels discover replicas through the master, so the master has to
+        // have acknowledged them before the sentinels come up. Wait for the
+        // link rather than guessing at how long it takes.
+        if self.num_replicas > 0 {
+            let expected = self.num_replicas;
+            crate::wait::wait_for(
+                || async {
+                    let Ok(info) = master.info(Some("replication")).await else {
+                        return false;
+                    };
+                    info.get("connected_slaves")
+                        .and_then(|v| v.parse::<u16>().ok())
+                        .is_some_and(|n| n >= expected)
+                },
+                REPLICATION_LINK_TIMEOUT,
+                Duration::from_millis(100),
+                format!("master did not report {expected} connected replica(s) in time"),
+            )
+            .await?;
+        }
 
         // 3. Start sentinels.
         let mut sentinel_handles = Vec::new();
@@ -678,10 +696,7 @@ impl RedisSentinelBuilder {
             sentinel_handles.push((port, pid, cli));
         }
 
-        // Wait for sentinels to discover each other.
-        tokio::time::sleep(Duration::from_secs(2)).await;
-
-        Ok(RedisSentinelHandle {
+        let handle = RedisSentinelHandle {
             master,
             replicas,
             sentinel_ports: sentinel_handles.iter().map(|(p, _, _)| *p).collect(),
@@ -696,9 +711,31 @@ impl RedisSentinelBuilder {
                 key_file: self.tls_key_file,
                 ca_cert_file: self.tls_ca_cert_file,
             },
-        })
+        };
+
+        // Sentinels learn about each other through the master they share, so a
+        // freshly started topology is not usable until that gossip has landed.
+        // `is_healthy` already encodes what "converged" means here: the master
+        // reachable and flagged `master`, its replicas counted, and every
+        // sentinel accounted for.
+        //
+        // On timeout the handle drops, which tears down what it started.
+        handle.wait_for_healthy(DISCOVERY_TIMEOUT).await?;
+
+        Ok(handle)
     }
 }
+
+/// How long [`RedisSentinelBuilder::start`] waits for the master to report its
+/// replicas before bringing sentinels up.
+const REPLICATION_LINK_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long [`RedisSentinelBuilder::start`] waits for sentinels to discover
+/// the master, its replicas, and each other.
+///
+/// Generous because it only bounds the failure case: a converged topology
+/// returns on the first poll.
+const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// TLS configuration snapshot stored in the handle for building CLI instances.
 #[derive(Clone, Debug, Default)]


### PR DESCRIPTION
Closes #140.

## Problem

Cluster and Sentinel startup stood on fixed sleeps where they needed to wait
for a topology to converge. Each is both too short under load, letting `start`
return before the topology is usable, and too long when convergence took
milliseconds.

Two of the five sleeps the issue lists are already gone: they were part of the
SHUTDOWN loops removed in #145. Three remain, all of them standing in for a
condition that can be queried directly.

| Location | Sleep | Actually waiting for |
|---|---|---|
| `src/cluster.rs:1027` | 2s | slots assigned and every node agreeing after CLUSTER CREATE |
| `src/sentinel.rs:559` | 1s | replicas linking up to the master |
| `src/sentinel.rs:682` | 2s | sentinels discovering each other |

## Approach

`src/wait.rs` already provides `wait_for`, a bounded poll with a caller-supplied
timeout message, and every `wait_for_*` helper in the crate is built on it.
Replace each sleep with a poll against the condition it stands for, and give
the timeout an error that names what failed to converge.

## Plan

1. Cluster: poll every node until `CLUSTER INFO` reports `cluster_state:ok`
   and the full 16384 slots are assigned, so `start` cannot return mid-formation.
2. Sentinel replicas: poll `INFO replication` on the master until it reports
   the expected replica count online.
3. Sentinel discovery: poll `SENTINEL sentinels <master>` until each sentinel
   sees the expected peers.
4. Give each a timeout that says which stage failed rather than returning a
   bare elapsed-time error.

## Testing

- Existing cluster and Sentinel suites confirm startup still converges.
- Startup is no slower than before and should be materially faster on an
  unloaded machine, since a converged topology returns immediately.
- Repeated full-suite runs, since this branch changes timing-sensitive paths.