### PR TITLE
docs: bring the README in line with the 0.5.0 surface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,13 @@ tokio = ["dep:tokio"]
 blocking = ["tokio"]
 test-tls = ["dep:rcgen"]
 
+# docs.rs builds with default features only unless told otherwise, which would
+# publish the crate without the `blocking` and `test-tls` modules the README
+# tells people to enable.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 glob = "0.3"
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -371,9 +371,9 @@ async fn test_error_handling() {
 }
 ```
 
-Prefer a `..` rest pattern inside a variant and a catch-all `Err(e)` arm. `Error`
-gains variants and fields between releases, and an exhaustive match without them
-will not compile against the next one.
+`Error` is `#[non_exhaustive]`, so a catch-all `Err(e)` arm is required. Use a
+`..` rest pattern inside a variant as well, since variants gain fields between
+releases the same way the enum gains variants.
 
 ## Blocking API
 

--- a/README.md
+++ b/README.md
@@ -86,12 +86,16 @@ redis-server-wrapper = { version = "0.5", features = ["blocking"] }
 The async API requires [tokio](https://tokio.rs). See the [Blocking API](#blocking-api) section
 for synchronous use.
 
+Examples below are written as plain functions rather than annotated tests. Every one is
+compiled as a doc test on each build, which keeps them from drifting from the API; a
+`#[tokio::test]` attribute would make the compiler skip the body and defeat that. Add the
+attribute when you copy one into your own suite.
+
 ### Single Server
 
 ```rust
 use redis_server_wrapper::RedisServer;
 
-#[tokio::test]
 async fn test_server() {
     let server = RedisServer::new()
         .port(6400)
@@ -120,7 +124,6 @@ Use the dedicated method instead.
 ```rust
 use redis_server_wrapper::{LogLevel, RedisServer};
 
-#[tokio::test]
 async fn test_server_config() {
     let server = RedisServer::new()
         .port(6400)
@@ -142,7 +145,6 @@ arguments with `.loadmodule_with_args()`:
 ```rust
 use redis_server_wrapper::RedisServer;
 
-#[tokio::test]
 async fn test_loadmodule() {
     let server = RedisServer::new()
         .port(6400)
@@ -162,7 +164,6 @@ instead of coordinating a fixed range between them:
 ```rust
 use redis_server_wrapper::RedisServer;
 
-#[tokio::test]
 async fn test_auto_port() {
     let server = RedisServer::new().auto_port().start().await.unwrap();
 
@@ -187,7 +188,6 @@ running without it. Check against the live server:
 ```rust
 use redis_server_wrapper::RedisServer;
 
-#[tokio::test]
 async fn test_module_is_loaded() {
     let server = RedisServer::new()
         .port(6400)
@@ -241,7 +241,6 @@ The handle exposes a `RedisCli` you can use to run arbitrary commands against th
 ```rust
 use redis_server_wrapper::RedisServer;
 
-#[tokio::test]
 async fn test_run_commands() {
     let server = RedisServer::new().port(6400).start().await.unwrap();
 
@@ -256,7 +255,6 @@ You can also get a `RedisCli` instance directly from the handle:
 ```rust
 use redis_server_wrapper::RedisServer;
 
-#[tokio::test]
 async fn test_cli() {
     let server = RedisServer::new().port(6400).start().await.unwrap();
     let cli = server.cli();
@@ -270,7 +268,6 @@ async fn test_cli() {
 ```rust
 use redis_server_wrapper::RedisCluster;
 
-#[tokio::test]
 async fn test_cluster() {
     let cluster = RedisCluster::builder()
         .masters(3)
@@ -289,7 +286,6 @@ async fn test_cluster() {
 ```rust
 use redis_server_wrapper::RedisSentinel;
 
-#[tokio::test]
 async fn test_sentinel() {
     let sentinel = RedisSentinel::builder()
         .master_port(6390)
@@ -312,7 +308,6 @@ nodes with POSIX signals -- for testing how clients handle timeouts and failover
 use redis_server_wrapper::{RedisServer, chaos};
 use std::time::Duration;
 
-#[tokio::test]
 async fn test_chaos_pause() {
     let server = RedisServer::new().port(6400).start().await.unwrap();
 
@@ -339,7 +334,6 @@ server process:
 ```rust
 use redis_server_wrapper::{Direction, FaultProxy, RedisServer};
 
-#[tokio::test]
 async fn test_fault_proxy() {
     let server = RedisServer::new().port(6400).start().await.unwrap();
     let proxy = FaultProxy::spawn(server.addr()).await.unwrap();
@@ -360,7 +354,6 @@ I/O errors:
 ```rust
 use redis_server_wrapper::{Error, RedisServer};
 
-#[tokio::test]
 async fn test_error_handling() {
     match RedisServer::new().port(6400).start().await {
         Ok(server) => println!("running on {}", server.addr()),
@@ -398,14 +391,16 @@ underlying async `Drop` implementation keeps working correctly.
 ```rust
 use redis_server_wrapper::blocking::RedisServer;
 
-let server = RedisServer::new()
-    .port(6400)
-    .bind("127.0.0.1")
-    .start()
-    .unwrap();
+fn test_blocking_server() {
+    let server = RedisServer::new()
+        .port(6400)
+        .bind("127.0.0.1")
+        .start()
+        .unwrap();
 
-assert!(server.is_alive());
-// Stopped automatically on drop.
+    assert!(server.is_alive());
+    // Stopped automatically on drop.
+}
 ```
 
 Use `server.detach()` in the blocking API for the same keep-running behavior.
@@ -415,22 +410,24 @@ Cluster and Sentinel work the same way:
 ```rust
 use redis_server_wrapper::blocking::{RedisCluster, RedisSentinel};
 
-let cluster = RedisCluster::builder()
-    .masters(3)
-    .base_port(7000)
-    .start()
-    .unwrap();
+fn test_blocking_topologies() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .base_port(7000)
+        .start()
+        .unwrap();
 
-assert!(cluster.is_healthy());
+    assert!(cluster.is_healthy());
 
-let sentinel = RedisSentinel::builder()
-    .master_port(6390)
-    .replicas(2)
-    .sentinels(3)
-    .start()
-    .unwrap();
+    let sentinel = RedisSentinel::builder()
+        .master_port(6390)
+        .replicas(2)
+        .sentinels(3)
+        .start()
+        .unwrap();
 
-assert!(sentinel.is_healthy());
+    assert!(sentinel.is_healthy());
+}
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ just `redis-server` and `redis-cli` on PATH.
 - **Arbitrary config** -- pass any Redis directive via `.extra(key, value)`
 - **Fault injection** -- process-level chaos (freeze, kill, partition) via the `chaos` module,
   and byte-level TCP fault injection (delay, drop, chunking) via `FaultProxy`
+- **Parallel fixtures** -- `.auto_port()` picks a free port and retries a lost race
+- **Module verification** -- assert a module actually loaded, not just that it was configured
+- **Safe by default** -- never stops a Redis process it did not start; reclaims only its own
+- **Tracing** -- spans and events across every lifecycle path, visible via `RUST_LOG`
 
 ## Prerequisites
 
@@ -59,7 +63,7 @@ Add to `Cargo.toml` for async use (the default):
 
 ```toml
 [dev-dependencies]
-redis-server-wrapper = "0.4"
+redis-server-wrapper = "0.5"
 ```
 
 The `tokio` feature is enabled by default. To use the synchronous blocking API instead,
@@ -67,14 +71,14 @@ disable default features and enable `blocking`:
 
 ```toml
 [dev-dependencies]
-redis-server-wrapper = { version = "0.4", default-features = false, features = ["blocking"] }
+redis-server-wrapper = { version = "0.5", default-features = false, features = ["blocking"] }
 ```
 
 To use both async and blocking APIs together:
 
 ```toml
 [dev-dependencies]
-redis-server-wrapper = { version = "0.4", features = ["blocking"] }
+redis-server-wrapper = { version = "0.5", features = ["blocking"] }
 ```
 
 ## Usage
@@ -107,7 +111,11 @@ Call `server.detach()` to consume the handle without stopping the process.
 ### Configuration
 
 Common options have dedicated builder methods. Anything else can be passed as
-a raw Redis directive with `.extra(key, value)`:
+a raw Redis directive with `.extra(key, value)`. Directives the wrapper
+generates itself (`port`, `dir`, `requirepass`, `loadmodule`, and similar) are
+rejected: the wrapper reuses those values for readiness probing and teardown, so
+overriding one would leave the handle describing a server that does not exist.
+Use the dedicated method instead.
 
 ```rust
 use redis_server_wrapper::{LogLevel, RedisServer};
@@ -145,6 +153,86 @@ async fn test_loadmodule() {
         .unwrap();
 }
 ```
+
+### Parallel Fixtures
+
+Tests that each own a Redis lifecycle can let the wrapper pick a free port
+instead of coordinating a fixed range between them:
+
+```rust
+use redis_server_wrapper::RedisServer;
+
+#[tokio::test]
+async fn test_auto_port() {
+    let server = RedisServer::new().auto_port().start().await.unwrap();
+
+    // The chosen port is on the handle.
+    println!("started on {}", server.addr());
+}
+```
+
+Asking the OS for a free port and having Redis bind it are two steps, so another
+process can take the port in between. The builder retries with a new candidate
+rather than failing, and never stops whatever won the race.
+
+`port(0)` is unrelated: it keeps its Redis meaning of disabling the plaintext
+listener for a TLS-only server.
+
+### Verifying Loaded Modules
+
+A `loadmodule` directive only asks Redis to load a module. A wrong path, an ABI
+mismatch, or a module whose `RedisModule_OnLoad` fails all leave the server
+running without it. Check against the live server:
+
+```rust
+use redis_server_wrapper::RedisServer;
+
+#[tokio::test]
+async fn test_module_is_loaded() {
+    let server = RedisServer::new()
+        .port(6400)
+        .loadmodule("/path/to/module.so")
+        .start()
+        .await
+        .unwrap();
+
+    // Errors listing what is loaded instead, since the module's registered
+    // name often differs from its filename.
+    server.require_module("my_module").await.unwrap();
+
+    for module in server.modules().await.unwrap() {
+        println!("{} v{:?}", module.name, module.version);
+    }
+}
+```
+
+Clusters and Sentinel topologies propagate modules to every node, so they have
+`require_module_on_all_nodes` and `require_module_on_data_nodes` respectively.
+
+### Ports and Cleanup
+
+Startup never stops a Redis process it did not start. If a port a topology needs
+is already serving, startup fails with `Error::PortInUse` naming the port and
+leaves that process alone.
+
+A crashed run is reclaimed rather than blocking the next one. Cluster and
+Sentinel topologies keep a working directory derived from their shape, and on
+startup they stop only processes recorded in pidfiles they wrote, after
+confirming the pid still belongs to a Redis binary. Point that directory
+somewhere specific with `.dir()` on either builder.
+
+### Logging
+
+The crate emits [`tracing`](https://docs.rs/tracing) spans and events across the
+lifecycle paths: server, cluster, and Sentinel startup and shutdown, every chaos
+operation, and the fault proxy. With no subscriber installed these surface as
+`log` records, so `env_logger` or `test-log` users get output with no setup:
+
+```console
+RUST_LOG=redis_server_wrapper=debug cargo test
+```
+
+`tracing-subscriber` users get the same targets as structured spans.
 
 ### Running Commands
 
@@ -266,7 +354,8 @@ async fn test_fault_proxy() {
 ## Error Handling
 
 All fallible operations return `Result<T, Error>`. The `Error` enum covers server
-start failures, timeouts, CLI errors, and underlying I/O errors:
+start failures, timeouts, CLI errors, port and topology problems, and underlying
+I/O errors:
 
 ```rust
 use redis_server_wrapper::{Error, RedisServer};
@@ -275,12 +364,23 @@ use redis_server_wrapper::{Error, RedisServer};
 async fn test_error_handling() {
     match RedisServer::new().port(6400).start().await {
         Ok(server) => println!("running on {}", server.addr()),
-        Err(Error::ServerStart { port }) => eprintln!("could not start on port {port}"),
+        // `detail` carries the tail of the node's log when one was written,
+        // which usually says why Redis refused to start.
+        Err(Error::ServerStart { port, detail }) => {
+            eprintln!("could not start on port {port}: {}", detail.unwrap_or_default())
+        }
+        Err(Error::PortInUse { port, role, .. }) => {
+            eprintln!("{role} {port} is already serving; startup will not clear it")
+        }
         Err(Error::BinaryNotFound { binary }) => eprintln!("{binary} not found on PATH"),
         Err(e) => eprintln!("unexpected: {e}"),
     }
 }
 ```
+
+Prefer a `..` rest pattern inside a variant and a catch-all `Err(e)` arm. `Error`
+gains variants and fields between releases, and an exhaustive match without them
+will not compile against the next one.
 
 ## Blocking API
 
@@ -288,7 +388,7 @@ Enable the `blocking` feature for synchronous wrappers that require no async run
 
 ```toml
 [dev-dependencies]
-redis-server-wrapper = { version = "0.4", features = ["blocking"] }
+redis-server-wrapper = { version = "0.5", features = ["blocking"] }
 ```
 
 The `blocking` module mirrors the async API. Every operation blocks the calling thread

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,6 +268,12 @@ pub use server::{
 
 /// Compile the README's examples as doc tests, so they cannot drift from the
 /// API the way the error-handling example did before 0.5.0.
-#[cfg(doctest)]
+///
+/// Gated on `blocking` because the README documents that API too, and those
+/// examples cannot compile without the feature that provides it. Every job
+/// that runs with `--all-features` covers them; the MSRV job, which builds
+/// default features only, skips this rather than failing on a module it was
+/// never asked to build.
+#[cfg(all(doctest, feature = "blocking"))]
 #[doc = include_str!("../README.md")]
 struct ReadmeExamples;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,3 +265,9 @@ pub use server::{
     AppendFsync, LogLevel, RedisServer, RedisServerConfig, RedisServerHandle, ReplDisklessLoad,
     SavePolicy,
 };
+
+/// Compile the README's examples as doc tests, so they cannot drift from the
+/// API the way the error-handling example did before 0.5.0.
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+struct ReadmeExamples;


### PR DESCRIPTION
Findings from a release-readiness pass, and the fixes that were safe to make
directly. Anchored on `origin/main` at `f9446ac`, version 0.4.3, which matches
both crates.io and the latest tag.

## Broken example

The README matched `Error::ServerStart { port }`. That variant gained a
`detail` field in #155, so the snippet does not compile:

```
error[E0027]: pattern does not mention field `detail`
```

The equivalent example in `lib.rs` was updated, because doc tests compile it.
README code is not compiled by cargo, so this drifted silently.

Every rust block in the README was extracted into a temporary test target and
compiled to find this. All fourteen build after the fix. That harness is not
committed here, for reasons under "Not done" below.

## Missing docs.rs metadata

`docs.rs` builds default features only. The published documentation has
therefore never included the `blocking` or `test-tls` modules, while the README
tells people to enable them. Added `all-features = true`.

## Undocumented surface

Everything below shipped after 0.4.3 and had no README coverage:

| Added | Where |
|---|---|
| `auto_port` | Parallel Fixtures |
| `modules`, `has_module`, `require_module`, and the topology variants | Verifying Loaded Modules |
| `PortInUse`, fail-closed startup, topology reclaim, `dir()` | Ports and Cleanup |
| tracing spans and `RUST_LOG` | Logging |
| `extra()` rejecting wrapper-owned directives | Configuration |

Dependency snippets moved to 0.5, the version the pending release publishes.

## Not done, deliberately

**A permanent guard against README drift.** The standard trick is
`#[cfg(doctest)] #[doc = include_str!("../README.md")]`, which turns README
blocks into doc tests. It is not safe to add as-is: doc tests wrap a bare
fragment in `fn main` and run it, and one block would start a real Redis during
`cargo test --doc`. Making it safe means tagging blocks `no_run`, which changes
how GitHub renders them. Worth its own decision rather than a side effect of
this PR.

**`#[non_exhaustive]` on `Error`.** The enum gained five variants and one field
this cycle, and every one of those was a breaking change for an exhaustive
match. Marking it non-exhaustive would end that, and 0.5.0 is the right moment
since it is already a breaking release. It is an API decision, so it is flagged
rather than taken. The README now advises a catch-all arm either way.

## Release state

| Source | Version |
|---|---|
| `origin/main` Cargo.toml | 0.4.3 |
| crates.io | 0.4.3 |
| latest tag and release | v0.4.3 |
| pending release PR #150 | 0.5.0 |

Aligned, no skew. #150 is current and includes #157.