### PR TITLE
feat: tracing instrumentation across lifecycle modules (closes #121)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ test-tls = ["dep:rcgen"]
 glob = "0.3"
 thiserror = "2"
 tokio = { version = "1", features = ["process", "time", "rt", "macros", "rt-multi-thread", "net", "io-util", "sync"], optional = true }
+tracing = { version = "0.1", default-features = false, features = ["std", "log"] }
 which = "7"
 rcgen = { version = "0.13", optional = true }
 

--- a/src/chaos.rs
+++ b/src/chaos.rs
@@ -64,6 +64,7 @@ use tokio::io::AsyncReadExt;
 /// swallows a failed kill.
 #[cfg(feature = "tokio")]
 fn send_signal(pid: u32, signal_flag: &str) -> Result<()> {
+    tracing::debug!(pid, signal = signal_flag, "send_signal");
     let output = Command::new("kill")
         .args([signal_flag, &pid.to_string()])
         .output()?;
@@ -88,6 +89,7 @@ fn send_signal(pid: u32, signal_flag: &str) -> Result<()> {
 /// a hard crash (e.g., OOM kill, hardware failure).
 #[cfg(feature = "tokio")]
 pub fn kill_node(handle: &RedisServerHandle) -> Result<()> {
+    tracing::info!(port = handle.port(), pid = handle.pid(), "kill_node");
     send_signal(handle.pid(), "-9")
 }
 
@@ -101,6 +103,7 @@ pub fn kill_node(handle: &RedisServerHandle) -> Result<()> {
 /// partition scenarios because the node can be resumed without losing state.
 #[cfg(feature = "tokio")]
 pub fn freeze_node(handle: &RedisServerHandle) -> Result<()> {
+    tracing::info!(port = handle.port(), pid = handle.pid(), "freeze_node");
     send_signal(handle.pid(), "-STOP")
 }
 
@@ -110,6 +113,7 @@ pub fn freeze_node(handle: &RedisServerHandle) -> Result<()> {
 /// replication will catch up automatically.
 #[cfg(feature = "tokio")]
 pub fn resume_node(handle: &RedisServerHandle) -> Result<()> {
+    tracing::info!(port = handle.port(), pid = handle.pid(), "resume_node");
     send_signal(handle.pid(), "-CONT")
 }
 
@@ -128,6 +132,12 @@ pub fn resume_node(handle: &RedisServerHandle) -> Result<()> {
 #[cfg(feature = "tokio")]
 pub fn pause_node(handle: &RedisServerHandle, duration: Duration) -> Result<()> {
     let pid = handle.pid();
+    tracing::info!(
+        port = handle.port(),
+        pid,
+        duration_ms = duration.as_millis() as u64,
+        "pause_node"
+    );
     send_signal(pid, "-STOP")?;
     tokio::spawn(async move {
         tokio::time::sleep(duration).await;
@@ -146,6 +156,7 @@ pub fn pause_node(handle: &RedisServerHandle, duration: Duration) -> Result<()> 
 /// See [`slow_down_writes`] to pause only write commands instead.
 #[cfg(feature = "tokio")]
 pub async fn slow_down(handle: &RedisServerHandle, millis: u64) -> Result<String> {
+    tracing::info!(port = handle.port(), millis, "slow_down");
     handle.run(&["CLIENT", "PAUSE", &millis.to_string()]).await
 }
 
@@ -157,6 +168,7 @@ pub async fn slow_down(handle: &RedisServerHandle, millis: u64) -> Result<String
 /// (e.g. during a failover) without blocking reads too.
 #[cfg(feature = "tokio")]
 pub async fn slow_down_writes(handle: &RedisServerHandle, millis: u64) -> Result<String> {
+    tracing::info!(port = handle.port(), millis, "slow_down_writes");
     handle
         .run(&["CLIENT", "PAUSE", &millis.to_string(), "WRITE"])
         .await
@@ -165,12 +177,14 @@ pub async fn slow_down_writes(handle: &RedisServerHandle, millis: u64) -> Result
 /// Trigger a background RDB save.
 #[cfg(feature = "tokio")]
 pub async fn trigger_save(handle: &RedisServerHandle) -> Result<String> {
+    tracing::info!(port = handle.port(), "trigger_save");
     handle.run(&["BGSAVE"]).await
 }
 
 /// Flush all data from a node.
 #[cfg(feature = "tokio")]
 pub async fn flushall(handle: &RedisServerHandle) -> Result<String> {
+    tracing::info!(port = handle.port(), "flushall");
     handle.run(&["FLUSHALL"]).await
 }
 
@@ -193,6 +207,7 @@ pub async fn flushall(handle: &RedisServerHandle) -> Result<String> {
 /// one.
 #[cfg(feature = "tokio")]
 pub async fn fill_memory(handle: &RedisServerHandle, prefix: &str, count: usize) -> Result<()> {
+    tracing::info!(port = handle.port(), prefix, count, "fill_memory");
     let value = "x".repeat(1024);
     handle
         .run(&[
@@ -225,6 +240,7 @@ pub async fn fill_memory(handle: &RedisServerHandle, prefix: &str, count: usize)
 /// configuration the node was started with, not on this call.
 #[cfg(feature = "tokio")]
 pub async fn restart_node(handle: &mut RedisServerHandle, timeout: Duration) -> Result<()> {
+    tracing::info!(port = handle.port(), "restart_node");
     handle.restart(timeout).await
 }
 
@@ -306,6 +322,12 @@ pub async fn kill_client_connections(
     handle: &RedisServerHandle,
     filter: ClientKillFilter,
 ) -> Result<u64> {
+    tracing::info!(
+        port = handle.port(),
+        ty = ?filter.ty,
+        addr = filter.addr.as_deref(),
+        "kill_client_connections"
+    );
     let mut args: Vec<String> = vec!["CLIENT".into(), "KILL".into()];
     if let Some(ty) = filter.ty {
         args.push("TYPE".into());
@@ -347,6 +369,11 @@ pub async fn kill_client_connections(
 /// script or a large O(N) command produces in a real incident.
 #[cfg(feature = "tokio")]
 pub fn block_event_loop(handle: &RedisServerHandle, duration: Duration) -> Result<()> {
+    tracing::info!(
+        port = handle.port(),
+        duration_ms = duration.as_millis() as u64,
+        "block_event_loop"
+    );
     let cli = handle.cli().clone();
     tokio::spawn(async move {
         let secs = duration.as_secs_f64().to_string();
@@ -371,6 +398,7 @@ pub fn block_event_loop(handle: &RedisServerHandle, duration: Duration) -> Resul
 /// replica while that happens.
 #[cfg(feature = "tokio")]
 pub async fn force_full_resync(master: &RedisServerHandle) -> Result<()> {
+    tracing::info!(port = master.port(), "force_full_resync");
     master.run(&["DEBUG", "CHANGE-REPL-ID"]).await?;
     master.run(&["CLIENT", "KILL", "TYPE", "replica"]).await?;
     Ok(())
@@ -450,6 +478,7 @@ pub async fn break_persistence(
                 .to_string(),
         });
     }
+    tracing::info!(port = handle.port(), "break_persistence");
 
     let dir = PathBuf::from(config_get_single(handle, "dir").await?);
     let metadata = std::fs::metadata(&dir)?;
@@ -492,6 +521,7 @@ impl<'a> PersistenceGuard<'a> {
     /// so restoring permissions alone is not enough to undo
     /// [`break_persistence`].
     pub async fn restore(mut self, timeout: Duration) -> Result<()> {
+        tracing::info!(port = self.handle.port(), "persistence_restore");
         let mut perms = std::fs::metadata(&self.dir)?.permissions();
         perms.set_mode(self.original_mode);
         std::fs::set_permissions(&self.dir, perms)?;
@@ -522,6 +552,7 @@ impl Drop for PersistenceGuard<'_> {
         if self.resolved {
             return;
         }
+        tracing::warn!(port = self.handle.port(), "persistence_guard_drop_reset");
         // Best-effort: at least restore write access synchronously so the
         // node's data directory isn't left unwritable if the test never
         // calls `restore`. Can't await here, so this doesn't confirm BGSAVE
@@ -578,6 +609,7 @@ pub async fn exhaust_maxclients(
     handle: &RedisServerHandle,
     maxclients: Option<u32>,
 ) -> Result<ClientFloodGuard<'_>> {
+    tracing::info!(port = handle.port(), ?maxclients, "exhaust_maxclients");
     let previous_maxclients = if let Some(n) = maxclients {
         let previous = config_get_single(handle, "maxclients").await?;
         handle
@@ -645,6 +677,7 @@ impl<'a> ClientFloodGuard<'a> {
     /// is no free slot to run `CONFIG SET` on until connections are freed
     /// first.
     pub async fn release(mut self) -> Result<()> {
+        tracing::info!(port = self.handle.port(), "client_flood_release");
         self.sockets.clear();
         if let Some(previous) = self.previous_maxclients.take() {
             self.handle
@@ -683,6 +716,13 @@ pub struct FlapGuard {
 #[cfg(feature = "tokio")]
 pub fn flap_node(handle: &RedisServerHandle, down: Duration, up: Duration) -> Result<FlapGuard> {
     let pid = handle.pid();
+    tracing::info!(
+        port = handle.port(),
+        pid,
+        down_ms = down.as_millis() as u64,
+        up_ms = up.as_millis() as u64,
+        "flap_node"
+    );
     send_signal(pid, "-STOP")?;
 
     let stop = Arc::new(AtomicBool::new(false));
@@ -710,6 +750,7 @@ pub fn flap_node(handle: &RedisServerHandle, down: Duration, up: Duration) -> Re
 #[cfg(feature = "tokio")]
 impl Drop for FlapGuard {
     fn drop(&mut self) {
+        tracing::debug!(pid = self.pid, "flap_guard_drop");
         self.stop.store(true, Ordering::Relaxed);
         self.task.abort();
         let _ = send_signal(self.pid, "-CONT");
@@ -730,6 +771,7 @@ impl Drop for FlapGuard {
 #[cfg(feature = "tokio")]
 pub async fn kill_master_by_slot(cluster: &RedisClusterHandle, slot: u16) -> Result<u16> {
     let owner = find_slot_owner(cluster, slot).await?;
+    tracing::info!(slot, port = owner.port(), "kill_master_by_slot");
     send_signal(owner.pid(), "-9")?;
     Ok(owner.port())
 }
@@ -751,6 +793,7 @@ pub async fn kill_master_by_key(cluster: &RedisClusterHandle, key: &str) -> Resu
 #[cfg(feature = "tokio")]
 pub async fn freeze_master_by_slot(cluster: &RedisClusterHandle, slot: u16) -> Result<u16> {
     let owner = find_slot_owner(cluster, slot).await?;
+    tracing::info!(slot, port = owner.port(), "freeze_master_by_slot");
     send_signal(owner.pid(), "-STOP")?;
     Ok(owner.port())
 }
@@ -763,6 +806,7 @@ pub async fn freeze_master_by_slot(cluster: &RedisClusterHandle, slot: u16) -> R
 /// `CLUSTER FAILOVER FORCE`.
 #[cfg(feature = "tokio")]
 pub async fn trigger_failover(replica: &RedisServerHandle) -> Result<String> {
+    tracing::info!(port = replica.port(), "trigger_failover");
     match replica.run(&["CLUSTER", "FAILOVER"]).await {
         Ok(result) if !result.contains("ERR") => Ok(result),
         _ => replica.run(&["CLUSTER", "FAILOVER", "FORCE"]).await,
@@ -778,6 +822,7 @@ pub async fn trigger_failover(replica: &RedisServerHandle) -> Result<String> {
 /// stay frozen; call [`recover`] to heal the partition either way.
 #[cfg(feature = "tokio")]
 pub fn partition(cluster: &RedisClusterHandle, reachable: &[usize]) -> Result<Vec<u16>> {
+    tracing::info!(?reachable, "partition");
     let mut frozen = Vec::new();
     for (i, node) in cluster.nodes().iter().enumerate() {
         if !reachable.contains(&i) {
@@ -799,6 +844,7 @@ pub fn partition(cluster: &RedisClusterHandle, reachable: &[usize]) -> Result<Ve
 /// from resuming. Returns the first failure, if any, after the full pass.
 #[cfg(feature = "tokio")]
 pub fn recover(cluster: &RedisClusterHandle) -> Result<()> {
+    tracing::info!(nodes = cluster.nodes().len(), "recover");
     let mut first_err = None;
     for node in cluster.nodes() {
         if let Err(e) = send_signal(node.pid(), "-CONT")
@@ -856,6 +902,7 @@ pub async fn crash_sentinel_during_failover(
     sentinel_idx: usize,
     point: SentinelCrashPoint,
 ) -> Result<()> {
+    tracing::info!(sentinel_idx, ?point, "crash_sentinel_during_failover");
     let cli = handle.sentinel_cli(sentinel_idx)?;
     let mode = match point {
         SentinelCrashPoint::AfterElection => "crash-after-election",
@@ -981,6 +1028,7 @@ impl<'a> ReshardGuard<'a> {
         from: &'a RedisServerHandle,
         to: &'a RedisServerHandle,
     ) -> Result<ReshardGuard<'a>> {
+        tracing::info!(slot, from = from.port(), to = to.port(), "reshard_start");
         let from_id = node_id(from).await?;
         let to_id = node_id(to).await?;
         let slot_str = slot.to_string();
@@ -1004,6 +1052,7 @@ impl<'a> ReshardGuard<'a> {
     /// Safe to call more than once (e.g. to sweep up keys written after a
     /// previous call). Returns the number of keys moved by this call.
     pub async fn migrate_keys(&self) -> Result<usize> {
+        tracing::info!(slot = self.slot, "reshard_migrate_keys");
         let password = self.cluster.password();
         let to_host = self.to.host().to_string();
         let to_port = self.to.port().to_string();
@@ -1037,6 +1086,7 @@ impl<'a> ReshardGuard<'a> {
     /// Finish the migration: sweep up any remaining keys, then reassign
     /// `slot` to the target node on every master.
     pub async fn complete(mut self) -> Result<usize> {
+        tracing::info!(slot = self.slot, "reshard_complete");
         let moved = self.migrate_keys().await?;
         let slot_str = self.slot.to_string();
         for node in self.cluster.master_nodes() {
@@ -1055,6 +1105,7 @@ impl<'a> ReshardGuard<'a> {
     /// leave a few keys reachable only via the target until the next
     /// reshard picks them up.
     pub async fn abort(mut self) -> Result<()> {
+        tracing::info!(slot = self.slot, "reshard_abort");
         let slot_str = self.slot.to_string();
         self.from
             .run(&["CLUSTER", "SETSLOT", &slot_str, "STABLE"])
@@ -1073,6 +1124,7 @@ impl Drop for ReshardGuard<'_> {
         if self.resolved {
             return;
         }
+        tracing::warn!(slot = self.slot, "reshard_guard_drop_reset");
         let slot_str = self.slot.to_string();
         self.from
             .cli()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -643,7 +643,13 @@ impl RedisCli {
     /// [`exit_error_code`](Self::exit_error_code)) redis-cli exits non-zero
     /// for `NOAUTH`, `ERR`, `WRONGTYPE`, `MOVED`, and the rest, and this
     /// returns [`Error::Cli`] carrying the error text.
+    ///
+    /// Traces `args` at `TRACE` with secrets redacted -- the connection's
+    /// own password never appears here (it goes through the `REDISCLI_AUTH`
+    /// environment variable instead), but caller-supplied args can carry one, e.g.
+    /// `chaos::ReshardGuard::migrate_keys`'s `MIGRATE ... AUTH <password>`.
     pub async fn run(&self, args: &[&str]) -> Result<String> {
+        tracing::trace!(host = %self.host, port = self.port, cmd = %redact(args), "run");
         let output = self.raw_output(args).await?;
         if output.status.success() {
             Ok(String::from_utf8_lossy(&output.stdout).to_string())
@@ -1073,6 +1079,58 @@ impl Default for RedisCli {
     }
 }
 
+/// Redact secrets out of a command's argument list before it's logged.
+///
+/// [`RedisCli::run`] never sees the connection's own password (that goes
+/// through `REDISCLI_AUTH`, see [`RedisCli::auth_env`]), but callers can
+/// still pass one directly as a command argument -- `MIGRATE ... AUTH
+/// <password>` (and `AUTH2 <username> <password>`) built by
+/// `chaos::ReshardGuard::migrate_keys`, or a `CONFIG SET requirepass
+/// <value>` / `CONFIG SET masterauth <value>` issued through a generic
+/// `CONFIG SET` helper. This masks:
+///
+/// - the token immediately following a (case-insensitive) `AUTH`
+/// - both tokens immediately following `AUTH2` (username and password --
+///   the second one is the actual secret, but redacting the username too
+///   costs nothing and errs toward the safer reading of "token following
+///   AUTH2")
+/// - the value in `CONFIG SET requirepass <value>` / `CONFIG SET masterauth
+///   <value>`
+///
+/// Returns a single space-joined string, since that's how the redacted
+/// output is meant to be logged.
+fn redact(args: &[&str]) -> String {
+    let mut out: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+    let mut i = 0;
+    while i < out.len() {
+        let upper = out[i].to_ascii_uppercase();
+        if upper == "AUTH" && i + 1 < out.len() {
+            out[i + 1] = "<redacted>".to_string();
+            i += 2;
+            continue;
+        }
+        if upper == "AUTH2" {
+            for slot in out.iter_mut().skip(i + 1).take(2) {
+                *slot = "<redacted>".to_string();
+            }
+            i += 3;
+            continue;
+        }
+        if upper == "CONFIG"
+            && i + 3 < out.len()
+            && out[i + 1].eq_ignore_ascii_case("SET")
+            && (out[i + 2].eq_ignore_ascii_case("requirepass")
+                || out[i + 2].eq_ignore_ascii_case("masterauth"))
+        {
+            out[i + 3] = "<redacted>".to_string();
+            i += 4;
+            continue;
+        }
+        i += 1;
+    }
+    out.join(" ")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1095,5 +1153,53 @@ mod tests {
         assert_eq!(cli.port, 6380);
         assert_eq!(cli.password.as_deref(), Some("secret"));
         assert_eq!(cli.bin, "/usr/local/bin/redis-cli");
+    }
+
+    #[test]
+    fn redact_masks_migrate_auth_password() {
+        let args = [
+            "MIGRATE", "10.0.0.1", "7001", "key", "0", "5000", "AUTH", "hunter2",
+        ];
+        let redacted = redact(&args);
+        assert!(!redacted.contains("hunter2"));
+        assert_eq!(redacted, "MIGRATE 10.0.0.1 7001 key 0 5000 AUTH <redacted>");
+    }
+
+    #[test]
+    fn redact_masks_migrate_auth2_username_and_password() {
+        let args = [
+            "MIGRATE", "10.0.0.1", "7001", "key", "0", "5000", "AUTH2", "myuser", "hunter2",
+        ];
+        let redacted = redact(&args);
+        assert!(!redacted.contains("hunter2"));
+        assert!(!redacted.contains("myuser"));
+        assert_eq!(
+            redacted,
+            "MIGRATE 10.0.0.1 7001 key 0 5000 AUTH2 <redacted> <redacted>"
+        );
+    }
+
+    #[test]
+    fn redact_masks_config_set_requirepass() {
+        let args = ["CONFIG", "SET", "requirepass", "hunter2"];
+        let redacted = redact(&args);
+        assert_eq!(redacted, "CONFIG SET requirepass <redacted>");
+    }
+
+    #[test]
+    fn redact_masks_config_set_masterauth() {
+        let args = ["CONFIG", "SET", "masterauth", "hunter2"];
+        let redacted = redact(&args);
+        assert_eq!(redacted, "CONFIG SET masterauth <redacted>");
+    }
+
+    #[test]
+    fn redact_leaves_unrelated_commands_untouched() {
+        let args = ["CONFIG", "SET", "maxclients", "100"];
+        let redacted = redact(&args);
+        assert_eq!(redacted, "CONFIG SET maxclients 100");
+
+        let args = ["GET", "key"];
+        assert_eq!(redact(&args), "GET key");
     }
 }

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use tracing::Instrument;
+
 use crate::cli::RedisCli;
 use crate::error::{Error, Result};
 use crate::server::{
@@ -784,12 +786,25 @@ impl RedisClusterBuilder {
     /// rather than being cleared: the wrapper cannot tell a leftover node of
     /// its own from an unrelated Redis, and stopping the latter would lose
     /// data it never owned.
-    pub async fn start(mut self) -> Result<RedisClusterHandle> {
+    pub async fn start(self) -> Result<RedisClusterHandle> {
+        let total_nodes = self.total_nodes();
+        let span = tracing::debug_span!(
+            "cluster_start",
+            masters = self.masters,
+            replicas_per_master = self.replicas_per_master,
+            total_nodes
+        );
+        async move { self.start_inner(total_nodes).await }
+            .instrument(span)
+            .await
+    }
+
+    async fn start_inner(mut self, total_nodes: u16) -> Result<RedisClusterHandle> {
+        let start_time = std::time::Instant::now();
         self.validate_topology()?;
         self.ensure_ports_free()?;
 
         // Start each node.
-        let total_nodes = self.total_nodes();
         let ports: Vec<u16> = self.ports().collect();
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -1009,6 +1024,11 @@ impl RedisClusterBuilder {
             let handle = server.start().await?;
             nodes.push(handle);
         }
+        tracing::debug!(
+            elapsed_ms = start_time.elapsed().as_millis() as u64,
+            nodes = nodes.len(),
+            "nodes_started"
+        );
 
         // Form the cluster.
         let node_addrs: Vec<String> = nodes.iter().map(|n| n.addr()).collect();
@@ -1022,9 +1042,18 @@ impl RedisClusterBuilder {
         cli = self.apply_tls_to_cli(cli);
         cli.cluster_create(&node_addrs, self.replicas_per_master)
             .await?;
+        tracing::debug!(
+            elapsed_ms = start_time.elapsed().as_millis() as u64,
+            "cluster_create_complete"
+        );
 
-        // Wait for convergence.
+        // Wait for convergence. Fixed sleep rather than a poll-until-healthy
+        // loop -- see issue #147 for replacing this with a convergence wait.
         tokio::time::sleep(Duration::from_secs(2)).await;
+        tracing::debug!(
+            elapsed_ms = start_time.elapsed().as_millis() as u64,
+            "convergence_wait_complete"
+        );
 
         Ok(RedisClusterHandle {
             nodes,

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,10 +6,22 @@ use std::io;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// A `redis-server` process failed to start.
-    #[error("redis-server failed to start on port {port}")]
+    ///
+    /// `detail`, when present, carries the last lines of the node's log file
+    /// (and, for a spawn-time failure, the daemonizing process's captured
+    /// stdout/stderr) so the reason survives even when no tracing subscriber
+    /// is installed -- the common case for most test runs, where an event
+    /// emitted alongside this error would otherwise be invisible.
+    #[error(
+        "redis-server failed to start on port {port}{}",
+        detail.as_deref().map(|d| format!("\n{d}")).unwrap_or_default()
+    )]
     ServerStart {
         /// The port on which the server failed to start.
         port: u16,
+        /// Tail of the node's log file plus any captured process output,
+        /// when available.
+        detail: Option<String>,
     },
 
     /// A sentinel process failed to start.

--- a/src/fault_proxy.rs
+++ b/src/fault_proxy.rs
@@ -295,6 +295,8 @@ impl FaultProxy {
             shutdown_rx,
         );
 
+        tracing::debug!(%addr, upstream = %upstream_addr, "fault_proxy_spawned");
+
         Ok(FaultProxy {
             addr,
             upstream_addr,
@@ -321,6 +323,7 @@ impl FaultProxy {
 
     /// Set (or replace) the delay applied before forwarding data in `direction`.
     pub fn set_delay(&self, direction: Direction, delay: Delay) {
+        tracing::info!(addr = %self.addr, ?direction, ?delay, "set_delay");
         self.state.write().unwrap().delay[direction.idx()] = Some(delay);
     }
 
@@ -335,12 +338,14 @@ impl FaultProxy {
     /// this setting is active. Closes with a clean FIN; use
     /// [`FaultProxy::close_after_with`] for a TCP reset instead.
     pub fn close_after(&self, direction: Direction, bytes: u64) {
+        tracing::info!(addr = %self.addr, ?direction, bytes, kind = ?CloseKind::Fin, "close_after");
         self.state.write().unwrap().close_after[direction.idx()] = Some((bytes, CloseKind::Fin));
     }
 
     /// Like [`FaultProxy::close_after`], but the connection is closed with
     /// `kind` once the threshold trips.
     pub fn close_after_with(&self, direction: Direction, bytes: u64, kind: CloseKind) {
+        tracing::info!(addr = %self.addr, ?direction, bytes, ?kind, "close_after_with");
         self.state.write().unwrap().close_after[direction.idx()] = Some((bytes, kind));
     }
 
@@ -354,6 +359,7 @@ impl FaultProxy {
     /// with [`FaultProxy::set_chunk_delay`] so the pieces genuinely arrive as
     /// separate reads instead of being coalesced by the kernel on loopback.
     pub fn set_chunk_size(&self, size: usize) {
+        tracing::info!(addr = %self.addr, size, "set_chunk_size");
         self.state.write().unwrap().chunk_size = Some(size.max(1));
     }
 
@@ -366,6 +372,7 @@ impl FaultProxy {
     /// piece as a separate read. No effect unless [`FaultProxy::set_chunk_size`]
     /// splits a read into more than one piece.
     pub fn set_chunk_delay(&self, delay: Duration) {
+        tracing::info!(addr = %self.addr, delay_ms = delay.as_millis() as u64, "set_chunk_delay");
         self.state.write().unwrap().chunk_delay = Some(delay);
     }
 
@@ -380,6 +387,7 @@ impl FaultProxy {
     /// proxy is dropped. Existing connections are unaffected; use
     /// [`FaultProxy::set_stall`] to affect connections already established.
     pub fn set_drop_all(&self, drop_all: bool) {
+        tracing::info!(addr = %self.addr, drop_all, "set_drop_all");
         self.state.write().unwrap().drop_all = drop_all;
     }
 
@@ -388,6 +396,7 @@ impl FaultProxy {
     /// complete until [`FaultProxy::clear_stall`] is called or the connection
     /// is severed by a pending [`FaultProxy::stall_then_close`] deadline.
     pub fn set_stall(&self, direction: Direction) {
+        tracing::info!(addr = %self.addr, ?direction, "set_stall");
         self.state.write().unwrap().stall[direction.idx()] = true;
     }
 
@@ -403,6 +412,7 @@ impl FaultProxy {
     /// new) `after` later. Use [`FaultProxy::set_stall`] alone for an
     /// indefinite hold. Replaces any previously pending deadline.
     pub fn stall_then_close(&self, after: Duration) {
+        tracing::info!(addr = %self.addr, after_ms = after.as_millis() as u64, "stall_then_close");
         {
             let mut state = self.state.write().unwrap();
             state.stall[Direction::ClientToUpstream.idx()] = true;
@@ -443,6 +453,7 @@ impl FaultProxy {
     /// crashed server. New connections are unaffected; combine with
     /// [`FaultProxy::disable`] to also stop accepting.
     pub fn reset_peer(&self) {
+        tracing::info!(addr = %self.addr, "reset_peer");
         self.sever_all(CloseKind::Rst);
     }
 
@@ -457,6 +468,7 @@ impl FaultProxy {
     /// (with `kind`) before any upstream connect; passthrough resumes after.
     /// Deterministic replacement for toxiproxy's probabilistic `toxicity`.
     pub fn reject_next(&self, n: u32, kind: CloseKind) {
+        tracing::info!(addr = %self.addr, n, ?kind, "reject_next");
         let mut state = self.state.write().unwrap();
         state.reject_remaining = n;
         state.reject_kind = kind;
@@ -474,6 +486,7 @@ impl FaultProxy {
     /// Note: another process can claim the port while disabled (rare for
     /// localhost tests, but a real race).
     pub async fn disable(&self) -> Result<()> {
+        tracing::info!(addr = %self.addr, "disable");
         let handle = self.accept_task.lock().unwrap().take();
         if let Some(handle) = handle {
             handle.abort();
@@ -493,6 +506,7 @@ impl FaultProxy {
         if self.accept_task.lock().unwrap().is_some() {
             return Ok(());
         }
+        tracing::info!(addr = %self.addr, "enable");
 
         let listener = TcpListener::bind(self.addr).await?;
         let handle = spawn_accept_task(
@@ -512,6 +526,7 @@ impl FaultProxy {
     /// [`FaultProxy::stall_then_close`] deadline and wakes any connections
     /// currently blocked on a stall.
     pub fn reset(&self) {
+        tracing::info!(addr = %self.addr, "reset");
         self.cancel_pending_stall_close();
         *self.state.write().unwrap() = FaultState::default();
         self.notify.notify_waiters();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@
 //! # async fn example() {
 //! match RedisServer::new().port(6400).start().await {
 //!     Ok(server) => println!("running on {}", server.addr()),
-//!     Err(Error::ServerStart { port }) => eprintln!("could not start on {port}"),
+//!     Err(Error::ServerStart { port, .. }) => eprintln!("could not start on {port}"),
 //!     Err(e) => eprintln!("unexpected: {e}"),
 //! }
 //! # }
@@ -187,6 +187,25 @@
 //! [dev-dependencies]
 //! redis-server-wrapper = { version = "*", default-features = false, features = ["blocking"] }
 //! ```
+//!
+//! # Logging
+//!
+//! The crate emits [`tracing`] spans and events across the lifecycle
+//! (server/cluster/sentinel start and stop, chaos operations, proxy setup)
+//! at levels from `TRACE` (individual `redis-cli` invocations, with
+//! passwords redacted) through `DEBUG` (step timing) to `WARN`/`ERROR`
+//! (escalating shutdowns, server-start failures). No `tracing` subscriber
+//! is required: `tracing`'s `log` feature is enabled unconditionally, so
+//! output shows up under `env_logger` or `test-log` with zero setup too.
+//!
+//! ```text
+//! RUST_LOG=redis_server_wrapper=debug cargo test
+//! ```
+//!
+//! Install a `tracing-subscriber` instead for structured spans with the
+//! same targets. Either way, a server-start failure's `Display` also
+//! carries the tail of the node's log file directly in the returned
+//! [`Error`], so the reason is visible even with no subscriber at all.
 //!
 //! # Platform Support
 //!

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use tokio::process::Command;
+use tracing::Instrument;
 
 use crate::cli::RedisCli;
 use crate::error::{Error, Result};
@@ -453,6 +454,17 @@ impl RedisSentinelBuilder {
 
     /// Start the full topology: master, replicas, sentinels.
     pub async fn start(self) -> Result<RedisSentinelHandle> {
+        let span = tracing::debug_span!(
+            "sentinel_start",
+            master_port = self.master_port,
+            num_replicas = self.num_replicas,
+            num_sentinels = self.num_sentinels
+        );
+        self.start_inner().instrument(span).await
+    }
+
+    async fn start_inner(self) -> Result<RedisSentinelHandle> {
+        let start_time = std::time::Instant::now();
         let mut monitored_masters = Vec::with_capacity(1 + self.monitored_masters.len());
         monitored_masters.push(MonitoredMaster {
             name: self.master_name.clone(),
@@ -511,6 +523,11 @@ impl RedisSentinelBuilder {
             master = master.extra(key.clone(), value.clone());
         }
         let master = master.start().await?;
+        tracing::debug!(
+            elapsed_ms = start_time.elapsed().as_millis() as u64,
+            port = master.port(),
+            "master_started"
+        );
 
         // 2. Start replicas.
         let mut replicas = Vec::new();
@@ -554,9 +571,19 @@ impl RedisSentinelBuilder {
             let replica = replica.start().await?;
             replicas.push(replica);
         }
+        tracing::debug!(
+            elapsed_ms = start_time.elapsed().as_millis() as u64,
+            replicas = replicas.len(),
+            "replicas_started"
+        );
 
-        // Let replication link up.
+        // Let replication link up. Fixed sleep rather than a poll-until-linked
+        // loop -- see issue #147 for replacing this with a convergence wait.
         tokio::time::sleep(Duration::from_secs(1)).await;
+        tracing::debug!(
+            elapsed_ms = start_time.elapsed().as_millis() as u64,
+            "replication_wait_complete"
+        );
 
         // 3. Start sentinels.
         let mut sentinel_handles = Vec::new();
@@ -648,6 +675,7 @@ impl RedisSentinelBuilder {
                 .await?;
 
             if !status.success() {
+                tracing::error!(port, "sentinel_start_failed");
                 return Err(Error::SentinelStart { port });
             }
 
@@ -669,6 +697,7 @@ impl RedisSentinelBuilder {
                         break p;
                     }
                     if std::time::Instant::now() >= deadline {
+                        tracing::error!(port, "sentinel_pidfile_wait_failed");
                         return Err(Error::SentinelStart { port });
                     }
                     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -677,9 +706,20 @@ impl RedisSentinelBuilder {
 
             sentinel_handles.push((port, pid, cli));
         }
+        tracing::debug!(
+            elapsed_ms = start_time.elapsed().as_millis() as u64,
+            sentinels = sentinel_handles.len(),
+            "sentinels_started"
+        );
 
-        // Wait for sentinels to discover each other.
+        // Wait for sentinels to discover each other. Fixed sleep rather than
+        // a poll-until-discovered loop -- see issue #147 for replacing this
+        // with a convergence wait.
         tokio::time::sleep(Duration::from_secs(2)).await;
+        tracing::debug!(
+            elapsed_ms = start_time.elapsed().as_millis() as u64,
+            "discovery_wait_complete"
+        );
 
         Ok(RedisSentinelHandle {
             master,
@@ -1052,6 +1092,9 @@ impl RedisSentinelHandle {
     /// Replicas and the master are stopped by their own handles' [`Drop`] impls,
     /// which also use the escalating strategy.
     pub fn stop(&self) {
+        let span = tracing::debug_span!("sentinel_stop", master_name = %self.master_name);
+        let _guard = span.entered();
+
         // Step 1: graceful shutdown for each sentinel.
         for port in &self.sentinel_ports {
             self.tls
@@ -1068,11 +1111,16 @@ impl RedisSentinelHandle {
         // Step 3: force kill any sentinels still alive.
         for pid in &self.sentinel_pids {
             if crate::process::pid_alive(*pid) {
+                tracing::warn!(pid, "force_kill_escalation");
                 crate::process::force_kill(*pid);
             }
         }
-        // Step 4: port cleanup as safety net.
+        // Step 4: port cleanup as safety net (see server.rs's stop() for why
+        // this is DEBUG rather than WARN: it runs unconditionally as a
+        // last-resort net, not only when it actually finds something to
+        // clean up).
         for port in &self.sentinel_ports {
+            tracing::debug!(port, "port_cleanup");
             crate::process::kill_by_port(*port);
         }
         // Replicas and master stopped by their handles' Drop.

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,9 +3,11 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
+use std::process::Output;
 use std::time::Duration;
 
 use tokio::process::Command;
+use tracing::Instrument;
 
 use crate::cli::RedisCli;
 use crate::config_token::directive;
@@ -2023,49 +2025,60 @@ impl RedisServer {
     /// and that no [`extra`](Self::extra) directive collides with one the
     /// wrapper generates, before attempting to launch anything.
     pub async fn start(self) -> Result<RedisServerHandle> {
-        self.validate_extras()?;
-        if which::which(&self.config.redis_server_bin).is_err() {
-            return Err(Error::BinaryNotFound {
-                binary: self.config.redis_server_bin.clone(),
-            });
+        let span = tracing::debug_span!(
+            "server_start",
+            port = self.config.port,
+            bind = %self.config.bind
+        );
+        async move {
+            self.validate_extras()?;
+            if which::which(&self.config.redis_server_bin).is_err() {
+                return Err(Error::BinaryNotFound {
+                    binary: self.config.redis_server_bin.clone(),
+                });
+            }
+            if which::which(&self.config.redis_cli_bin).is_err() {
+                return Err(Error::BinaryNotFound {
+                    binary: self.config.redis_cli_bin.clone(),
+                });
+            }
+
+            let node_dir = self.config.dir.join(format!("node-{}", self.config.port));
+
+            // Clean up any stale process from a previous run before (re)creating
+            // the node directory. This handles test crashes that leave orphaned
+            // redis-server processes behind.
+            let stale_pidfile = node_dir.join("redis.pid");
+            if let Some(stale_pid) = crate::process::read_pidfile(&stale_pidfile)
+                && crate::process::pid_alive(stale_pid)
+            {
+                tracing::debug!(pid = stale_pid, "stale_pid_kill");
+                crate::process::force_kill(stale_pid);
+            }
+
+            // Anything still holding the port after that is not ours: the pidfile
+            // above is the only claim of ownership the wrapper has. Fail with the
+            // port named rather than letting redis-server fail to bind, which a
+            // daemonizing start would not even report.
+            crate::preflight::ensure_ports_available(
+                &self.config.bind,
+                [(self.config.port, crate::preflight::PortRole::Server)],
+            )?;
+
+            crate::secure_file::create_dir_all(&node_dir)?;
+
+            let (cli, pid) =
+                launch_server(&self.config, &node_dir, Duration::from_secs(10)).await?;
+
+            Ok(RedisServerHandle {
+                config: self.config,
+                cli,
+                pid,
+                detached: false,
+            })
         }
-        if which::which(&self.config.redis_cli_bin).is_err() {
-            return Err(Error::BinaryNotFound {
-                binary: self.config.redis_cli_bin.clone(),
-            });
-        }
-
-        let node_dir = self.config.dir.join(format!("node-{}", self.config.port));
-
-        // Clean up any stale process from a previous run before (re)creating
-        // the node directory. This handles test crashes that leave orphaned
-        // redis-server processes behind.
-        let stale_pidfile = node_dir.join("redis.pid");
-        if let Some(stale_pid) = crate::process::read_pidfile(&stale_pidfile)
-            && crate::process::pid_alive(stale_pid)
-        {
-            crate::process::force_kill(stale_pid);
-        }
-
-        // Anything still holding the port after that is not ours: the pidfile
-        // above is the only claim of ownership the wrapper has. Fail with the
-        // port named rather than letting redis-server fail to bind, which a
-        // daemonizing start would not even report.
-        crate::preflight::ensure_ports_available(
-            &self.config.bind,
-            [(self.config.port, crate::preflight::PortRole::Server)],
-        )?;
-
-        crate::secure_file::create_dir_all(&node_dir)?;
-
-        let (cli, pid) = launch_server(&self.config, &node_dir, Duration::from_secs(10)).await?;
-
-        Ok(RedisServerHandle {
-            config: self.config,
-            cli,
-            pid,
-            detached: false,
-        })
+        .instrument(span)
+        .await
     }
 
     fn generate_config(&self, node_dir: &std::path::Path) -> String {
@@ -2715,6 +2728,90 @@ impl Default for RedisServer {
     }
 }
 
+/// Resolve the on-disk path of a node's log file from its config.
+///
+/// Mirrors [`RedisServer::generate_config`]'s `logfile` directive: a
+/// user-configured `logfile` is used as-is if absolute, else resolved
+/// against `node_dir` (Redis `chdir`s to `dir` before opening a relative
+/// `logfile`); with no configured `logfile` the default is
+/// `{node_dir}/redis.log`. Shared by [`launch_server`]'s failure paths (the
+/// log doesn't exist as a [`RedisServerHandle`] yet at that point) and
+/// [`RedisServerHandle::log_path`].
+fn resolve_log_path(config: &RedisServerConfig, node_dir: &std::path::Path) -> PathBuf {
+    match config.logfile.as_deref() {
+        Some(logfile) => {
+            let path = PathBuf::from(logfile);
+            if path.is_absolute() {
+                path
+            } else {
+                node_dir.join(path)
+            }
+        }
+        None => node_dir.join("redis.log"),
+    }
+}
+
+/// Read the last `max_lines` lines of `path`, if it exists and is readable.
+///
+/// Best-effort: returns `None` rather than an error, since this is called
+/// on an already-failing path and shouldn't itself become the reason the
+/// caller loses the original failure.
+fn log_tail(path: &std::path::Path, max_lines: usize) -> Option<String> {
+    let contents = fs::read_to_string(path).ok()?;
+    let lines: Vec<&str> = contents.lines().collect();
+    if lines.is_empty() {
+        return None;
+    }
+    let start = lines.len().saturating_sub(max_lines);
+    Some(lines[start..].join("\n"))
+}
+
+/// Build the `detail` for [`Error::ServerStart`] out of whatever evidence is
+/// available: the node's log tail, plus (when the daemonizing process itself
+/// exited non-zero, e.g. a config-parse error printed before the logfile
+/// opens) its captured stdout/stderr.
+fn spawn_failure_detail(log_path: &std::path::Path, output: Option<&Output>) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(tail) = log_tail(log_path, 20) {
+        parts.push(format!("log tail ({}):\n{tail}", log_path.display()));
+    }
+    if let Some(output) = output {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stdout.trim().is_empty() {
+            parts.push(format!("stdout:\n{}", stdout.trim()));
+        }
+        if !stderr.trim().is_empty() {
+            parts.push(format!("stderr:\n{}", stderr.trim()));
+        }
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n\n"))
+    }
+}
+
+/// Attach a node's log tail to an error that doesn't already carry one --
+/// used on the [`RedisCli::wait_for_ready`] failure path, which returns
+/// [`Error::Timeout`] rather than [`Error::ServerStart`].
+fn attach_log_tail(err: Error, log_path: &std::path::Path) -> Error {
+    let Some(tail) = log_tail(log_path, 20) else {
+        return err;
+    };
+    let suffix = format!("\nlog tail ({}):\n{tail}", log_path.display());
+    match err {
+        Error::Timeout { message } => Error::Timeout {
+            message: message + &suffix,
+        },
+        Error::ServerStart { port, detail: None } => Error::ServerStart {
+            port,
+            detail: Some(format!("log tail ({}):\n{tail}", log_path.display())),
+        },
+        other => other,
+    }
+}
+
 /// Write `config`'s conf file into `node_dir`, launch `redis-server` against
 /// it, wait for it to answer `PING`, and return a [`RedisCli`] wired up for
 /// it plus the pid it wrote to `redis.pid`.
@@ -2727,28 +2824,50 @@ async fn launch_server(
     node_dir: &std::path::Path,
     ready_timeout: Duration,
 ) -> Result<(RedisCli, u32)> {
+    let log_path = resolve_log_path(config, node_dir);
+    let start = std::time::Instant::now();
+
     let conf_path = node_dir.join("redis.conf");
     let conf_content = RedisServer {
         config: config.clone(),
     }
     .generate_config(node_dir);
     crate::secure_file::write(&conf_path, conf_content)?;
+    tracing::debug!(
+        elapsed_ms = start.elapsed().as_millis() as u64,
+        "config_written"
+    );
 
     let module_args = if config.no_stack_modules {
         Vec::new()
     } else {
         crate::stack::detect_stack_modules(&config.redis_server_bin)
     };
-    let status = Command::new(&config.redis_server_bin)
+    // `.output()` (not `.status()` with the streams nulled) so that a
+    // config-parse error -- which redis-server prints to its own
+    // stdout/stderr and exits on *before* it daemonizes and opens the
+    // logfile -- is captured here rather than lost. Once redis-server
+    // successfully daemonizes, this call still returns promptly: the parent
+    // process exits as soon as the child detaches.
+    let output = Command::new(&config.redis_server_bin)
         .arg(&conf_path)
         .args(&module_args)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
+        .output()
         .await?;
+    tracing::debug!(elapsed_ms = start.elapsed().as_millis() as u64, "spawned");
 
-    if !status.success() {
-        return Err(Error::ServerStart { port: config.port });
+    if !output.status.success() {
+        let detail = spawn_failure_detail(&log_path, Some(&output));
+        tracing::error!(
+            port = config.port,
+            log_path = %log_path.display(),
+            log_tail = detail.as_deref().unwrap_or(""),
+            "server_start_failed"
+        );
+        return Err(Error::ServerStart {
+            port: config.port,
+            detail,
+        });
     }
 
     // The plain `port` always speaks unencrypted Redis protocol; `tls-port`
@@ -2783,7 +2902,11 @@ async fn launch_server(
         }
     }
 
-    cli.wait_for_ready(ready_timeout).await?;
+    cli.wait_for_ready(ready_timeout).await.map_err(|e| {
+        tracing::error!(port = config.port, log_path = %log_path.display(), "server_ready_wait_failed");
+        attach_log_tail(e, &log_path)
+    })?;
+    tracing::debug!(elapsed_ms = start.elapsed().as_millis() as u64, "ready");
 
     let pid_path = node_dir.join("redis.pid");
     let pid: u32 = {
@@ -2795,11 +2918,25 @@ async fn launch_server(
                 break p;
             }
             if std::time::Instant::now() >= deadline {
-                return Err(Error::ServerStart { port: config.port });
+                let detail = spawn_failure_detail(&log_path, None);
+                tracing::error!(
+                    port = config.port,
+                    log_path = %log_path.display(),
+                    log_tail = detail.as_deref().unwrap_or(""),
+                    "server_pidfile_wait_failed"
+                );
+                return Err(Error::ServerStart {
+                    port: config.port,
+                    detail,
+                });
             }
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
     };
+    tracing::debug!(
+        elapsed_ms = start.elapsed().as_millis() as u64,
+        "pidfile_read"
+    );
 
     Ok((cli, pid))
 }
@@ -2922,17 +3059,7 @@ impl RedisServerHandle {
     /// `logfile` is configured.
     pub fn log_path(&self) -> PathBuf {
         let node_dir = self.config.dir.join(format!("node-{}", self.config.port));
-        match self.config.logfile.as_deref() {
-            Some(logfile) => {
-                let path = PathBuf::from(logfile);
-                if path.is_absolute() {
-                    path
-                } else {
-                    node_dir.join(path)
-                }
-            }
-            None => node_dir.join("redis.log"),
-        }
+        resolve_log_path(&self.config, &node_dir)
     }
 
     /// Current byte length of [`Self::log_path`].
@@ -3000,16 +3127,29 @@ impl RedisServerHandle {
     /// 2. Waits 500ms for the process to exit.
     /// 3. If still alive, calls [`crate::process::force_kill`] (SIGTERM then SIGKILL).
     /// 4. Attempts to release the port via [`crate::process::kill_by_port`] as a final safety net.
+    ///
+    /// Synchronous and called from [`Drop`], so this enters its span with a
+    /// guard rather than `.instrument()` -- there is no `.await` in this
+    /// function for a guard to be held across.
     pub fn stop(&self) {
+        let span = tracing::debug_span!("server_stop", port = self.config.port);
+        let _guard = span.entered();
+
         // Step 1: graceful shutdown.
         self.cli.shutdown();
         // Step 2: grace period.
         std::thread::sleep(std::time::Duration::from_millis(500));
         // Step 3: force kill if still alive.
         if crate::process::pid_alive(self.pid) {
+            tracing::warn!(pid = self.pid, "force_kill_escalation");
             crate::process::force_kill(self.pid);
         }
-        // Step 4: port cleanup as safety net.
+        // Step 4: port cleanup as safety net. Demoted to DEBUG rather than
+        // WARN: kill_by_port runs unconditionally on every clean stop() as a
+        // safety net and its return type doesn't distinguish "found and
+        // killed a leftover listener" from "port was already free", so a
+        // WARN here would fire on the common case too.
+        tracing::debug!(port = self.config.port, "port_cleanup");
         crate::process::kill_by_port(self.config.port);
     }
 
@@ -3035,13 +3175,18 @@ impl RedisServerHandle {
     /// modules are passed on the command line rather than baked into the
     /// config file.
     pub(crate) async fn restart(&mut self, timeout: Duration) -> Result<()> {
-        let node_dir = self.config.dir.join(format!("node-{}", self.config.port));
-        let _ = fs::remove_file(node_dir.join("redis.pid"));
+        let span = tracing::debug_span!("server_restart", port = self.config.port);
+        async move {
+            let node_dir = self.config.dir.join(format!("node-{}", self.config.port));
+            let _ = fs::remove_file(node_dir.join("redis.pid"));
 
-        let (cli, pid) = launch_server(&self.config, &node_dir, timeout).await?;
-        self.cli = cli;
-        self.pid = pid;
-        Ok(())
+            let (cli, pid) = launch_server(&self.config, &node_dir, timeout).await?;
+            self.cli = cli;
+            self.pid = pid;
+            Ok(())
+        }
+        .instrument(span)
+        .await
     }
 }
 

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -283,3 +283,26 @@ async fn wait_for_log_after_bgsave() {
         .expect("wait_for_log did not find the bgsave completion line");
     assert!(line.contains("Background saving terminated with success"));
 }
+
+/// An unrecognized directive makes `redis-server` reject the config file and
+/// exit non-zero before it daemonizes or opens the logfile -- exactly the
+/// case the switch from `.status()` to `.output()` exists for: the failure
+/// reason lives only in the daemonizing process's own stderr, not in the
+/// (nonexistent) log file, and it must still reach the returned error.
+#[tokio::test]
+async fn start_failure_surfaces_log_tail_in_error() {
+    let result = RedisServer::new()
+        .port(17906)
+        .extra("thisisnotarealdirective", "yes")
+        .start()
+        .await;
+
+    let err = result
+        .err()
+        .expect("redis-server should have aborted on the bad directive");
+    let message = err.to_string();
+    assert!(
+        message.contains("thisisnotarealdirective") || message.contains("Unresolved"),
+        "expected the log tail in the error message, got: {message}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements the three items from #121 (tracing-dep-unconditional, span-event-taxonomy, failure-log-tail) in one PR, per the issue's own design ("designed together").

- **tracing-dep-unconditional**: `tracing = { version = "0.1", default-features = false, features = ["std", "log"] }` added unconditionally (no feature gate). No `tracing-attributes`/`syn`/`quote` pulled in; the `log` feature means `env_logger`/`test-log` users get output with zero setup.
- **span-event-taxonomy**: spans around the multi-step lifecycle sequences (server/cluster/sentinel start, server/sentinel stop) with `elapsed_ms` events per step; INFO events on chaos-module fault-injection ops and fault-proxy control methods; WARN on escalation/recovery paths that were silent (force-kill escalation, `ReshardGuard`/`PersistenceGuard` Drop resets); DEBUG for routine safety-net paths (port cleanup).
- **failure-log-tail**: `launch_server`'s daemonizing spawn switches from `.status()` to `.output()` so a config-parse error (which prints before the logfile even opens) is captured. All three post-config failure paths in `launch_server` attach the node's log tail (plus captured process output where relevant) to the returned error. `Error::ServerStart` gains a `detail: Option<String>` field so the reason is visible in the error's `Display` even with no tracing subscriber installed -- the default for most test runs.

## Notes on staleness in the issue

The issue was written 2026-07-10 against a since-changed codebase. Re-verified against current code before implementing:

- `base_args()` no longer carries `-a <password>` (already fixed via `REDISCLI_AUTH`). The redaction requirement still stands for caller-supplied args -- `chaos::ReshardGuard::migrate_keys` passes `MIGRATE ... AUTH <password>` through `RedisCli::run`, so `run()` traces `args` through a `redact()` pass that masks the token after `AUTH`/`AUTH2` and the value in `CONFIG SET requirepass|masterauth`.
- The hard 500ms/2s sleeps in cluster/sentinel startup (flagged for removal in #147) are still present in this checkout, so the cluster/sentinel spans instrument the surrounding lifecycle steps (node/replica/sentinel start, cluster_create, the fixed wait itself) rather than assuming a convergence-wait replaced them.
- `RedisServerHandle::log_path()` already existed (landed via #132, the observability-bundle PR) -- reused via a shared `resolve_log_path()` helper rather than re-added.
- All line-number references in the issue had shifted; every code path was re-located by searching for the described behavior rather than trusting the cited line ranges.

Per the issue's "Verification notes" (adversarial-review corrections, treated as authoritative over the initial proposals): log tail lives in the returned `Error::ServerStart`, not only a tracing event; `.status()` → `.output()`; `port_cleanup` is DEBUG not WARN; sync `stop()`/Drop paths use an entered span guard, not `.instrument()`; no `.entered()` guard is held across an `.await` anywhere.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (local + MSRV 1.88.0 toolchain)
- [x] Added `start_failure_surfaces_log_tail_in_error` integration test exercising the config-parse-error path end to end (confirms the daemonizing-spawn stderr capture actually reaches the returned error's `Display`)
- [x] `cargo doc --no-deps --all-features`