### PR TITLE
feat: add collision-aware automatic port allocation

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -502,6 +502,15 @@ impl RedisServer {
         self
     }
 
+    /// Let the wrapper pick a free port at start.
+    ///
+    /// See [`crate::server::RedisServer::auto_port`] for the race handling and
+    /// why this is not spelled `port(0)`.
+    pub fn auto_port(mut self) -> Self {
+        self.inner = self.inner.auto_port();
+        self
+    }
+
     /// Set the bind address (default: `127.0.0.1`).
     pub fn bind(mut self, bind: impl Into<String>) -> Self {
         self.inner = self.inner.bind(bind);

--- a/src/error.rs
+++ b/src/error.rs
@@ -138,6 +138,23 @@ pub enum Error {
         loaded: Vec<String>,
     },
 
+    /// Automatic port allocation ran out of attempts.
+    ///
+    /// Every candidate the OS handed out was claimed by another process
+    /// before `redis-server` could bind it. On a normal machine this does not
+    /// happen: it points at something aggressively grabbing ephemeral ports,
+    /// or at an exhausted ephemeral range.
+    #[error(
+        "could not acquire a free port after {attempts} attempts{}",
+        last.as_deref().map(|e| format!(" (last failure: {e})")).unwrap_or_default()
+    )]
+    PortAllocation {
+        /// How many candidates were tried.
+        attempts: usize,
+        /// The failure from the final attempt, if there was one.
+        last: Option<String>,
+    },
+
     /// A topology was described in a way that cannot be started.
     ///
     /// Returned before anything starts, so a rejected topology leaves no

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -10,7 +10,7 @@
 //! belongs to something else. These helpers check first and fail with the port
 //! named, leaving whatever holds it alone.
 
-use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::time::Duration;
 
 use crate::error::{Error, Result};
@@ -110,6 +110,23 @@ pub fn ensure_ports_available(
     Ok(())
 }
 
+/// Ask the OS for a port that is free right now.
+///
+/// Binds `127.0.0.1:0`, reads back what the kernel assigned, and releases it.
+/// The port is free at the moment it is returned and nothing holds it
+/// afterwards, so another process can claim it before the caller does.
+///
+/// That window is unavoidable: reserving a port and handing it to a separate
+/// process that must bind it itself cannot be atomic. Callers are expected to
+/// treat the result as a candidate and retry on a lost race, which is what
+/// [`crate::server::RedisServer::auto_port`] does.
+pub fn reserve_ephemeral_port() -> Result<u16> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).map_err(Error::Io)?;
+    let port = listener.local_addr().map_err(Error::Io)?.port();
+    drop(listener);
+    Ok(port)
+}
+
 /// The cluster bus port Redis derives from a client port.
 ///
 /// Redis uses client port + 10000 unless `cluster-port` overrides it. Returns
@@ -124,7 +141,6 @@ mod tests {
     use super::*;
 
     use std::io::{Read, Write};
-    use std::net::TcpListener;
 
     #[test]
     fn unbound_port_is_available() {
@@ -219,6 +235,28 @@ mod tests {
 
         drop(a);
         drop(b);
+    }
+
+    #[test]
+    fn reserved_port_is_free_when_returned() {
+        let port = reserve_ephemeral_port().expect("the OS should hand out a port");
+        assert_ne!(port, 0, "a reserved port must be concrete");
+        assert!(
+            port_available("127.0.0.1", port),
+            "the reservation must be released, not held"
+        );
+        // Released means bindable, which is what the caller's process needs.
+        TcpListener::bind(("127.0.0.1", port)).expect("reserved port should be bindable");
+    }
+
+    #[test]
+    fn successive_reservations_differ() {
+        // Not a hard guarantee from the OS, but a reservation scheme that
+        // returned the same port twice in a row would defeat the purpose.
+        let a = reserve_ephemeral_port().unwrap();
+        let _hold = TcpListener::bind(("127.0.0.1", a)).unwrap();
+        let b = reserve_ephemeral_port().unwrap();
+        assert_ne!(a, b, "a held port must not be handed out again");
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -310,6 +310,9 @@ pub struct RedisServerConfig {
     /// List of Redis module paths to load at startup, each with its load-time arguments.
     pub loadmodule: Vec<(PathBuf, Vec<String>)>,
 
+    /// Ask the OS for a free port at start instead of using [`Self::port`].
+    pub auto_port: bool,
+
     // -- advanced --
     /// Server tick frequency in Hz, if set (Redis default: `10`).
     pub hz: Option<u32>,
@@ -680,6 +683,7 @@ impl Default for RedisServerConfig {
             stream_idmp_duration: None,
             stream_idmp_maxsize: None,
             loadmodule: Vec::new(),
+            auto_port: false,
             hz: None,
             io_threads: None,
             io_threads_do_reads: None,
@@ -750,6 +754,15 @@ impl Default for RedisServerConfig {
     }
 }
 
+/// How many OS-assigned ports [`RedisServer::auto_port`] will try before
+/// giving up.
+///
+/// Each attempt loses only if another process claims the port in the window
+/// between the OS handing it out and `redis-server` binding it, so needing
+/// even a second attempt is already unusual. The budget exists to bound a
+/// pathological machine, not to be reached.
+pub const MAX_PORT_ATTEMPTS: usize = 8;
+
 /// Builder for a Redis server.
 pub struct RedisServer {
     config: RedisServerConfig,
@@ -768,6 +781,33 @@ impl RedisServer {
     /// Set the listening port (default: 6379).
     pub fn port(mut self, port: u16) -> Self {
         self.config.port = port;
+        self
+    }
+
+    /// Let the wrapper pick a free port at start, for fixtures that run in
+    /// parallel and cannot coordinate a fixed range between them.
+    ///
+    /// Read the chosen port back from [`RedisServerHandle::port`] or
+    /// [`RedisServerHandle::addr`] once started.
+    ///
+    /// This is a separate mode rather than a meaning for `port(0)`, which
+    /// keeps its Redis sense of disabling the plaintext listener for a
+    /// TLS-only server. Setting both takes the automatic port.
+    ///
+    /// # Races
+    ///
+    /// Asking the OS for a free port and having `redis-server` bind it are
+    /// necessarily two steps, so another process can take the port in
+    /// between. That is the flaw in the usual bind-to-zero-and-release
+    /// workaround this replaces. The gap cannot be closed, only handled: a
+    /// candidate lost to another process is abandoned and a new one tried,
+    /// up to [`MAX_PORT_ATTEMPTS`] times, after which
+    /// [`Error::PortAllocation`] is returned.
+    ///
+    /// A lost race never disturbs the winner. Nothing here stops a process
+    /// holding a port the wrapper wanted.
+    pub fn auto_port(mut self) -> Self {
+        self.config.auto_port = true;
         self
     }
 
@@ -2042,6 +2082,50 @@ impl RedisServer {
     /// and that no [`extra`](Self::extra) directive collides with one the
     /// wrapper generates, before attempting to launch anything.
     pub async fn start(self) -> Result<RedisServerHandle> {
+        if self.config.auto_port {
+            return self.start_on_an_automatic_port().await;
+        }
+        self.start_on_the_configured_port().await
+    }
+
+    /// Try successive OS-assigned ports until one sticks.
+    ///
+    /// Only a lost race retries. Any other failure is a property of the
+    /// configuration rather than of the port, and retrying it would just fail
+    /// again on a different number.
+    async fn start_on_an_automatic_port(self) -> Result<RedisServerHandle> {
+        let mut last: Option<Error> = None;
+
+        for _ in 0..MAX_PORT_ATTEMPTS {
+            let mut attempt = RedisServer {
+                config: self.config.clone(),
+            };
+            let candidate = crate::preflight::reserve_ephemeral_port()?;
+            attempt.config.port = candidate;
+
+            match attempt.start_on_the_configured_port().await {
+                Ok(handle) => return Ok(handle),
+                // Someone took the candidate between reserving it and binding
+                // it. Their process is left alone; take a different number.
+                Err(e @ (Error::PortInUse { .. } | Error::ServerStart { .. })) => {
+                    tracing::debug!(port = candidate, "auto_port_retry");
+                    last = Some(e);
+                }
+                Err(other) => return Err(other),
+            }
+        }
+
+        Err(Error::PortAllocation {
+            attempts: MAX_PORT_ATTEMPTS,
+            last: last.map(|e| e.to_string()),
+        })
+    }
+
+    /// Start on whatever port the config already names.
+    ///
+    /// The span lives here rather than on `start` so each automatic-port
+    /// attempt is its own span, carrying the port it actually tried.
+    async fn start_on_the_configured_port(self) -> Result<RedisServerHandle> {
         let span = tracing::debug_span!(
             "server_start",
             port = self.config.port,

--- a/tests/auto_port.rs
+++ b/tests/auto_port.rs
@@ -1,0 +1,146 @@
+//! Automatic port allocation for fixtures that run in parallel.
+//!
+//! The pattern this replaces is binding `127.0.0.1:0`, reading the assigned
+//! port, dropping the listener, and passing the number to the builder. That
+//! leaves a window where another process can take the port before Redis binds
+//! it, and the caller has no way to recover. `auto_port` keeps the same
+//! reservation trick but owns the retry.
+
+use redis_server_wrapper::RedisServer;
+
+#[tokio::test]
+async fn auto_port_starts_on_a_usable_port() {
+    let server = RedisServer::new()
+        .auto_port()
+        .start()
+        .await
+        .expect("a server with an automatic port should start");
+
+    let port = server.port();
+    assert_ne!(port, 0, "the handle must report the port actually chosen");
+    assert_eq!(server.addr(), format!("127.0.0.1:{port}"));
+
+    // The reported port is the one serving, not just a number that was free.
+    server.run(&["SET", "k", "v"]).await.expect("SET failed");
+    let value = server.run(&["GET", "k"]).await.expect("GET failed");
+    assert_eq!(value.trim(), "v");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_fixtures_get_distinct_ports() {
+    // The case the issue was filed for: independent tests each owning a Redis
+    // lifecycle, with no coordinated port range between them. Started on
+    // separate tasks so the reservations genuinely overlap.
+    const FIXTURES: usize = 12;
+
+    let mut tasks = Vec::with_capacity(FIXTURES);
+    for _ in 0..FIXTURES {
+        tasks.push(tokio::spawn(async {
+            RedisServer::new()
+                .auto_port()
+                .start()
+                .await
+                .expect("fixture should start")
+        }));
+    }
+
+    let mut servers = Vec::with_capacity(FIXTURES);
+    for task in tasks {
+        servers.push(task.await.expect("fixture task panicked"));
+    }
+
+    let mut ports: Vec<u16> = servers.iter().map(|s| s.port()).collect();
+    let before = ports.len();
+    assert_eq!(before, FIXTURES);
+
+    ports.sort_unstable();
+    ports.dedup();
+    assert_eq!(ports.len(), before, "every fixture must get its own port");
+
+    // All of them are still up: allocation did not stop an earlier fixture.
+    for server in &servers {
+        assert!(server.is_alive().await, "fixture on {} died", server.port());
+    }
+}
+
+#[tokio::test]
+async fn allocation_never_disturbs_the_process_holding_a_port() {
+    // Stand a server on a fixed port, then allocate many automatic ones. The
+    // fixed server must be untouched: automatic allocation abandons a
+    // contested candidate, it never clears one.
+    let bystander = RedisServer::new()
+        .port(19300)
+        .start()
+        .await
+        .expect("bystander should start");
+    bystander
+        .run(&["SET", "precious", "data"])
+        .await
+        .expect("seed failed");
+
+    let mut allocated = Vec::new();
+    for _ in 0..8 {
+        allocated.push(
+            RedisServer::new()
+                .auto_port()
+                .start()
+                .await
+                .expect("automatic allocation should succeed"),
+        );
+    }
+
+    for server in &allocated {
+        assert_ne!(
+            server.port(),
+            19300,
+            "allocation handed out a port that was already serving"
+        );
+    }
+
+    assert!(bystander.is_alive().await);
+    let value = bystander
+        .run(&["GET", "precious"])
+        .await
+        .expect("bystander should still answer");
+    assert_eq!(value.trim(), "data");
+}
+
+#[tokio::test]
+async fn explicit_port_zero_is_not_automatic_allocation() {
+    // port(0) keeps its Redis meaning of disabling the plaintext listener, so
+    // it must not be quietly reinterpreted as a request for a free port. With
+    // no TLS configured that is a server with no listener at all, which fails
+    // to become ready rather than silently coming up on some other port.
+    let result = RedisServer::new().port(0).start().await;
+
+    match result {
+        Ok(handle) => panic!(
+            "port(0) should not have produced a reachable server, got port {}",
+            handle.port()
+        ),
+        Err(e) => {
+            let text = e.to_string();
+            assert!(
+                !text.contains("could not acquire a free port"),
+                "port(0) must not have been treated as automatic allocation: {text}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn auto_port_overrides_a_configured_port() {
+    let server = RedisServer::new()
+        .port(19301)
+        .auto_port()
+        .start()
+        .await
+        .expect("failed to start");
+
+    assert_ne!(
+        server.port(),
+        19301,
+        "auto_port should take precedence over an explicit port"
+    );
+    assert!(server.is_alive().await);
+}


### PR DESCRIPTION
Closes #146.

## Plan

Add `RedisServer::auto_port()`, a separate mode rather than an overload of
`port()`, since `port(0)` keeps its Redis meaning of disabling the plaintext
listener for TLS-only configurations.

1. `preflight::reserve_ephemeral_port` asks the OS for a free port by binding
   `127.0.0.1:0` and releasing it. That is the same pattern callers use today,
   and it carries the same TOCTOU window, which is why the builder retries
   rather than trusting the first answer.
2. `start` retries on a lost race. `RedisServer` is a cloneable config, so each
   attempt takes a fresh candidate and runs the normal start path. Only
   port-acquisition failures retry: any other error returns immediately, since
   retrying a bad config would just fail again more slowly.
3. Exhausting the attempt budget returns a specific error rather than a
   generic start failure.
4. Nothing about the fail-closed guarantee from #145 changes. A candidate that
   turns out to be occupied is abandoned, never cleared, so a losing race
   leaves the winner untouched.

Scope is `RedisServer` only, as the issue suggests. Cluster and Sentinel need
contiguous ranges plus bus ports, which is a different allocation problem.

## Testing

- Concurrent allocation: many fixtures started at once all come up on distinct
  ports.
- A collision leaves the process that won the port running and serving.
- `port(0)` still means TLS-only, not auto.