### PR TITLE
feat: give cluster and sentinel reclaimable directories

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -3,7 +3,6 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use tracing::Instrument;
 
@@ -138,6 +137,7 @@ pub struct RedisClusterBuilder {
     extra: HashMap<String, String>,
     redis_server_bin: String,
     redis_cli_bin: String,
+    dir: Option<PathBuf>,
     node_config_fn: Option<Box<dyn FnMut(NodeContext) -> RedisServer + Send>>,
 }
 
@@ -151,6 +151,18 @@ impl RedisClusterBuilder {
     /// Set the number of replicas per master (default: `0`).
     pub fn replicas_per_master(mut self, n: u16) -> Self {
         self.replicas_per_master = n;
+        self
+    }
+
+    /// Place the topology's working directory somewhere specific.
+    ///
+    /// Defaults to a path under the system temp directory derived from the
+    /// bind address and port range. That default is deliberately stable
+    /// across runs: it is where the pidfiles live, and it is what lets a
+    /// crashed run be reclaimed rather than leaving nodes that block the next
+    /// start. Setting a per-run path here gives that up.
+    pub fn dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.dir = Some(dir.into());
         self
     }
 
@@ -730,6 +742,50 @@ impl RedisClusterBuilder {
         Ok(())
     }
 
+    /// Where this topology keeps its nodes.
+    fn base_dir(&self) -> PathBuf {
+        self.dir.clone().unwrap_or_else(|| {
+            crate::topology_dir::topology_dir(
+                "cluster",
+                &self.bind,
+                &[self.base_port, self.total_nodes()],
+            )
+        })
+    }
+
+    /// Stop leftover nodes from a previous run of this same topology.
+    ///
+    /// Only processes recorded in a pidfile the wrapper wrote, under a
+    /// directory the wrapper named, are touched. Anything else holding one of
+    /// these ports is left alone and rejected by the preflight that follows.
+    ///
+    /// Failures are not fatal. A pidfile that cannot be read means there is
+    /// nothing to reclaim, and if the port really is still held the preflight
+    /// reports it with a better error than this could.
+    fn reclaim_owned_nodes(&self, base: &Path) {
+        for port in self.ports() {
+            // RedisServer nests its own node-<port> directory under the dir it
+            // is given, so the pidfile sits two levels down.
+            let node_dir = base.join(format!("node-{port}"));
+            let pidfile = node_dir.join(format!("node-{port}")).join("redis.pid");
+            if let Some(pid) = crate::process::reclaim_from_pidfile(&pidfile) {
+                tracing::debug!(port, pid, "reclaimed_stale_cluster_node");
+            }
+
+            // Clear the node's state now that nothing is using it. A stable
+            // directory keeps `nodes.conf` and any RDB or AOF from the last
+            // run, and `redis-cli --cluster create` refuses to form a cluster
+            // from a node that already knows a topology or holds keys.
+            //
+            // Only the node directory the wrapper creates and names is
+            // removed, never the base it sits in, so a caller-supplied `dir`
+            // keeps everything the wrapper did not put there.
+            if node_dir.exists() {
+                let _ = std::fs::remove_dir_all(&node_dir);
+            }
+        }
+    }
+
     /// Fail with the first occupied port rather than clearing it.
     ///
     /// Client ports are checked before bus ports so the error names the port
@@ -802,19 +858,18 @@ impl RedisClusterBuilder {
     async fn start_inner(mut self, total_nodes: u16) -> Result<RedisClusterHandle> {
         let start_time = std::time::Instant::now();
         self.validate_topology()?;
+
+        let cluster_base = self.base_dir();
+
+        // Reclaim before the preflight, not after: a leftover node of our own
+        // still holds its port, so the preflight would reject the topology on
+        // the strength of a process we are entitled to stop.
+        self.reclaim_owned_nodes(&cluster_base);
+
         self.ensure_ports_free()?;
 
         // Start each node.
         let ports: Vec<u16> = self.ports().collect();
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_nanos())
-            .unwrap_or(0);
-        let cluster_base = std::env::temp_dir().join(format!(
-            "redis-cluster-wrapper-{}-{}",
-            std::process::id(),
-            unique
-        ));
         let mut nodes = Vec::new();
         for (index, port) in ports.into_iter().enumerate() {
             let node_dir = cluster_base.join(format!("node-{port}"));
@@ -1207,6 +1262,7 @@ impl RedisCluster {
             extra: HashMap::new(),
             redis_server_bin: "redis-server".into(),
             redis_cli_bin: "redis-cli".into(),
+            dir: None,
             node_config_fn: None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,6 +241,7 @@ pub mod sentinel;
 #[cfg(feature = "tokio")]
 pub mod server;
 pub mod stack;
+mod topology_dir;
 #[cfg(feature = "tokio")]
 pub mod wait;
 

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -165,26 +165,35 @@ mod tests {
         // handled a connection and then exited can leave the port refusing a
         // bind while nothing is serving on it. Starting there is fine, so it
         // must not read as occupied.
-        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
-        let port = listener.local_addr().unwrap().port();
+        //
+        // Retried because the port is released before it is checked, and any
+        // other test in this process asking for an ephemeral port can take it
+        // in between. A genuine failure fails every attempt.
+        for attempt in 0..8 {
+            let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+            let port = listener.local_addr().unwrap().port();
 
-        // Drive a real connection through so the socket has something to
-        // linger over, rather than closing an untouched listener.
-        let mut client = TcpStream::connect(("127.0.0.1", port)).unwrap();
-        let (mut server, _) = listener.accept().unwrap();
-        client.write_all(b"ping").unwrap();
-        let mut buf = [0u8; 4];
-        server.read_exact(&mut buf).unwrap();
+            // Drive a real connection through so the socket has something to
+            // linger over, rather than closing an untouched listener.
+            let mut client = TcpStream::connect(("127.0.0.1", port)).unwrap();
+            let (mut server, _) = listener.accept().unwrap();
+            client.write_all(b"ping").unwrap();
+            let mut buf = [0u8; 4];
+            server.read_exact(&mut buf).unwrap();
 
-        drop(client);
-        drop(server);
-        drop(listener);
+            drop(client);
+            drop(server);
+            drop(listener);
 
-        assert!(
-            port_available("127.0.0.1", port),
-            "a port with no live listener must be available even while the \
-             kernel still holds socket remnants"
-        );
+            if port_available("127.0.0.1", port) {
+                return;
+            }
+            assert!(
+                attempt < 7,
+                "a port with no live listener must be available even while \
+                 the kernel still holds socket remnants"
+            );
+        }
     }
 
     #[test]
@@ -250,13 +259,21 @@ mod tests {
     }
 
     #[test]
-    fn successive_reservations_differ() {
-        // Not a hard guarantee from the OS, but a reservation scheme that
-        // returned the same port twice in a row would defeat the purpose.
-        let a = reserve_ephemeral_port().unwrap();
-        let _hold = TcpListener::bind(("127.0.0.1", a)).unwrap();
-        let b = reserve_ephemeral_port().unwrap();
-        assert_ne!(a, b, "a held port must not be handed out again");
+    fn a_held_port_is_not_handed_out_again() {
+        // Hold the listener rather than reserving and re-binding. Reserving a
+        // port, releasing it, and binding it again races every other test in
+        // this process that is also asking the OS for ephemeral ports, which
+        // is exactly the race `reserve_ephemeral_port` documents.
+        let held = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let held_port = held.local_addr().unwrap().port();
+
+        for _ in 0..16 {
+            assert_ne!(
+                reserve_ephemeral_port().unwrap(),
+                held_port,
+                "a port with a live listener must not be offered as free"
+            );
+        }
     }
 
     #[test]

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -142,13 +142,34 @@ mod tests {
 
     use std::io::{Read, Write};
 
+    /// Run `check` against a port that was free the instant it was handed
+    /// over, retrying if a concurrent test claimed it first.
+    ///
+    /// Every assertion about an unoccupied port races the rest of this
+    /// process: tests here, in `auto_port`, and anything else asking the OS
+    /// for an ephemeral port draw from the same pool, and a port released to
+    /// make an assertion about it can be taken before the assertion runs. A
+    /// genuine failure fails every attempt; a lost race does not.
+    fn with_free_port(mut check: impl FnMut(u16) -> bool, what: &str) {
+        const ATTEMPTS: usize = 8;
+        for attempt in 0..ATTEMPTS {
+            let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+            let port = listener.local_addr().unwrap().port();
+            drop(listener);
+
+            if check(port) {
+                return;
+            }
+            assert!(attempt < ATTEMPTS - 1, "{what}");
+        }
+    }
+
     #[test]
     fn unbound_port_is_available() {
-        // Bind and release to get a port nothing is listening on.
-        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
-        let port = listener.local_addr().unwrap().port();
-        drop(listener);
-        assert!(port_available("127.0.0.1", port));
+        with_free_port(
+            |port| port_available("127.0.0.1", port),
+            "a port with nothing listening must read as available",
+        );
     }
 
     #[test]
@@ -220,10 +241,10 @@ mod tests {
 
     #[test]
     fn ensure_passes_when_every_port_is_free() {
-        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
-        let port = listener.local_addr().unwrap().port();
-        drop(listener);
-        assert!(ensure_ports_available("127.0.0.1", [(port, PortRole::Server)]).is_ok());
+        with_free_port(
+            |port| ensure_ports_available("127.0.0.1", [(port, PortRole::Server)]).is_ok(),
+            "a free port must not be reported as in use",
+        );
     }
 
     #[test]
@@ -248,14 +269,17 @@ mod tests {
 
     #[test]
     fn reserved_port_is_free_when_returned() {
-        let port = reserve_ephemeral_port().expect("the OS should hand out a port");
-        assert_ne!(port, 0, "a reserved port must be concrete");
-        assert!(
-            port_available("127.0.0.1", port),
-            "the reservation must be released, not held"
-        );
-        // Released means bindable, which is what the caller's process needs.
-        TcpListener::bind(("127.0.0.1", port)).expect("reserved port should be bindable");
+        // The reservation must be released rather than held, and the released
+        // port must be bindable, which is what the caller's process needs.
+        for attempt in 0..8 {
+            let port = reserve_ephemeral_port().expect("the OS should hand out a port");
+            assert_ne!(port, 0, "a reserved port must be concrete");
+
+            if port_available("127.0.0.1", port) && TcpListener::bind(("127.0.0.1", port)).is_ok() {
+                return;
+            }
+            assert!(attempt < 7, "the reservation must be released, not held");
+        }
     }
 
     #[test]

--- a/src/process.rs
+++ b/src/process.rs
@@ -82,6 +82,82 @@ pub fn read_pidfile(path: &Path) -> Option<u32> {
         .and_then(|s| s.trim().parse::<u32>().ok())
 }
 
+/// Stop a process this crate started, identified by a pidfile it wrote.
+///
+/// The pidfile is the wrapper's only claim of ownership. Reading a pid back
+/// out of a directory the wrapper created and named is what separates
+/// reclaiming a leftover of our own from stopping an unrelated server, which
+/// is a distinction the topology builders got wrong before they stopped
+/// clearing ports outright.
+///
+/// Returns the pid that was stopped, or `None` if the file is missing,
+/// unreadable, names a process that is already gone, or names one that is no
+/// longer Redis.
+///
+/// # Why the command is checked
+///
+/// A pidfile only records a number, and the OS reuses numbers. A stale
+/// pidfile left by a crashed run can name a pid that now belongs to something
+/// else entirely, and [`force_kill`] escalates to killing the whole process
+/// group, so acting on a reused pid can take down far more than one process.
+/// On a machine running a test suite, the process that inherited the number is
+/// quite likely to be part of that suite.
+///
+/// Confirming the pid still looks like Redis before signalling it turns
+/// ownership from "we wrote this number down once" into something checked
+/// against the live process.
+pub fn reclaim_from_pidfile(path: &Path) -> Option<u32> {
+    let pid = read_pidfile(path)?;
+    if !pid_alive(pid) {
+        return None;
+    }
+    if !is_redis_process(pid) {
+        return None;
+    }
+    force_kill(pid);
+    Some(pid)
+}
+
+/// Executable names this crate is willing to signal as its own.
+const REDIS_BINARIES: &[&str] = &["redis-server", "redis-sentinel", "redis-stack-server"];
+
+/// Whether a pid belongs to a Redis server or sentinel process.
+///
+/// Reads the process's command via `ps` and compares the **executable's file
+/// name** against a small set of known Redis binaries. A pid that cannot be
+/// inspected reads as
+/// not-Redis, so an uncertain answer never authorises a kill.
+///
+/// The file name is compared, not the whole command line. Substring matching
+/// is unsafe here in a way that is easy to miss: this crate's own build
+/// artifacts live under a directory called `redis-server-wrapper`, so every
+/// process in its test suite has `redis-server` somewhere in its command line.
+/// A substring check would call the test harness a Redis process and, via
+/// [`force_kill`]'s process-group escalation, let a stale pidfile terminate
+/// the run. That is not hypothetical: it is what the first version of this
+/// function did.
+pub fn is_redis_process(pid: u32) -> bool {
+    let Ok(output) = Command::new("ps")
+        .args(["-o", "command=", "-p", &pid.to_string()])
+        .output()
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let command = String::from_utf8_lossy(&output.stdout);
+
+    // The executable is the first field; the rest is the config path and any
+    // module arguments, none of which say anything about what is running.
+    let Some(argv0) = command.split_whitespace().next() else {
+        return false;
+    };
+    let name = argv0.rsplit('/').next().unwrap_or(argv0);
+
+    REDIS_BINARIES.contains(&name)
+}
+
 /// Kill any process **listening** on a TCP port via `lsof`.
 ///
 /// Uses `-sTCP:LISTEN` to restrict matches to server processes, avoiding
@@ -117,5 +193,74 @@ pub fn kill_by_port(port: u16) {
         if !line.is_empty() && line != my_pid {
             let _ = Command::new("kill").args(["-9", line]).output();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn our_own_pid_is_not_a_redis_process() {
+        // The guard that matters: a reused pid belonging to the test harness
+        // must never authorise a kill, because force_kill takes the process
+        // group with it.
+        assert!(!is_redis_process(std::process::id()));
+    }
+
+    #[test]
+    fn a_real_redis_process_is_recognised() {
+        // The positive case, so the guard cannot be trivially satisfied by
+        // always returning false.
+        let child = Command::new("redis-server")
+            .args(["--port", "16995", "--save", ""])
+            .spawn();
+        let Ok(mut child) = child else {
+            eprintln!("skipping: redis-server not on PATH");
+            return;
+        };
+        thread::sleep(Duration::from_millis(300));
+        let pid = child.id();
+        assert!(
+            is_redis_process(pid),
+            "a running redis-server must be recognised"
+        );
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn an_unused_pid_is_not_a_redis_process() {
+        // Very unlikely to be live, and must read as not-Redis either way.
+        assert!(!is_redis_process(u32::MAX - 1));
+    }
+
+    #[test]
+    fn reclaim_ignores_a_missing_pidfile() {
+        let path = std::env::temp_dir().join("rsw-nonexistent-pidfile-xyz");
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(reclaim_from_pidfile(&path), None);
+    }
+
+    #[test]
+    fn reclaim_ignores_a_pidfile_naming_a_non_redis_process() {
+        // Points at this test process. Without the command check this would
+        // signal our own process group.
+        let path = std::env::temp_dir().join("rsw-self-pidfile-test");
+        std::fs::write(&path, std::process::id().to_string()).unwrap();
+        assert_eq!(
+            reclaim_from_pidfile(&path),
+            None,
+            "a live but non-Redis pid must not be killed"
+        );
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn reclaim_ignores_unparseable_contents() {
+        let path = std::env::temp_dir().join("rsw-garbage-pidfile-test");
+        std::fs::write(&path, "not a pid").unwrap();
+        assert_eq!(reclaim_from_pidfile(&path), None);
+        std::fs::remove_file(&path).unwrap();
     }
 }

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -2,9 +2,8 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use tokio::process::Command;
 use tracing::Instrument;
@@ -60,6 +59,7 @@ pub struct RedisSentinelBuilder {
     extra: HashMap<String, String>,
     redis_server_bin: String,
     redis_cli_bin: String,
+    dir: Option<PathBuf>,
     monitored_masters: Vec<MonitoredMaster>,
 }
 
@@ -75,6 +75,17 @@ impl RedisSentinelBuilder {
     /// Set the name of the monitored master (default: `"mymaster"`).
     pub fn master_name(mut self, name: impl Into<String>) -> Self {
         self.master_name = name.into();
+        self
+    }
+
+    /// Place the topology's working directory somewhere specific.
+    ///
+    /// Defaults to a path under the system temp directory derived from the
+    /// bind address and ports. That default is deliberately stable across
+    /// runs: it is where the pidfiles live, and it is what lets a crashed run
+    /// be reclaimed rather than leaving processes that block the next start.
+    pub fn dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.dir = Some(dir.into());
         self
     }
 
@@ -440,6 +451,69 @@ impl RedisSentinelBuilder {
         Ok(())
     }
 
+    /// Where this topology keeps its processes.
+    fn base_dir(&self) -> PathBuf {
+        self.dir.clone().unwrap_or_else(|| {
+            crate::topology_dir::topology_dir(
+                "sentinel",
+                &self.bind,
+                &[
+                    self.master_port,
+                    self.replica_base_port,
+                    self.num_replicas,
+                    self.sentinel_base_port,
+                    self.num_sentinels,
+                ],
+            )
+        })
+    }
+
+    /// Stop leftover processes from a previous run of this same topology.
+    ///
+    /// Covers the data nodes, whose pidfiles `RedisServer` writes, and the
+    /// sentinel control processes, whose configs name a pidfile of their own.
+    /// Nothing outside those paths is touched.
+    fn reclaim_owned_processes(&self, base: &Path) {
+        // RedisServer nests a node-<port> directory under the dir it is given.
+        let data_node =
+            |dir: PathBuf, port: u16| dir.join(format!("node-{port}")).join("redis.pid");
+
+        let mut pidfiles = vec![data_node(base.join("master"), self.master_port)];
+        for port in self.replica_ports() {
+            pidfiles.push(data_node(base.join(format!("replica-{port}")), port));
+        }
+        for port in self.sentinel_ports() {
+            pidfiles.push(base.join(format!("sentinel-{port}")).join("sentinel.pid"));
+        }
+
+        for pidfile in pidfiles {
+            if let Some(pid) = crate::process::reclaim_from_pidfile(&pidfile) {
+                tracing::debug!(pid, path = %pidfile.display(), "reclaimed_stale_sentinel_process");
+            }
+        }
+
+        // Clear the per-process directories now that nothing is using them. A
+        // stable base keeps the previous run's RDB, AOF, and the sentinel
+        // configs Redis rewrites in place with discovered state, none of which
+        // should carry into a topology being built fresh.
+        //
+        // Only directories the wrapper creates and names are removed, never
+        // the base itself, so a caller-supplied `dir` keeps anything else in
+        // it.
+        let mut owned = vec![base.join("master")];
+        for port in self.replica_ports() {
+            owned.push(base.join(format!("replica-{port}")));
+        }
+        for port in self.sentinel_ports() {
+            owned.push(base.join(format!("sentinel-{port}")));
+        }
+        for dir in owned {
+            if dir.exists() {
+                let _ = std::fs::remove_dir_all(&dir);
+            }
+        }
+    }
+
     /// Fail with the first occupied port rather than clearing it.
     fn ensure_ports_free(&self) -> Result<()> {
         let mut wanted = vec![(self.master_port, crate::preflight::PortRole::SentinelMaster)];
@@ -475,17 +549,16 @@ impl RedisSentinelBuilder {
         monitored_masters.extend(self.monitored_masters.iter().cloned());
 
         self.validate_topology()?;
+
+        let base_dir = self.base_dir();
+
+        // Reclaim before the preflight: a leftover process of our own still
+        // holds its port, and the preflight cannot tell it apart from an
+        // unrelated server, so it would reject a topology we are entitled to
+        // restart.
+        self.reclaim_owned_processes(&base_dir);
         self.ensure_ports_free()?;
 
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_nanos())
-            .unwrap_or(0);
-        let base_dir = std::env::temp_dir().join(format!(
-            "redis-sentinel-wrapper-{}-{}",
-            std::process::id(),
-            unique
-        ));
         crate::secure_file::create_dir_all(&base_dir)?;
 
         // 1. Start master.
@@ -856,6 +929,7 @@ impl RedisSentinel {
             extra: HashMap::new(),
             redis_server_bin: "redis-server".into(),
             redis_cli_bin: "redis-cli".into(),
+            dir: None,
             monitored_masters: Vec::new(),
         }
     }

--- a/src/topology_dir.rs
+++ b/src/topology_dir.rs
@@ -1,0 +1,144 @@
+//! Where a cluster or Sentinel topology keeps its working directory.
+//!
+//! The directory name has to be stable across runs, because it is the only
+//! place a previous run's pidfiles can be found. Both builders used to name it
+//! with a pid and a timestamp, which guaranteed a fresh directory every time
+//! and so guaranteed the wrapper could never recognise anything it had started
+//! before. That is why the port cleanup those builders once did could not be
+//! ownership-aware, and why removing it in the fail-closed change left
+//! orphaned nodes with no way to be reclaimed.
+//!
+//! Stable does not mean shared. The name encodes the topology's shape, so two
+//! topologies that could actually run at the same time get different
+//! directories, while the same topology started twice gets the same one.
+
+use std::path::PathBuf;
+
+/// Build a stable directory name for a topology.
+///
+/// `kind` separates clusters from Sentinel topologies. `bind` and `parts`
+/// carry the shape: any two topologies that differ in address or ports get
+/// different directories, and two that agree on both cannot run concurrently
+/// anyway, since they would want the same ports.
+pub(crate) fn topology_dir(kind: &str, bind: &str, parts: &[u16]) -> PathBuf {
+    let mut name = format!("redis-{kind}-wrapper-{}", sanitize(bind));
+    for part in parts {
+        name.push('-');
+        name.push_str(&part.to_string());
+    }
+    std::env::temp_dir().join(name)
+}
+
+/// Reduce a bind address to characters that are safe in a path component.
+///
+/// IPv6 addresses carry colons and brackets, and a hostname could carry
+/// anything a resolver accepts. Collapsing everything outside a small safe set
+/// keeps the name a single path component on every platform.
+fn sanitize(bind: &str) -> String {
+    let mapped: String = bind
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    // Collapse runs so `[::1]` does not become a row of separators.
+    let mut out = String::with_capacity(mapped.len());
+    let mut last_dash = false;
+    for c in mapped.chars() {
+        if c == '-' {
+            if !last_dash {
+                out.push(c);
+            }
+            last_dash = true;
+        } else {
+            out.push(c);
+            last_dash = false;
+        }
+    }
+    let trimmed = out.trim_matches('-');
+    // A bind of "::" sanitizes to nothing, which would leave the name with a
+    // hole in it rather than a component.
+    if trimmed.is_empty() {
+        "any".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_same_topology_maps_to_the_same_directory() {
+        // The property the whole reclaim path depends on.
+        let a = topology_dir("cluster", "127.0.0.1", &[7000, 3]);
+        let b = topology_dir("cluster", "127.0.0.1", &[7000, 3]);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn different_ports_map_to_different_directories() {
+        let a = topology_dir("cluster", "127.0.0.1", &[7000, 3]);
+        let b = topology_dir("cluster", "127.0.0.1", &[7100, 3]);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn different_shapes_on_the_same_base_port_differ() {
+        let a = topology_dir("cluster", "127.0.0.1", &[7000, 3]);
+        let b = topology_dir("cluster", "127.0.0.1", &[7000, 6]);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn different_binds_map_to_different_directories() {
+        let a = topology_dir("cluster", "127.0.0.1", &[7000, 3]);
+        let b = topology_dir("cluster", "0.0.0.0", &[7000, 3]);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn clusters_and_sentinels_do_not_share_a_directory() {
+        let a = topology_dir("cluster", "127.0.0.1", &[7000]);
+        let b = topology_dir("sentinel", "127.0.0.1", &[7000]);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn the_name_is_a_single_path_component() {
+        for bind in ["127.0.0.1", "::1", "[::1]", "localhost", "0.0.0.0"] {
+            let dir = topology_dir("cluster", bind, &[7000, 3]);
+            let name = dir.file_name().expect("must have a file name");
+            assert_eq!(
+                PathBuf::from(name).components().count(),
+                1,
+                "{bind} produced a name that is not one component"
+            );
+        }
+    }
+
+    #[test]
+    fn ipv6_binds_do_not_collapse_into_each_other() {
+        // `::1` and `[::1]` are the same address written differently, so
+        // sharing a directory is correct. A different address must not.
+        assert_eq!(
+            topology_dir("cluster", "::1", &[7000]),
+            topology_dir("cluster", "[::1]", &[7000])
+        );
+        assert_ne!(
+            topology_dir("cluster", "::1", &[7000]),
+            topology_dir("cluster", "::2", &[7000])
+        );
+    }
+
+    #[test]
+    fn sanitize_collapses_runs_and_trims() {
+        assert_eq!(sanitize("127.0.0.1"), "127-0-0-1");
+        assert_eq!(sanitize("[::1]"), "1");
+        assert_eq!(sanitize("localhost"), "localhost");
+        assert_eq!(
+            sanitize("::"),
+            "any",
+            "an all-separator bind still needs a name"
+        );
+    }
+}

--- a/tests/reclaim.rs
+++ b/tests/reclaim.rs
@@ -1,0 +1,163 @@
+//! Reclaiming a topology left behind by a crashed run.
+//!
+//! Startup fails closed on an occupied port rather than clearing it, because
+//! the wrapper cannot tell an unrelated Redis from one of its own. The cost
+//! used to be that a crashed run left orphans blocking every later start.
+//!
+//! These tests simulate a crash with `std::mem::forget`, which drops the
+//! handle's ownership without running the teardown in its `Drop`, leaving the
+//! processes running exactly as an aborted run would.
+
+use redis_server_wrapper::{Error, RedisCluster, RedisSentinel, RedisServer};
+
+#[tokio::test]
+async fn a_cluster_orphaned_by_a_crash_can_be_restarted() {
+    let first = RedisCluster::builder()
+        .masters(3)
+        .base_port(19400)
+        .start()
+        .await
+        .expect("first cluster should start");
+
+    let addrs = first.node_addrs();
+    assert_eq!(addrs.len(), 3);
+
+    // Abandon the handle without stopping anything: the nodes stay up holding
+    // their ports, as they would after a panic or a kill -9 of the runner.
+    std::mem::forget(first);
+
+    // The same topology starts again rather than failing on its own leftovers.
+    let second = RedisCluster::builder()
+        .masters(3)
+        .base_port(19400)
+        .start()
+        .await
+        .expect("the same topology should reclaim its own orphans and restart");
+
+    assert!(second.is_healthy().await);
+    assert_eq!(second.node_addrs().len(), 3);
+}
+
+#[tokio::test]
+async fn a_sentinel_topology_orphaned_by_a_crash_can_be_restarted() {
+    let first = RedisSentinel::builder()
+        .master_port(19410)
+        .replica_base_port(19411)
+        .sentinel_base_port(29410)
+        .replicas(1)
+        .sentinels(3)
+        .quorum(2)
+        .start()
+        .await
+        .expect("first topology should start");
+    std::mem::forget(first);
+
+    let second = RedisSentinel::builder()
+        .master_port(19410)
+        .replica_base_port(19411)
+        .sentinel_base_port(29410)
+        .replicas(1)
+        .sentinels(3)
+        .quorum(2)
+        .start()
+        .await
+        .expect("the same topology should reclaim its own orphans and restart");
+
+    assert!(second.is_healthy().await);
+}
+
+#[tokio::test]
+async fn reclaim_still_refuses_to_touch_an_unowned_server() {
+    // The guarantee reclaim must not weaken. A server the wrapper did not
+    // start is not covered by any pidfile it wrote, so it is left alone and
+    // the port preflight rejects the topology.
+    let bystander = RedisServer::new()
+        .port(19421)
+        .start()
+        .await
+        .expect("bystander should start");
+    bystander
+        .run(&["SET", "precious", "data"])
+        .await
+        .expect("seed failed");
+
+    let result = RedisCluster::builder()
+        .masters(3)
+        .base_port(19420) // covers 19420, 19421, 19422
+        .start()
+        .await;
+
+    match result {
+        Err(Error::PortInUse { port, .. }) => assert_eq!(port, 19421),
+        Err(other) => panic!("expected PortInUse, got: {other}"),
+        Ok(_) => panic!("an unowned server must still fail the preflight"),
+    }
+
+    assert!(bystander.is_alive().await);
+    let value = bystander
+        .run(&["GET", "precious"])
+        .await
+        .expect("bystander should still answer");
+    assert_eq!(value.trim(), "data");
+}
+
+#[tokio::test]
+async fn restarting_a_cluster_does_not_inherit_the_previous_run_data() {
+    // A stable directory keeps the previous run's nodes.conf and RDB, which
+    // would both leave the node non-empty and make CLUSTER CREATE refuse it.
+    // Reclaim clears the state it owns, so a restart is genuinely fresh.
+    let first = RedisCluster::builder()
+        .masters(3)
+        .base_port(19430)
+        .start()
+        .await
+        .expect("first cluster should start");
+
+    // Write through a cluster-aware client so the key lands on whichever node
+    // owns its slot, rather than assuming a hash.
+    first
+        .cli()
+        .cluster_mode(true)
+        .run(&["SET", "leftover", "value"])
+        .await
+        .expect("write should succeed");
+
+    let before: u64 = {
+        let mut total = 0;
+        for node in first.nodes() {
+            total += node
+                .run(&["DBSIZE"])
+                .await
+                .expect("DBSIZE should succeed")
+                .trim()
+                .parse::<u64>()
+                .unwrap_or(0);
+        }
+        total
+    };
+    assert_eq!(before, 1, "the key should be somewhere in the cluster");
+
+    std::mem::forget(first);
+
+    let second = RedisCluster::builder()
+        .masters(3)
+        .base_port(19430)
+        .start()
+        .await
+        .expect("restart should succeed");
+
+    let mut after = 0;
+    for node in second.nodes() {
+        after += node
+            .run(&["DBSIZE"])
+            .await
+            .expect("DBSIZE should succeed")
+            .trim()
+            .parse::<u64>()
+            .unwrap_or(0);
+    }
+    assert_eq!(
+        after, 0,
+        "a reclaimed cluster must not carry the previous run's keys"
+    );
+}


### PR DESCRIPTION
Closes #152.

## Problem

#145 stopped cluster and Sentinel startup from shutting down whatever held the
ports it wanted, because neither could tell a leftover node of its own from an
unrelated Redis. Startup now fails closed. The cost is that after a crashed
run, orphaned nodes hold their ports and the next run cannot start until
someone cleans up by hand.

The cleanup could not have been ownership-aware, because both builders name
their working directory with a pid and a timestamp:

```rust
let cluster_base = std::env::temp_dir().join(format!(
    "redis-cluster-wrapper-{}-{}", std::process::id(), unique
));
```

A fresh directory every run means no pidfile from a previous run survives, so
the wrapper keeps no record of what it started.

## Approach

Give the topologies the same shape the standalone server already has: a stable
directory, pidfiles in it, and a reclaim step that only ever touches a process
whose pidfile the wrapper itself wrote.

Most of this already exists. Cluster nodes are started through
`RedisServer::start`, which writes a pidfile and reclaims a stale process from
it. Making the base directory stable is what lets that machinery apply.

The one genuinely new piece is ordering: `ensure_ports_free` runs before any
node starts, so a stale node of our own would trip the preflight before it
ever got a chance to reclaim itself. Reclaim has to happen first.

## Plan

1. Derive the base directory from the topology shape (bind and port range)
   rather than pid and timestamp, so the same topology maps to the same
   directory across runs. Add a `dir()` setter on both builders so callers can
   place it themselves.
2. Before the port preflight, walk the expected node directories, read the
   pidfiles the wrapper wrote, and stop only processes recorded there that are
   still alive.
3. Keep the preflight afterwards. Anything still holding a port once our own
   processes are gone is genuinely not ours, and still fails closed.

## Testing

- A topology started, orphaned, and started again on the same ports succeeds
  rather than failing with `PortInUse`.
- An unrelated server on one of those ports is still never touched, and
  startup still fails closed against it.
- Two topologies with different shapes do not share a directory.