### PR TITLE
ci: build the module fixture in the Redis compatibility matrix

### DIFF
--- a/.github/workflows/redis-compat.yml
+++ b/.github/workflows/redis-compat.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/redis-dist
-          key: redis-${{ matrix.redis }}-${{ runner.os }}
+          key: redis-${{ matrix.redis }}-${{ runner.os }}-v2
 
       - name: Build Redis ${{ matrix.redis }}
         if: steps.redis-cache.outputs.cache-hit != 'true'
@@ -81,6 +81,10 @@ jobs:
           make -C /tmp/redis-src -j"$(nproc)" BUILD_TLS=yes
           mkdir -p ~/redis-dist
           cp /tmp/redis-src/src/redis-server /tmp/redis-src/src/redis-cli ~/redis-dist/
+          # Keep the module API header too. On a cache hit the source tree
+          # is gone, and this is the only copy of redismodule.h that is
+          # guaranteed to match the Redis actually under test.
+          cp /tmp/redis-src/src/redismodule.h ~/redis-dist/
 
       - name: Put Redis ${{ matrix.redis }} on PATH
         run: |
@@ -98,6 +102,19 @@ jobs:
           # matrix report a pass it never earned.
           redis-server --version | grep -q "v=${{ matrix.redis }}"
 
+      # Unlike the main workflow, which fetches a header over the network and
+      # tolerates failure, this builds against the header from the very source
+      # tree that produced the redis-server under test. Module coverage is
+      # authoritative here, so a failure to build the fixture is a hard error
+      # rather than a silent skip.
+      - name: Build Redis test module for ${{ matrix.redis }}
+        run: |
+          set -euo pipefail
+          cc -fPIC -shared -I "$HOME/redis-dist" \
+            tests/support/rsw_test_module.c \
+            -o "${RUNNER_TEMP}/rsw_test_module.so"
+          echo "REDIS_TEST_MODULE=${RUNNER_TEMP}/rsw_test_module.so" >> "$GITHUB_ENV"
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
@@ -107,4 +124,10 @@ jobs:
           shared-key: "redis-compat"
 
       - name: Run test suite against Redis ${{ matrix.redis }}
-        run: cargo test --all-features --verbose
+        run: |
+          set -euo pipefail
+          # A test that skips by returning early reports "ok", so an unset
+          # fixture would look like a pass. Fail instead.
+          test -n "${REDIS_TEST_MODULE:-}"
+          test -f "${REDIS_TEST_MODULE}"
+          cargo test --all-features --verbose


### PR DESCRIPTION
Follow-up to #148 and #149, both now merged.

## Why

The module tests from #149 need `REDIS_TEST_MODULE` pointing at a compiled
module. The main workflow builds it best effort: it fetches `redismodule.h`
over the network and tolerates failure, because the distro Redis packages do
not ship the header. That works, but it means module coverage depends on a
network fetch and degrades to a silent skip.

The compatibility workflow builds Redis from source, so the header matching
the exact `redis-server` under test is already on disk. Building the fixture
there makes module coverage authoritative on every supported line.

## Changes

- Copy `redismodule.h` into the cached distribution next to the binaries. On a
  cache hit the source tree is gone, so this is the only copy guaranteed to
  match the server under test.
- Bump the cache key to `-v2`, since entries written under the old key hold
  binaries without the header.
- Build the fixture per matrix cell and export `REDIS_TEST_MODULE`.
- Assert the fixture exists before running the suite.

## On that last point

A test that skips by returning early reports `ok`. An unset
`REDIS_TEST_MODULE` would therefore look like a passing module run on the very
workflow meant to be authoritative for module support. The check turns that
into a failure.

The same wart affects the MSRV job in the main workflow, which has no fixture
step and so skips the module tests while reporting them as passed. Tracked in
#151.

## Verification

Both workflow files parse. The matrix itself can only be verified by running
it, which this PR does across all four supported Redis lines.