### PR TITLE
fix: verify an automatic port actually belongs to our server

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -2124,9 +2124,35 @@ impl RedisServer {
                 std::process::id(),
                 ATTEMPT.fetch_add(1, Ordering::Relaxed)
             ));
+            let expected_dir = attempt
+                .config
+                .dir
+                .join(format!("node-{candidate}"))
+                .display()
+                .to_string();
+            let attempt_bind = attempt.config.bind.clone();
 
             match attempt.start_on_the_configured_port().await {
-                Ok(handle) => return Ok(handle),
+                // A successful start is not proof the server on that port is
+                // ours. Every check along the way can be satisfied by someone
+                // else's server: the daemonizing parent exits 0 whether or not
+                // the child binds, and the readiness probe connects to
+                // whatever is listening. Ask the server which directory it is
+                // running from, which is unique to this attempt.
+                Ok(handle) => match handle.run(&["CONFIG", "GET", "dir"]).await {
+                    Ok(reply) if reply.contains(&expected_dir) => return Ok(handle),
+                    _ => {
+                        tracing::debug!(port = candidate, "auto_port_lost_race");
+                        // Dropping the handle here would stop the server that
+                        // won the port, which is not ours to stop.
+                        handle.detach();
+                        last = Some(Error::PortInUse {
+                            host: attempt_bind.clone(),
+                            port: candidate,
+                            role: crate::preflight::PortRole::Server.to_string(),
+                        });
+                    }
+                },
                 // Someone took the candidate between reserving it and binding
                 // it. Their process is left alone; take a different number.
                 Err(e @ (Error::PortInUse { .. } | Error::ServerStart { .. })) => {

--- a/tests/auto_port.rs
+++ b/tests/auto_port.rs
@@ -175,3 +175,29 @@ async fn auto_port_overrides_a_configured_port() {
     );
     assert!(server.is_alive().await);
 }
+
+#[tokio::test]
+async fn config_get_dir_identifies_the_server_behind_a_port() {
+    // The invariant the automatic-port ownership check rests on. Neither the
+    // spawn's exit status nor the readiness probe can tell our server from
+    // someone else's on the same port, so the retry loop asks the server which
+    // directory it is running from. If Redis ever stopped reporting that, the
+    // check would reject every attempt and allocation would fail rather than
+    // silently hand back a foreign server, but pin it either way.
+    let server = RedisServer::new()
+        .auto_port()
+        .start()
+        .await
+        .expect("failed to start");
+
+    let reply = server
+        .run(&["CONFIG", "GET", "dir"])
+        .await
+        .expect("CONFIG GET dir should succeed");
+
+    let node_dir = server.node_dir().display().to_string();
+    assert!(
+        reply.contains(&node_dir),
+        "CONFIG GET dir returned {reply:?}, which does not contain {node_dir}"
+    );
+}


### PR DESCRIPTION
Completes the fix started in #160, which was necessary but not sufficient: the
collision still reproduced on CI afterwards, on the Redis 8.8.0 job of #163.

## Why #160 was not enough

It stopped a losing attempt from reading the winner's pidfile. It did not
address the fact that nothing in the start path proves the server answering on
a port is the one we launched:

| Step | Behavior on a lost race |
|---|---|
| spawn `redis-server` | parent exits 0 whether or not the child binds |
| `wait_for_ready` | connects to the winner's server and succeeds |
| pidfile wait | the only real gate, a 1s poll on a file Redis may write before failing to bind |

## The fix

Ask the server which directory it is running from. That is unique per attempt,
so a mismatch means we are talking to someone else's server. Discard and retry
on a new port.

The rejected handle is detached rather than dropped, since dropping it would
stop the server that won the port.

## Testing

Full suite plus repeated auto_port runs locally, though the race is occasional
enough that local passes are weak evidence. The stronger argument is that the
check is positive rather than an absence: it confirms identity instead of
inferring it from a step that can succeed for the wrong reason.

Adds a test pinning the invariant, that `CONFIG GET dir` reports the node
directory. If Redis ever stopped doing so, allocation would fail loudly rather
than hand back a foreign server.