### PR TITLE
ci: define and test a supported Redis version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
     name: Test Suite
     runs-on: ${{ matrix.os }}
     strategy:
+      # Report every cell. Cancelling the rest on the first failure hides
+      # whether a break is platform-specific or universal, which is the first
+      # thing you need to know when diagnosing one.
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         rust: [stable]

--- a/.github/workflows/redis-compat.yml
+++ b/.github/workflows/redis-compat.yml
@@ -1,0 +1,110 @@
+name: Redis Compatibility
+
+# The supported Redis release lines, exercised against pinned builds.
+#
+# The main CI workflow installs whatever redis-server the platform package
+# manager provides, which drifts without notice and tests exactly one version.
+# This workflow pins the lines the crate claims to support and builds each from
+# source, so a behavior change between Redis versions surfaces here as a named
+# failure rather than as an unexplained break on some future runner image.
+#
+# Building Redis takes a few minutes uncached, so this does not run on every
+# push. It runs on pull requests that touch the wrapper's Redis-facing surface,
+# on main, weekly to catch upstream changes, and on demand.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/redis-compat.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/redis-compat.yml"
+  schedule:
+    # Mondays at 06:00 UTC. Catches a new 8.x patch release without a push.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  compat:
+    name: Redis ${{ matrix.redis }}
+    runs-on: ubuntu-latest
+    strategy:
+      # Report every line's result. A break on 7.2 should not hide the state
+      # of 8.2, which is the whole point of testing a matrix of versions.
+      fail-fast: false
+      matrix:
+        include:
+          - redis: "7.2.14"
+            line: "7.2"
+          - redis: "7.4.9"
+            line: "7.4"
+          - redis: "8.2.6"
+            line: "8.2"
+          - redis: "8.8.0"
+            line: "8.x"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Redis ${{ matrix.redis }} build
+        id: redis-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/redis-dist
+          key: redis-${{ matrix.redis }}-${{ runner.os }}
+
+      - name: Build Redis ${{ matrix.redis }}
+        if: steps.redis-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config libssl-dev
+          curl -fsSL -o /tmp/redis.tar.gz \
+            "https://download.redis.io/releases/redis-${{ matrix.redis }}.tar.gz"
+          mkdir -p /tmp/redis-src
+          tar xzf /tmp/redis.tar.gz -C /tmp/redis-src --strip-components=1
+          # BUILD_TLS=yes so the TLS-gated tests exercise a real TLS build
+          # rather than being silently skipped on a non-TLS binary.
+          make -C /tmp/redis-src -j"$(nproc)" BUILD_TLS=yes
+          mkdir -p ~/redis-dist
+          cp /tmp/redis-src/src/redis-server /tmp/redis-src/src/redis-cli ~/redis-dist/
+
+      - name: Put Redis ${{ matrix.redis }} on PATH
+        run: |
+          set -euo pipefail
+          chmod +x ~/redis-dist/redis-server ~/redis-dist/redis-cli
+          echo "$HOME/redis-dist" >> "$GITHUB_PATH"
+
+      - name: Verify the version under test
+        run: |
+          set -euo pipefail
+          redis-server --version
+          redis-cli --version
+          # Fail loudly rather than testing a different version than claimed:
+          # a silent fallback to the runner's own redis-server would make this
+          # matrix report a pass it never earned.
+          redis-server --version | grep -q "v=${{ matrix.redis }}"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "redis-compat"
+
+      - name: Run test suite against Redis ${{ matrix.redis }}
+        run: cargo test --all-features --verbose

--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ just `redis-server` and `redis-cli` on PATH.
 
 Minimum supported Rust version (MSRV): 1.88, enforced in CI.
 
+## Redis compatibility
+
+These release lines are tested in CI against pinned builds, on every pull request that touches
+the crate's Redis-facing surface and weekly:
+
+| Line | Pinned build under test |
+|------|-------------------------|
+| 7.2  | 7.2.14                  |
+| 7.4  | 7.4.9                   |
+| 8.2  | 8.2.6                   |
+| 8.x  | 8.8.0                   |
+
+Each is built from source with `BUILD_TLS=yes` and runs the full suite, so the TLS paths are
+exercised rather than skipped. Other versions may work; these are the ones a regression would
+be caught on.
+
+The main CI workflow separately runs against whatever `redis-server` the platform package
+manager provides on Ubuntu and macOS, which covers the case most users actually install.
+
 ## Platform support
 
 Unix-like platforms only (Linux, macOS, BSD). Process lifecycle management relies on POSIX


### PR DESCRIPTION
Closes #141.

## What

A `Redis Compatibility` workflow that pins the supported release lines and
builds each from source, replacing an unpinned single version that drifted
with the runner image.

| Line | Pinned build |
|------|--------------|
| 7.2  | 7.2.14       |
| 7.4  | 7.4.9        |
| 8.2  | 8.2.6        |
| 8.x  | 8.8.0        |

Each runs the full suite. Builds use `BUILD_TLS=yes` so the TLS-gated tests
exercise a real TLS build instead of being skipped, and are cached per version.

The job asserts the binary reports the version it claims. Without that, a
build failure that left the runner's own `redis-server` on PATH would make the
matrix report a pass it never earned.

## Scheduling

Building Redis is slow uncached, so this does not run on every push: pull
requests touching `src/`, `tests/`, or the manifests; pushes to main; weekly,
to catch a new 8.x patch release; and `workflow_dispatch`.

## Also here

`fail-fast: false` on both matrices. Cancelling remaining cells on the first
failure hides whether a break is platform-specific or universal. Both CI
failures on this branch's predecessors cost a diagnostic round trip for
exactly that reason.

## Deliberately not here

The issue also notes the silent Homebrew Stack discovery in `src/stack.rs`.
Left alone: this PR is CI-only so it does not conflict with the module and
tracing work happening in parallel. Worth a follow-up issue.

## Verification

Both workflow files parse. The matrix itself can only be verified by running
it, which this PR does.