### PR TITLE
fix: tolerate a sentinel that crashes before replying

### DIFF
--- a/src/chaos.rs
+++ b/src/chaos.rs
@@ -909,9 +909,34 @@ pub async fn crash_sentinel_during_failover(
         SentinelCrashPoint::AfterPromotion => "crash-after-promotion",
     };
     cli.run(&["SENTINEL", "SIMULATE-FAILURE", mode]).await?;
-    cli.run(&["SENTINEL", "FAILOVER", handle.master_name()])
-        .await?;
-    Ok(())
+
+    match cli
+        .run(&["SENTINEL", "FAILOVER", handle.master_name()])
+        .await
+    {
+        Ok(_) => Ok(()),
+        // The crash armed a moment ago can land before the reply is flushed,
+        // which redis-cli reports as a closed connection. That is the outcome
+        // this function exists to produce, arriving a little early, so it is
+        // success rather than failure. Anything else, including a Redis error
+        // reply such as an unknown master name, still propagates.
+        Err(Error::Cli { ref detail, .. }) if connection_closed(detail) => {
+            tracing::debug!(sentinel_idx, "sentinel crashed before replying");
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Whether a redis-cli failure means the peer went away mid-command.
+///
+/// Distinguishes a process that died, which several chaos primitives cause
+/// deliberately, from a Redis error reply, which is a real failure.
+fn connection_closed(detail: &str) -> bool {
+    let detail = detail.to_ascii_lowercase();
+    detail.contains("server closed the connection")
+        || detail.contains("connection reset")
+        || detail.contains("broken pipe")
 }
 
 // ---------------------------------------------------------------------------
@@ -1330,6 +1355,24 @@ fn parse_cluster_node_port(addr: &str) -> Option<u16> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn connection_closed_recognises_a_dead_peer() {
+        // Exactly what redis-cli reported when an armed sentinel crashed
+        // before flushing its reply.
+        assert!(connection_closed("Error: Server closed the connection"));
+        assert!(connection_closed("Connection reset by peer"));
+        assert!(connection_closed("Broken pipe"));
+    }
+
+    #[test]
+    fn connection_closed_does_not_swallow_redis_errors() {
+        // A Redis error reply is a real failure and must still propagate.
+        assert!(!connection_closed("ERR No such master with that name"));
+        assert!(!connection_closed("NOAUTH Authentication required."));
+        assert!(!connection_closed("WRONGTYPE Operation against a key"));
+        assert!(!connection_closed(""));
+    }
 
     #[test]
     fn slot_in_range_single() {


### PR DESCRIPTION
Pre-existing flake, surfaced by CI on #158. Not caused by that branch, which is
docs-only.

## The bug

`crash_sentinel_during_failover` arms a sentinel with `SENTINEL
SIMULATE-FAILURE` and then issues `SENTINEL FAILOVER` to trigger it. The crash
can land before the reply is flushed:

```
Cli { host: "127.0.0.1", port: 28120, detail: "Error: Server closed the connection" }
```

redis-cli exits non-zero, so the helper returned an error for exactly the
outcome it exists to produce.

The test carried a comment asserting that "both commands reply +OK before the
process actually dies." That is usually true, which is why this failed
occasionally rather than always.

## The fix

A closed connection on the failover command is success. The crash arrived
early.

Redis error replies still propagate. The check matches a peer going away
(`server closed the connection`, `connection reset`, `broken pipe`), not any
failure, so an unknown master name or a `NOAUTH` still surfaces as an error.
Unit tests cover both directions.

## Testing

Sentinel suite three times, full suite once, clippy, fmt. The race is
occasional, so the unit tests on the predicate are the stronger evidence here
than repeated passes.