### PR TITLE
fix: give each automatic-port attempt its own directory

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -2094,6 +2094,10 @@ impl RedisServer {
     /// configuration rather than of the port, and retrying it would just fail
     /// again on a different number.
     async fn start_on_an_automatic_port(self) -> Result<RedisServerHandle> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        /// Distinguishes concurrent automatic-port attempts within a process.
+        static ATTEMPT: AtomicU64 = AtomicU64::new(0);
+
         let mut last: Option<Error> = None;
 
         for _ in 0..MAX_PORT_ATTEMPTS {
@@ -2102,6 +2106,24 @@ impl RedisServer {
             };
             let candidate = crate::preflight::reserve_ephemeral_port()?;
             attempt.config.port = candidate;
+
+            // Give every attempt its own directory.
+            //
+            // The node directory is derived from the port, so two attempts
+            // that draw the same candidate would otherwise share one, and with
+            // it the pidfile. Both would then see the pidfile the winner wrote
+            // and both would report success, leaving two handles believing
+            // they own a port with one server behind it. The loser's teardown
+            // would stop the winner's server.
+            //
+            // With separate directories the loser's `redis-server` fails to
+            // bind, writes no pidfile of its own, and the start fails and
+            // retries on a different port, which is the intended behavior.
+            attempt.config.dir = attempt.config.dir.join(format!(
+                "auto-{}-{}",
+                std::process::id(),
+                ATTEMPT.fetch_add(1, Ordering::Relaxed)
+            ));
 
             match attempt.start_on_the_configured_port().await {
                 Ok(handle) => return Ok(handle),

--- a/tests/auto_port.rs
+++ b/tests/auto_port.rs
@@ -57,9 +57,40 @@ async fn concurrent_fixtures_get_distinct_ports() {
     ports.dedup();
     assert_eq!(ports.len(), before, "every fixture must get its own port");
 
+    // Distinct directories, not just distinct ports. Two attempts that drew the
+    // same candidate would otherwise share a node directory and its pidfile,
+    // and the loser would read the winner's and report success: two handles,
+    // one server, and a teardown that stops someone else's.
+    let mut dirs: Vec<_> = servers.iter().map(|s| s.node_dir()).collect();
+    let dir_count = dirs.len();
+    dirs.sort();
+    dirs.dedup();
+    assert_eq!(
+        dirs.len(),
+        dir_count,
+        "every fixture must own its own directory"
+    );
+
     // All of them are still up: allocation did not stop an earlier fixture.
     for server in &servers {
         assert!(server.is_alive().await, "fixture on {} died", server.port());
+    }
+
+    // And each is genuinely its own server, not several handles onto one.
+    for (i, server) in servers.iter().enumerate() {
+        server
+            .run(&["SET", "owner", &i.to_string()])
+            .await
+            .expect("write should succeed");
+    }
+    for (i, server) in servers.iter().enumerate() {
+        let owner = server.run(&["GET", "owner"]).await.expect("read failed");
+        assert_eq!(
+            owner.trim(),
+            i.to_string(),
+            "fixture {i} on port {} is not a distinct server",
+            server.port()
+        );
     }
 }
 


### PR DESCRIPTION
Fixes a correctness bug in `auto_port` from #154. Found by CI on #158, which
is a docs-only branch: the failure was pre-existing on main, not caused by it.

## The bug

The node directory is derived from the port:

```rust
let node_dir = self.config.dir.join(format!("node-{}", self.config.port));
```

Two concurrent `auto_port` starts can draw the same candidate, because
reserving a port releases it before Redis binds it. They then share that
directory and its pidfile.

What follows is worse than a lost race:

1. Both preflight the port and both see it free.
2. Both launch `redis-server`. One binds; the other fails and exits.
3. The loser's readiness probe connects to the port and succeeds, because the
   winner is listening there.
4. The loser waits for a pidfile and finds the one the winner wrote.
5. Both starts report success. Two handles, one server.

Dropping either handle stops the other's server.

## The fix

Each attempt gets its own directory, keyed on process id and an attempt
counter. The loser now finds no pidfile of its own, times out, and retries on
a different port, which is what the retry loop was always for.

## Testing

`concurrent_fixtures_get_distinct_ports` is the test that caught this. It now
also asserts:

- distinct node directories, not just distinct ports
- that each handle is a distinct server, by writing a different value through
  each and reading it back

That second one is what actually fails on the old behavior. Distinct ports
alone would not have caught it if the collision had resolved differently.

Five clean runs locally plus a full suite pass. The collision is occasional, so
absence of a local failure is weak evidence either way; the added assertions
are the stronger check.