### PR TITLE
ci: pin the Ubuntu job to the oldest supported Redis line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # The oldest line the README declares support for. Kept in step with
+  # the floor of the matrix in redis-compat.yml.
+  UBUNTU_REDIS_VERSION: "7.2.14"
 
 jobs:
   test:
@@ -43,15 +46,58 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Redis (Ubuntu)
+      # Ubuntu pins the oldest supported line so the fast signal matches the
+      # floor the README declares. The runner image ships 7.0.15, which is
+      # below that floor, so `apt-get install redis-server` was gating every
+      # pull request on a version the crate does not claim to support.
+      #
+      # macOS is left on brew, which tracks the newest line. Between them
+      # every pull request sees both ends of the supported range; the lines in
+      # between are covered by the compatibility workflow.
+      - name: Cache Redis ${{ env.UBUNTU_REDIS_VERSION }} build
+        if: runner.os == 'Linux'
+        id: redis-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/redis-dist
+          key: ci-redis-${{ env.UBUNTU_REDIS_VERSION }}-${{ runner.os }}
+
+      - name: Build Redis ${{ env.UBUNTU_REDIS_VERSION }} (Ubuntu)
+        if: runner.os == 'Linux' && steps.redis-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config libssl-dev
+          curl -fsSL -o /tmp/redis.tar.gz \
+            "https://download.redis.io/releases/redis-${UBUNTU_REDIS_VERSION}.tar.gz"
+          mkdir -p /tmp/redis-src
+          tar xzf /tmp/redis.tar.gz -C /tmp/redis-src --strip-components=1
+          make -C /tmp/redis-src -j"$(nproc)" BUILD_TLS=yes
+          mkdir -p ~/redis-dist
+          cp /tmp/redis-src/src/redis-server /tmp/redis-src/src/redis-cli ~/redis-dist/
+          # The module fixture needs a header matching this exact build.
+          cp /tmp/redis-src/src/redismodule.h ~/redis-dist/
+
+      - name: Put Redis on PATH (Ubuntu)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y redis-server
+          set -euo pipefail
+          chmod +x ~/redis-dist/redis-server ~/redis-dist/redis-cli
+          echo "$HOME/redis-dist" >> "$GITHUB_PATH"
 
       - name: Install Redis (macOS)
         if: runner.os == 'macOS'
         run: brew install redis
+
+      - name: Verify the version under test
+        run: |
+          set -euo pipefail
+          redis-server --version
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            # Fail loudly rather than silently falling back to the runner's
+            # own redis-server, which would put the pin back where it started.
+            redis-server --version | grep -q "v=${UBUNTU_REDIS_VERSION}"
+          fi
 
       # tests/module_loading.rs skips itself unless REDIS_TEST_MODULE points at
       # a compiled module. Building the fixture needs redismodule.h, which the
@@ -68,9 +114,15 @@ jobs:
           set -euo pipefail
           version="$(redis-server --version | sed -n 's/.*v=\([0-9][0-9.]*\).*/\1/p')"
           echo "detected Redis $version"
-          curl -fsSL -o "${RUNNER_TEMP}/redismodule.h" \
-            "https://raw.githubusercontent.com/redis/redis/${version}/src/redismodule.h"
-          cc -fPIC -shared -I "${RUNNER_TEMP}" \
+          if [ -f "$HOME/redis-dist/redismodule.h" ]; then
+            # Linux builds Redis from source, so the matching header is local.
+            include="$HOME/redis-dist"
+          else
+            include="${RUNNER_TEMP}"
+            curl -fsSL -o "${include}/redismodule.h" \
+              "https://raw.githubusercontent.com/redis/redis/${version}/src/redismodule.h"
+          fi
+          cc -fPIC -shared -I "${include}" \
             tests/support/rsw_test_module.c \
             -o "${RUNNER_TEMP}/rsw_test_module.so"
           echo "REDIS_TEST_MODULE=${RUNNER_TEMP}/rsw_test_module.so" >> "$GITHUB_ENV"

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Each is built from source with `BUILD_TLS=yes` and runs the full suite, so the T
 exercised rather than skipped. Other versions may work; these are the ones a regression would
 be caught on.
 
-The main CI workflow separately runs against whatever `redis-server` the platform package
-manager provides on Ubuntu and macOS, which covers the case most users actually install.
+Every pull request additionally sees both ends of that range: the Ubuntu job pins 7.2.14, the
+oldest supported line, and the macOS job uses whatever Homebrew currently provides, which
+tracks the newest. The lines in between are covered by the matrix above.
 
 ## Platform support
 


### PR DESCRIPTION
Closes #151. Takes option 1 from the issue.

## Problem

The README declares 7.2 as the oldest supported line. The main workflow
installed Redis with apt, and `ubuntu-latest` ships 7.0.15, so every pull
request was gated on a version the crate does not claim to support. Meanwhile
7.2 itself only ran in the compatibility workflow, which does not run on every
push.

## Change

Ubuntu pins 7.2.14, built from source and cached the same way the
compatibility workflow already caches its builds. macOS stays on Homebrew,
which tracks the newest line.

That gives every pull request both ends of the supported range, with the lines
in between covered by the matrix:

| Job | Redis | Role |
|---|---|---|
| Test Suite (ubuntu) | 7.2.14 | oldest supported |
| Test Suite (macOS) | Homebrew current | newest |
| Redis Compatibility | 7.2 / 7.4 / 8.2 / 8.x | every declared line |

The job asserts the binary reports the pinned version. Without that, a build
failure leaving the runner's own `redis-server` on PATH would quietly restore
exactly the situation this fixes.

## Side benefit

The pinned build provides `redismodule.h`, so the module fixture on Linux now
compiles against the header from the exact build under test instead of
fetching one from GitHub. macOS keeps the fetch, since Homebrew does not ship
the header.

## Not addressed here

The issue also notes that a test skipping by early return reports `ok`, so the
MSRV job's module tests look like passes when they are skips. That is a source
change rather than a CI one, and is left for its own pass.

## Cost

First run on each cache key builds Redis, a few minutes. After that it is a
cache restore.