### PR TITLE
feat!: mark Error as non_exhaustive

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,15 @@
 use std::io;
 
 /// Errors returned by redis-server-wrapper operations.
+///
+/// Marked `#[non_exhaustive]`: this enum gains variants as the wrapper learns
+/// to report more failures precisely, and every such addition would otherwise
+/// break an exhaustive `match` downstream. The 0.5.0 cycle alone added five.
+/// Match the variants you handle and end with a catch-all `Err(e)` arm, and
+/// use a `..` rest pattern inside a variant so a new field does not break
+/// either.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     /// A `redis-server` process failed to start.
     ///


### PR DESCRIPTION
Follow-up from the release-readiness audit in #158.

## Why now

`Error` gained five variants this cycle (`PortInUse`, `InvalidTopology`,
`ReservedDirective`, `ModuleNotLoaded`, `PortAllocation`) plus a `detail` field
on `ServerStart`. Every one of those broke any downstream exhaustive match.

`#[non_exhaustive]` makes future variants additive. It is itself a breaking
change, so 0.5.0 is the moment: it is already a breaking release, and deferring
means paying the same cost again later for no benefit.

## Impact

Downstream code matching every variant without a catch-all stops compiling and
needs a final `Err(e) => ...` arm. Code that already has one is unaffected.

Nothing in this repository needed changing. The integration tests are external
crates, so they are subject to the rule, and they already used catch-all arms
or `matches!`.

## Verification

Full suite green across all features, clippy `-D warnings`, fmt, docs.