### PR TITLE
feat: verify module loading against a real module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,37 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install redis
 
+      # tests/module_loading.rs skips itself unless REDIS_TEST_MODULE points at
+      # a compiled module. Building the fixture needs redismodule.h, which the
+      # distro Redis packages do not ship, so fetch the one matching the
+      # version actually installed.
+      #
+      # Best effort: a fetch or compile failure leaves the variable unset and
+      # the module tests skip rather than failing the run. The compatibility
+      # workflow builds Redis from source and has the real header, which is
+      # where module coverage is authoritative.
+      - name: Build Redis test module
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          version="$(redis-server --version | sed -n 's/.*v=\([0-9][0-9.]*\).*/\1/p')"
+          echo "detected Redis $version"
+          curl -fsSL -o "${RUNNER_TEMP}/redismodule.h" \
+            "https://raw.githubusercontent.com/redis/redis/${version}/src/redismodule.h"
+          cc -fPIC -shared -I "${RUNNER_TEMP}" \
+            tests/support/rsw_test_module.c \
+            -o "${RUNNER_TEMP}/rsw_test_module.so"
+          echo "REDIS_TEST_MODULE=${RUNNER_TEMP}/rsw_test_module.so" >> "$GITHUB_ENV"
+          echo "module fixture built for Redis $version"
+
+      - name: Report module test coverage
+        run: |
+          if [ -n "${REDIS_TEST_MODULE:-}" ]; then
+            echo "module tests will run against ${REDIS_TEST_MODULE}"
+          else
+            echo "::warning::module fixture unavailable, module tests will skip"
+          fi
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1375,6 +1375,21 @@ impl RedisClusterHandle {
         .await
     }
 
+    /// Fail unless every node in the cluster has this module loaded.
+    ///
+    /// A cluster-wide check rather than a per-node one because the builder
+    /// propagates `loadmodule` to every node, so a module present on some
+    /// nodes and absent on others is the interesting failure: commands then
+    /// succeed or fail depending on which node a key hashes to.
+    ///
+    /// The error names the first node missing it.
+    pub async fn require_module_on_all_nodes(&self, name: &str) -> Result<()> {
+        for node in &self.nodes {
+            node.require_module(name).await?;
+        }
+        Ok(())
+    }
+
     /// Access a specific node by index.
     ///
     /// Nodes are ordered by port: masters first (indices `0..masters`),

--- a/src/error.rs
+++ b/src/error.rs
@@ -107,6 +107,25 @@ pub enum Error {
         role: String,
     },
 
+    /// A module expected to be loaded was not.
+    ///
+    /// A `loadmodule` directive only asks Redis to load a module. A wrong
+    /// path, an ABI mismatch, or a module whose `RedisModule_OnLoad` returns
+    /// an error all leave the server running without it, so the modules that
+    /// are loaded are listed to make a name mismatch obvious.
+    #[error(
+        "module `{name}` is not loaded on port {port} (loaded: {})",
+        if loaded.is_empty() { "none".to_string() } else { loaded.join(", ") }
+    )]
+    ModuleNotLoaded {
+        /// The module name that was expected.
+        name: String,
+        /// The port of the server that was checked.
+        port: u16,
+        /// Names of the modules actually loaded there.
+        loaded: Vec<String>,
+    },
+
     /// A topology was described in a way that cannot be started.
     ///
     /// Returned before anything starts, so a rejected topology leaves no

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,7 @@ pub mod config_token;
 pub mod error;
 #[cfg(feature = "tokio")]
 pub mod fault_proxy;
+pub mod modules;
 pub mod preflight;
 pub mod process;
 mod secure_file;

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -1,0 +1,195 @@
+//! Inspecting the Redis modules a running server has loaded.
+//!
+//! Loading a module through the builder only puts a `loadmodule` directive in
+//! the config. Whether Redis actually loaded it is a separate question: a
+//! wrong path, an ABI mismatch, or a module whose `RedisModule_OnLoad`
+//! returns an error all leave a server running with the module absent. These
+//! helpers answer that question against the live server.
+
+use std::collections::HashMap;
+
+/// A module reported by `MODULE LIST`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModuleInfo {
+    /// The name the module registered with `RedisModule_Init`, which is what
+    /// `MODULE UNLOAD` and these helpers match on. It is not derived from the
+    /// filename and often differs from it.
+    pub name: String,
+    /// The module's own version number, or `None` if Redis did not report one.
+    pub version: Option<u64>,
+    /// Path Redis loaded the module from. Empty for modules built into the
+    /// server rather than loaded from disk.
+    pub path: String,
+    /// Load-time arguments the module was given.
+    pub args: Vec<String>,
+}
+
+/// Parse the reply to `MODULE LIST` as redis-cli renders it by default.
+///
+/// redis-cli flattens the nested reply to one value per line, so the structure
+/// has to be recovered from the key order Redis emits: `name`, `ver`, `path`,
+/// then `args`. A record begins at each `name`, and because `args` is last and
+/// variable length, its values run until the next `name` or the end of input.
+///
+/// Unknown keys are skipped, so a Redis version that reports more fields than
+/// these still parses. Redis 6 reported only `name` and `ver`, which parses
+/// too: the missing fields stay empty.
+///
+/// Two inputs would confuse this, both vanishingly unlikely and neither worth
+/// a JSON dependency to rule out: a module argument whose value is literally
+/// `name`, and one containing a newline.
+pub fn parse_module_list(raw: &str) -> Vec<ModuleInfo> {
+    let lines: Vec<&str> = raw.lines().collect();
+    let mut modules: Vec<ModuleInfo> = Vec::new();
+    let mut i = 0;
+
+    while i < lines.len() {
+        match lines[i].trim() {
+            "name" if i + 1 < lines.len() => {
+                modules.push(ModuleInfo {
+                    name: lines[i + 1].trim().to_string(),
+                    version: None,
+                    path: String::new(),
+                    args: Vec::new(),
+                });
+                i += 2;
+            }
+            "ver" if i + 1 < lines.len() => {
+                if let Some(m) = modules.last_mut() {
+                    m.version = lines[i + 1].trim().parse().ok();
+                }
+                i += 2;
+            }
+            "path" if i + 1 < lines.len() => {
+                if let Some(m) = modules.last_mut() {
+                    m.path = lines[i + 1].trim().to_string();
+                }
+                i += 2;
+            }
+            "args" => {
+                i += 1;
+                let mut args = Vec::new();
+                while i < lines.len() && lines[i].trim() != "name" {
+                    let value = lines[i].trim();
+                    // The empty line Redis emits for an empty argument vector
+                    // is structure, not an argument.
+                    if !value.is_empty() {
+                        args.push(value.to_string());
+                    }
+                    i += 1;
+                }
+                if let Some(m) = modules.last_mut() {
+                    m.args = args;
+                }
+            }
+            _ => i += 1,
+        }
+    }
+
+    modules
+}
+
+/// Index parsed modules by name, for callers checking several at once.
+pub fn by_name(modules: Vec<ModuleInfo>) -> HashMap<String, ModuleInfo> {
+    modules.into_iter().map(|m| (m.name.clone(), m)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Captured from `redis-cli MODULE LIST` against Redis 8.8.1 with one
+    /// loaded module and one built in.
+    const TWO_MODULES: &str = "name\n\
+                               rsw_test_module\n\
+                               ver\n\
+                               1\n\
+                               path\n\
+                               /tmp/rsw_test_module.so\n\
+                               args\n\
+                               \n\
+                               name\n\
+                               vectorset\n\
+                               ver\n\
+                               1\n\
+                               path\n\
+                               \n\
+                               args\n";
+
+    /// Same, with the module loaded as `loadmodule <path> alpha "two words"`.
+    const WITH_ARGS: &str = "name\n\
+                             rsw_test_module\n\
+                             ver\n\
+                             1\n\
+                             path\n\
+                             /tmp/rsw_test_module.so\n\
+                             args\n\
+                             alpha\n\
+                             two words\n\
+                             name\n\
+                             vectorset\n\
+                             ver\n\
+                             1\n\
+                             path\n\
+                             \n\
+                             args\n";
+
+    #[test]
+    fn empty_input_yields_no_modules() {
+        assert!(parse_module_list("").is_empty());
+        assert!(parse_module_list("\n\n").is_empty());
+    }
+
+    #[test]
+    fn parses_name_version_and_path() {
+        let mods = parse_module_list(TWO_MODULES);
+        assert_eq!(mods.len(), 2);
+
+        assert_eq!(mods[0].name, "rsw_test_module");
+        assert_eq!(mods[0].version, Some(1));
+        assert_eq!(mods[0].path, "/tmp/rsw_test_module.so");
+        assert!(mods[0].args.is_empty());
+    }
+
+    #[test]
+    fn builtin_module_has_an_empty_path() {
+        let mods = parse_module_list(TWO_MODULES);
+        assert_eq!(mods[1].name, "vectorset");
+        assert_eq!(mods[1].path, "");
+        assert!(mods[1].args.is_empty());
+    }
+
+    #[test]
+    fn parses_multi_valued_args_without_swallowing_the_next_module() {
+        let mods = parse_module_list(WITH_ARGS);
+        assert_eq!(mods.len(), 2, "args must not consume the next record");
+        assert_eq!(mods[0].args, vec!["alpha", "two words"]);
+        assert_eq!(mods[1].name, "vectorset");
+    }
+
+    #[test]
+    fn tolerates_a_redis_6_reply_without_path_or_args() {
+        let raw = "name\nold_module\nver\n2\n";
+        let mods = parse_module_list(raw);
+        assert_eq!(mods.len(), 1);
+        assert_eq!(mods[0].name, "old_module");
+        assert_eq!(mods[0].version, Some(2));
+        assert_eq!(mods[0].path, "");
+    }
+
+    #[test]
+    fn skips_unknown_keys() {
+        let raw = "name\nm\nver\n1\nfuture_field\nsomething\npath\n/p.so\nargs\n";
+        let mods = parse_module_list(raw);
+        assert_eq!(mods.len(), 1);
+        assert_eq!(mods[0].path, "/p.so");
+    }
+
+    #[test]
+    fn indexes_by_name() {
+        let index = by_name(parse_module_list(TWO_MODULES));
+        assert!(index.contains_key("rsw_test_module"));
+        assert!(index.contains_key("vectorset"));
+        assert_eq!(index["rsw_test_module"].version, Some(1));
+    }
+}

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -897,6 +897,23 @@ impl RedisSentinelHandle {
         &self.replicas
     }
 
+    /// Fail unless every data node has this module loaded.
+    ///
+    /// Covers the master and every replica, since the builder propagates
+    /// `loadmodule` to all of them. Sentinel processes are not data nodes and
+    /// do not load modules, so they are not checked.
+    ///
+    /// A replica missing a module the master has will fail to apply
+    /// replicated commands from it, and would serve reads without it after a
+    /// promotion.
+    pub async fn require_module_on_data_nodes(&self, name: &str) -> Result<()> {
+        self.master.require_module(name).await?;
+        for replica in &self.replicas {
+            replica.require_module(name).await?;
+        }
+        Ok(())
+    }
+
     /// All monitored master names.
     pub fn monitored_master_names(&self) -> Vec<&str> {
         self.monitored_masters

--- a/src/server.rs
+++ b/src/server.rs
@@ -10,6 +10,7 @@ use tokio::process::Command;
 use crate::cli::RedisCli;
 use crate::config_token::directive;
 use crate::error::{Error, Result};
+use crate::modules::ModuleInfo;
 
 /// Full configuration snapshot for a single `redis-server` process.
 ///
@@ -2017,6 +2018,22 @@ impl RedisServer {
         Ok(())
     }
 
+    /// Reject module specs Redis cannot act on.
+    ///
+    /// An empty path renders as `loadmodule ""`, which Redis rejects at
+    /// startup with a message that does not mention the builder call that
+    /// produced it. Catching it here names the problem instead.
+    fn validate_modules(&self) -> Result<()> {
+        for (path, _) in &self.config.loadmodule {
+            if path.as_os_str().is_empty() {
+                return Err(Error::InvalidTopology {
+                    message: "loadmodule path is empty".to_string(),
+                });
+            }
+        }
+        Ok(())
+    }
+
     /// Start the server. Returns a handle that stops the server on Drop.
     ///
     /// Verifies that `redis-server` and `redis-cli` binaries are available,
@@ -2024,6 +2041,7 @@ impl RedisServer {
     /// wrapper generates, before attempting to launch anything.
     pub async fn start(self) -> Result<RedisServerHandle> {
         self.validate_extras()?;
+        self.validate_modules()?;
         if which::which(&self.config.redis_server_bin).is_err() {
             return Err(Error::BinaryNotFound {
                 binary: self.config.redis_server_bin.clone(),
@@ -2839,6 +2857,45 @@ impl RedisServerHandle {
         self.node_dir().join("redis.conf")
     }
 
+    /// The modules this server currently has loaded, via `MODULE LIST`.
+    ///
+    /// Includes modules built into the server as well as ones loaded from
+    /// disk; the two are told apart by [`ModuleInfo::path`], which is empty
+    /// for built-ins.
+    pub async fn modules(&self) -> Result<Vec<ModuleInfo>> {
+        let raw = self.run(&["MODULE", "LIST"]).await?;
+        Ok(crate::modules::parse_module_list(&raw))
+    }
+
+    /// Whether a module with this name is loaded.
+    ///
+    /// The name is the one the module registered with `RedisModule_Init`,
+    /// which is not derived from its filename and often differs from it. Check
+    /// [`Self::modules`] if you are unsure what a module calls itself.
+    ///
+    /// A `loadmodule` directive in the config is not evidence the module
+    /// loaded: a wrong path, an ABI mismatch, or a module whose
+    /// `RedisModule_OnLoad` fails all leave the server running without it.
+    pub async fn has_module(&self, name: &str) -> Result<bool> {
+        Ok(self.modules().await?.iter().any(|m| m.name == name))
+    }
+
+    /// Fail unless a module with this name is loaded.
+    ///
+    /// The error lists what is loaded instead, since the usual cause is a name
+    /// that differs from the filename.
+    pub async fn require_module(&self, name: &str) -> Result<()> {
+        let loaded = self.modules().await?;
+        if loaded.iter().any(|m| m.name == name) {
+            return Ok(());
+        }
+        Err(Error::ModuleNotLoaded {
+            name: name.to_string(),
+            port: self.config.port,
+            loaded: loaded.into_iter().map(|m| m.name).collect(),
+        })
+    }
+
     /// The server's bind address.
     pub fn host(&self) -> &str {
         &self.config.bind
@@ -3465,6 +3522,26 @@ mod tests {
         assert_eq!(s.config.tls_session_cache_timeout, Some(300));
         assert_eq!(s.config.tls_replication, Some(true));
         assert_eq!(s.config.tls_cluster, Some(true));
+    }
+
+    #[test]
+    fn empty_loadmodule_path_is_rejected() {
+        let err = RedisServer::new()
+            .loadmodule("")
+            .validate_modules()
+            .expect_err("an empty module path must be rejected");
+        assert!(matches!(err, Error::InvalidTopology { .. }), "{err}");
+    }
+
+    #[test]
+    fn valid_loadmodule_paths_are_accepted() {
+        assert!(
+            RedisServer::new()
+                .loadmodule("/x/mod.so")
+                .loadmodule_with_args("/y/mod.so", ["a"])
+                .validate_modules()
+                .is_ok()
+        );
     }
 
     #[test]

--- a/tests/module_loading.rs
+++ b/tests/module_loading.rs
@@ -1,0 +1,185 @@
+//! Module loading against a real compiled Redis module.
+//!
+//! The builder surface for `loadmodule` was only ever covered by config-render
+//! assertions, which prove a directive was written and nothing about whether
+//! Redis acted on it. These tests load an actual module and check `MODULE
+//! LIST` on every node of every topology.
+//!
+//! They need a compiled module, which is not something `cargo test` can
+//! produce on its own, so they skip when `REDIS_TEST_MODULE` is unset. Build
+//! the fixture in `tests/support/rsw_test_module.c` and point the variable at
+//! it:
+//!
+//! ```console
+//! cc -fPIC -shared -I<redis-src>/src tests/support/rsw_test_module.c \
+//!    -o /tmp/rsw_test_module.so
+//! REDIS_TEST_MODULE=/tmp/rsw_test_module.so cargo test --all-features
+//! ```
+//!
+//! CI builds it against each Redis version in the compatibility matrix.
+
+use redis_server_wrapper::{Error, RedisCluster, RedisSentinel, RedisServer};
+
+/// The name the fixture registers with `RedisModule_Init`. Deliberately
+/// unlike its filename, since that mismatch is the usual reason a module check
+/// fails.
+const MODULE_NAME: &str = "rsw_test_module";
+
+/// Path to the compiled fixture, or `None` when the suite should skip.
+fn module_path() -> Option<String> {
+    match std::env::var("REDIS_TEST_MODULE") {
+        Ok(path) if !path.trim().is_empty() => {
+            assert!(
+                std::path::Path::new(&path).exists(),
+                "REDIS_TEST_MODULE points at {path}, which does not exist"
+            );
+            Some(path)
+        }
+        _ => {
+            eprintln!("skipping: REDIS_TEST_MODULE is not set");
+            None
+        }
+    }
+}
+
+#[tokio::test]
+async fn standalone_loads_a_module() {
+    let Some(module) = module_path() else { return };
+
+    let server = RedisServer::new()
+        .port(19100)
+        .loadmodule(&module)
+        .start()
+        .await
+        .expect("server with a module should start");
+
+    server
+        .require_module(MODULE_NAME)
+        .await
+        .expect("module should be loaded");
+
+    // Listed is not the same as working: prove the module is actually serving.
+    let echoed = server
+        .run(&["RSW.ECHO", "hello"])
+        .await
+        .expect("the module's command should be callable");
+    assert_eq!(echoed.trim(), "hello");
+}
+
+#[tokio::test]
+async fn module_metadata_is_reported() {
+    let Some(module) = module_path() else { return };
+
+    let server = RedisServer::new()
+        .port(19101)
+        .loadmodule(&module)
+        .start()
+        .await
+        .expect("failed to start");
+
+    let modules = server.modules().await.expect("MODULE LIST failed");
+    let found = modules
+        .iter()
+        .find(|m| m.name == MODULE_NAME)
+        .expect("fixture module missing from MODULE LIST");
+
+    assert_eq!(found.version, Some(1));
+    assert_eq!(found.path, module, "path should be what Redis loaded");
+}
+
+#[tokio::test]
+async fn module_load_time_arguments_reach_the_module() {
+    let Some(module) = module_path() else { return };
+
+    // An argument containing a space is the case that silently became two
+    // arguments before config values were encoded as single tokens.
+    let server = RedisServer::new()
+        .port(19102)
+        .loadmodule_with_args(&module, ["alpha", "two words"])
+        .start()
+        .await
+        .expect("failed to start with module arguments");
+
+    let modules = server.modules().await.expect("MODULE LIST failed");
+    let found = modules
+        .iter()
+        .find(|m| m.name == MODULE_NAME)
+        .expect("fixture module missing");
+
+    assert_eq!(
+        found.args,
+        vec!["alpha", "two words"],
+        "an argument with a space must arrive as one argument"
+    );
+}
+
+#[tokio::test]
+async fn missing_module_reports_what_is_loaded() {
+    let Some(module) = module_path() else { return };
+
+    let server = RedisServer::new()
+        .port(19103)
+        .loadmodule(&module)
+        .start()
+        .await
+        .expect("failed to start");
+
+    let err = server
+        .require_module("not_a_real_module")
+        .await
+        .expect_err("a module that is not loaded must be an error");
+
+    match err {
+        Error::ModuleNotLoaded { name, loaded, .. } => {
+            assert_eq!(name, "not_a_real_module");
+            assert!(
+                loaded.iter().any(|m| m == MODULE_NAME),
+                "the error should list what is loaded, got: {loaded:?}"
+            );
+        }
+        other => panic!("unexpected error: {other}"),
+    }
+}
+
+#[tokio::test]
+async fn every_cluster_node_loads_the_module() {
+    let Some(module) = module_path() else { return };
+
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .replicas_per_master(1)
+        .base_port(19110)
+        .loadmodule(&module)
+        .start()
+        .await
+        .expect("cluster with a module should start");
+
+    cluster
+        .require_module_on_all_nodes(MODULE_NAME)
+        .await
+        .expect("every node should have the module");
+
+    assert_eq!(cluster.nodes().len(), 6);
+}
+
+#[tokio::test]
+async fn every_sentinel_data_node_loads_the_module() {
+    let Some(module) = module_path() else { return };
+
+    let sentinel = RedisSentinel::builder()
+        .master_port(19130)
+        .replica_base_port(19131)
+        .sentinel_base_port(29130)
+        .replicas(2)
+        .sentinels(3)
+        .quorum(2)
+        .loadmodule(&module)
+        .start()
+        .await
+        .expect("sentinel topology with a module should start");
+
+    sentinel
+        .require_module_on_data_nodes(MODULE_NAME)
+        .await
+        .expect("master and every replica should have the module");
+}

--- a/tests/support/rsw_test_module.c
+++ b/tests/support/rsw_test_module.c
@@ -1,0 +1,53 @@
+/*
+ * A minimal Redis module used only to prove the wrapper actually loads modules.
+ *
+ * It registers a name and one command and does nothing else. The point is to
+ * be trivially buildable on any platform with a C compiler, so the module
+ * loading path can be tested against a real `redis-server` without pulling in
+ * a module framework or a second language toolchain.
+ *
+ * Build (needs redismodule.h from the matching Redis source tree):
+ *
+ *   cc -fPIC -shared -I<redis-src>/src tests/support/rsw_test_module.c \
+ *      -o /tmp/rsw_test_module.so
+ *
+ * Then point the test suite at it:
+ *
+ *   REDIS_TEST_MODULE=/tmp/rsw_test_module.so cargo test --all-features
+ *
+ * Tests that need a module skip themselves when that variable is unset, so a
+ * plain `cargo test` on a machine without a compiled module still passes.
+ */
+
+#include "redismodule.h"
+
+/* RSW.ECHO <value> -- returns its argument.
+ *
+ * Exists so a test can prove the module is not merely listed but actually
+ * serving commands. */
+static int RswEcho_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
+                                int argc) {
+    if (argc != 2) {
+        return RedisModule_WrongArity(ctx);
+    }
+    RedisModule_ReplyWithString(ctx, argv[1]);
+    return REDISMODULE_OK;
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv,
+                       int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (RedisModule_Init(ctx, "rsw_test_module", 1, REDISMODULE_APIVER_1) ==
+        REDISMODULE_ERR) {
+        return REDISMODULE_ERR;
+    }
+
+    if (RedisModule_CreateCommand(ctx, "rsw.echo", RswEcho_RedisCommand,
+                                  "readonly", 0, 0, 0) == REDISMODULE_ERR) {
+        return REDISMODULE_ERR;
+    }
+
+    return REDISMODULE_OK;
+}


### PR DESCRIPTION
Closes #138.

## Fixture: matching the Elixir sibling

Worth flagging, because it changes the shape of this PR from what the issue
implied. The Elixir sibling does not use `redis-event-stream-module` as its
test fixture. That repository appears there only as a runnable example. Its
actual CI fixture is `test/support/version_matrix_module.c`, a 13-line C
module compiled with one `cc` invocation.

Matched that. `tests/support/rsw_test_module.c` registers a name and one
command (`RSW.ECHO`) and does nothing else.

This is better than the alternative here: `redis-event-stream-module` is a
Rust cdylib with a git-pinned `redis-module` dependency that drags in bindgen
and clang, so using it would have made every module test build a second crate
and coupled this work to the Redis version matrix in #148. The C fixture has
neither problem.

## What this adds

| Method | Scope |
|---|---|
| `RedisServerHandle::modules` | parsed `MODULE LIST` |
| `RedisServerHandle::has_module` | one server |
| `RedisServerHandle::require_module` | one server, errors with what is loaded |
| `RedisClusterHandle::require_module_on_all_nodes` | every node |
| `RedisSentinelHandle::require_module_on_data_nodes` | master and replicas |

`Error::ModuleNotLoaded` lists the modules actually present, since the usual
cause is a module name that differs from its filename.

Also rejects an empty `loadmodule` path at `start`, rather than emitting
`loadmodule ""` for Redis to reject without naming the builder call.

## Parsing

redis-cli flattens the reply to one value per line. Pairwise key/value parsing
does not work: `args` is variable length, so a module with two arguments
swallows the next module's record. The parser instead uses the fixed key order
Redis emits (`name`, `ver`, `path`, `args`, with `args` last), which is
recoverable. Unit tests cover captured output from Redis 8.8.1 for the
one-module, two-module, with-args, and Redis-6-shaped cases.

`--json` would be cleaner but needs a JSON parser, and this crate's entire
dependency set is five entries.

## Running the tests

They skip when `REDIS_TEST_MODULE` is unset, so `cargo test` still passes with
no fixture:

```bash
cc -fPIC -shared -I<redis-src>/src tests/support/rsw_test_module.c -o /tmp/rsw_test_module.so
```

CI builds the fixture against the header matching its installed Redis. That
step is best effort: a fetch failure leaves the tests skipping with a workflow
warning rather than failing the run, because the distro Redis packages do not
ship `redismodule.h`. Module coverage becomes authoritative in the
compatibility workflow from #148, which builds Redis from source and therefore
has the real header. Wiring it in there is a follow-up once that merges, to
avoid both branches editing the same new file.

## Verification

Full suite green with `REDIS_TEST_MODULE` set, including the 6 module tests
against real Redis 8.8.1. clippy `-D warnings`, fmt, and docs clean.

The load-time argument test asserts that `["alpha", "two words"]` arrives as
two arguments rather than three. That is the bug fixed in #142, which until
now had only a config-render assertion behind it.