### PR TITLE
fix: make stopping a server handle idempotent and ownership-aware

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,12 @@ use crate::error::{Error, Result};
 /// issue long-running commands (e.g. `DEBUG SLEEP`) through it.
 pub(crate) const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(3);
 
+/// How long a fire-and-forget invocation waits before killing redis-cli.
+///
+/// Generous enough that a healthy server always replies well inside it, short
+/// enough that a wedged one cannot stall a teardown.
+const FIRE_AND_FORGET_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// RESP protocol version for client connections.
 #[derive(Debug, Clone, Copy)]
 pub enum RespProtocol {
@@ -679,13 +685,49 @@ impl RedisCli {
 
     /// Run a command, ignoring output. Used for fire-and-forget (SHUTDOWN).
     pub fn fire_and_forget(&self, args: &[&str]) {
-        let _ = Command::new(&self.bin)
+        self.fire_and_forget_bounded(args, FIRE_AND_FORGET_TIMEOUT);
+    }
+
+    /// Run a command, ignoring output, and give up after `timeout`.
+    ///
+    /// The bound is not a nicety. This is reached from `Drop` by way of
+    /// `RedisServerHandle::stop`, and redis-cli waits indefinitely for a reply
+    /// that a frozen (`SIGSTOP`ped) or otherwise wedged server will never
+    /// send: the kernel completes the handshake from the accept queue, so the
+    /// connection succeeds and then nothing happens. Without a deadline that
+    /// blocks the dropping thread forever, which in a test binary means the
+    /// process never exits and the run hangs until CI kills the job.
+    ///
+    /// On expiry the child is killed and reaped, so no zombie is left behind.
+    /// Whether the command took effect is deliberately not reported: callers
+    /// of a fire-and-forget path are not waiting on the answer, and every one
+    /// of them escalates afterwards anyway.
+    pub fn fire_and_forget_bounded(&self, args: &[&str], timeout: Duration) {
+        let Ok(mut child) = Command::new(&self.bin)
             .args(self.base_args())
             .args(args)
             .envs(self.auth_env())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
-            .status();
+            .spawn()
+        else {
+            return;
+        };
+
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            match child.try_wait() {
+                // Exited on its own, cleanly or not.
+                Ok(Some(_)) | Err(_) => return,
+                Ok(None) => {}
+            }
+            if std::time::Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
     }
 
     /// Send PING and return true if PONG is received.

--- a/src/process.rs
+++ b/src/process.rs
@@ -39,10 +39,13 @@ pub fn pid_alive(pid: u32) -> bool {
 ///
 /// Strategy:
 /// 1. Send SIGTERM to give the process a chance to shut down cleanly.
-/// 2. Sleep 500ms.
-/// 3. If still alive, SIGKILL the process group (`kill -9 -$pid`) to catch wrapper
+/// 2. Send SIGCONT so a process suspended by `SIGSTOP` (e.g. a frozen node in
+///    a chaos test) actually receives that SIGTERM instead of leaving it
+///    queued until something else resumes the process.
+/// 3. Sleep 500ms.
+/// 4. If still alive, SIGKILL the process group (`kill -9 -$pid`) to catch wrapper
 ///    scripts and any children they spawned (e.g. `redis-stack-server`).
-/// 4. SIGKILL the individual PID as a fallback.
+/// 5. SIGKILL the individual PID as a fallback.
 ///
 /// Uses synchronous [`std::process::Command`] so this is safe to call from [`Drop`] impls.
 ///
@@ -60,10 +63,17 @@ pub fn force_kill(pid: u32) {
     // Step 1: SIGTERM -- graceful shutdown attempt.
     let _ = Command::new("kill").args([&pid_str]).output();
 
-    // Step 2: Grace period.
+    // Step 2: SIGCONT -- a stopped process (SIGSTOP, e.g. via chaos::freeze_node)
+    // does not act on SIGTERM until it resumes. Without this, a frozen process
+    // sits on the queued SIGTERM through the whole grace period below and this
+    // function relies entirely on SIGKILL's stop-independent delivery to make
+    // any progress at all. Waking it here lets the SIGTERM actually run first.
+    let _ = Command::new("kill").args(["-CONT", &pid_str]).output();
+
+    // Step 3: Grace period.
     thread::sleep(Duration::from_millis(500));
 
-    // Step 3: If still alive, escalate to SIGKILL on process group.
+    // Step 4: If still alive, escalate to SIGKILL on process group.
     if pid_alive(pid) {
         // Kill the whole process group to catch wrapper script children.
         let _ = Command::new("kill").args(["-9", &pgid_str]).output();

--- a/src/server.rs
+++ b/src/server.rs
@@ -2225,6 +2225,7 @@ impl RedisServer {
                 cli,
                 pid,
                 detached: false,
+                stopped: std::sync::atomic::AtomicBool::new(false),
             })
         }
         .instrument(span)
@@ -3097,6 +3098,12 @@ pub struct RedisServerHandle {
     cli: RedisCli,
     pid: u32,
     detached: bool,
+    /// Whether this handle has already stopped its process.
+    ///
+    /// Interior mutability because `stop` takes `&self` and `Drop` has to see
+    /// the result. Without it a handle stopped explicitly stops again on
+    /// drop, and by then the port may belong to something else.
+    stopped: std::sync::atomic::AtomicBool,
 }
 
 impl RedisServerHandle {
@@ -3321,6 +3328,17 @@ impl RedisServerHandle {
     /// guard rather than `.instrument()` -- there is no `.await` in this
     /// function for a guard to be held across.
     pub fn stop(&self) {
+        use std::sync::atomic::Ordering;
+
+        // Stopping twice is not just wasted work. Between the first stop and
+        // the second, the port can be taken by an unrelated server, and every
+        // step below addresses the process by port or escalates past the
+        // recorded pid. The second stop would target the newcomer.
+        if self.stopped.swap(true, Ordering::SeqCst) {
+            tracing::debug!(port = self.config.port, "stop_already_done");
+            return;
+        }
+
         let span = tracing::debug_span!("server_stop", port = self.config.port);
         let _guard = span.entered();
 
@@ -3333,13 +3351,28 @@ impl RedisServerHandle {
             tracing::warn!(pid = self.pid, "force_kill_escalation");
             crate::process::force_kill(self.pid);
         }
-        // Step 4: port cleanup as safety net. Demoted to DEBUG rather than
-        // WARN: kill_by_port runs unconditionally on every clean stop() as a
-        // safety net and its return type doesn't distinguish "found and
-        // killed a leftover listener" from "port was already free", so a
-        // WARN here would fire on the common case too.
-        tracing::debug!(port = self.config.port, "port_cleanup");
-        crate::process::kill_by_port(self.config.port);
+
+        // Step 4: port cleanup, but only while something of ours might still
+        // hold the port.
+        //
+        // `kill_by_port` kills whatever is listening, which cannot be shown to
+        // be ours. It used to run on every stop, so a clean shutdown followed
+        // by an unrelated server binding the freed port would have killed the
+        // newcomer. It is only justified when the escalation above failed and
+        // the recorded process is still alive, which is the case it was added
+        // for: a wrapper script whose child holds the listener.
+        if crate::process::pid_alive(self.pid) {
+            tracing::debug!(port = self.config.port, "port_cleanup");
+            crate::process::kill_by_port(self.config.port);
+        }
+    }
+
+    /// Whether this handle has already stopped its process.
+    ///
+    /// A handle that was detached reports `false`: it never stopped anything
+    /// and never will.
+    pub fn is_stopped(&self) -> bool {
+        self.stopped.load(std::sync::atomic::Ordering::SeqCst)
     }
 
     /// Wait until the server is ready (PING -> PONG).
@@ -3955,6 +3988,7 @@ mod tests {
             pid: 0,
             // Never a real process; avoid Drop trying to stop it.
             detached: true,
+            stopped: std::sync::atomic::AtomicBool::new(false),
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -3346,22 +3346,35 @@ impl RedisServerHandle {
         self.cli.shutdown();
         // Step 2: grace period.
         std::thread::sleep(std::time::Duration::from_millis(500));
+
+        // Whether the graceful path worked decides everything below. A server
+        // that exited on request took its listener with it; one that did not
+        // may have left children holding the port.
+        let shutdown_failed = crate::process::pid_alive(self.pid);
+
         // Step 3: force kill if still alive.
-        if crate::process::pid_alive(self.pid) {
+        if shutdown_failed {
             tracing::warn!(pid = self.pid, "force_kill_escalation");
             crate::process::force_kill(self.pid);
         }
 
-        // Step 4: port cleanup, but only while something of ours might still
-        // hold the port.
+        // Step 4: port cleanup, but only after a shutdown that did not work.
         //
         // `kill_by_port` kills whatever is listening, which cannot be shown to
-        // be ours. It used to run on every stop, so a clean shutdown followed
-        // by an unrelated server binding the freed port would have killed the
-        // newcomer. It is only justified when the escalation above failed and
-        // the recorded process is still alive, which is the case it was added
-        // for: a wrapper script whose child holds the listener.
-        if crate::process::pid_alive(self.pid) {
+        // be ours. Running it on every stop meant a clean shutdown followed by
+        // an unrelated server binding the freed port would kill the newcomer,
+        // which is the bug this change exists to fix.
+        //
+        // It is still needed when the graceful path failed: that is the case
+        // it was added for, a wrapper script whose child holds the listener
+        // and outlives the pid we recorded. Skipping it there leaves a wedged
+        // process holding both the port and any inherited stdio, which in a
+        // test binary is a run that never ends.
+        //
+        // Deciding on the pre-escalation state rather than the post keeps the
+        // window tiny: the port cannot have been handed to anyone else in the
+        // moments since, because our own process was still holding it.
+        if shutdown_failed {
             tracing::debug!(port = self.config.port, "port_cleanup");
             crate::process::kill_by_port(self.config.port);
         }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -306,3 +306,78 @@ async fn start_failure_surfaces_log_tail_in_error() {
         "expected the log tail in the error message, got: {message}"
     );
 }
+
+// -- stop idempotence (#165) --
+
+#[tokio::test]
+async fn a_stopped_handle_does_not_kill_the_ports_next_occupant() {
+    // The reported bug. A handle stopped explicitly used to stop again on
+    // drop, and by then the port could belong to an unrelated server.
+    let first = RedisServer::new()
+        .auto_port()
+        .start()
+        .await
+        .expect("first server should start");
+    let port = first.port();
+    first.stop();
+    assert!(first.is_stopped());
+
+    let second = RedisServer::new()
+        .port(port)
+        .dir(std::env::temp_dir().join("rsw-stop-idempotence"))
+        .start()
+        .await
+        .expect("a second server should be able to take the freed port");
+    second
+        .run(&["SET", "survivor", "yes"])
+        .await
+        .expect("seed failed");
+
+    // The dangerous moment: this used to run the whole stop sequence again,
+    // addressed at a port the first handle no longer owned.
+    drop(first);
+
+    assert!(
+        second.is_alive().await,
+        "dropping a stopped handle killed the port's new occupant"
+    );
+    let value = second
+        .run(&["GET", "survivor"])
+        .await
+        .expect("the second server should still answer");
+    assert_eq!(value.trim(), "yes");
+}
+
+#[tokio::test]
+async fn stopping_twice_is_harmless() {
+    let server = RedisServer::new()
+        .auto_port()
+        .start()
+        .await
+        .expect("failed to start");
+    assert!(!server.is_stopped());
+
+    server.stop();
+    server.stop();
+    server.stop();
+
+    assert!(server.is_stopped());
+    assert!(!server.is_alive().await);
+}
+
+#[tokio::test]
+async fn a_detached_handle_reports_that_it_stopped_nothing() {
+    let server = RedisServer::new()
+        .auto_port()
+        .start()
+        .await
+        .expect("failed to start");
+    let port = server.port();
+    assert!(!server.is_stopped());
+    server.detach();
+
+    // Still running, because detach suppressed the teardown.
+    let cli = redis_server_wrapper::RedisCli::new().port(port);
+    assert!(cli.ping().await);
+    cli.shutdown();
+}

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -381,3 +381,44 @@ async fn a_detached_handle_reports_that_it_stopped_nothing() {
     assert!(cli.ping().await);
     cli.shutdown();
 }
+
+#[tokio::test]
+async fn stopping_a_frozen_server_cannot_hang() {
+    // The failure that wedged CI. A SIGSTOPped server still completes the TCP
+    // handshake from the kernel's accept queue, so redis-cli connects and then
+    // waits for a reply that never comes. Reached from Drop, an unbounded wait
+    // there means the test binary never exits and the run hangs until the job
+    // is killed.
+    let server = RedisServer::new()
+        .auto_port()
+        .start()
+        .await
+        .expect("failed to start");
+    let port = server.port();
+
+    chaos::freeze_node(&server).expect("freeze failed");
+
+    // Bounded generously: the point is that this returns at all, not that it
+    // is quick. Unbounded, it never returns.
+    let stopped = tokio::time::timeout(
+        Duration::from_secs(30),
+        tokio::task::spawn_blocking(move || {
+            server.stop();
+            server
+        }),
+    )
+    .await;
+
+    let server = stopped
+        .expect("stopping a frozen server hung")
+        .expect("stop panicked");
+
+    assert!(server.is_stopped());
+    assert!(
+        !redis_server_wrapper::RedisCli::new()
+            .port(port)
+            .ping()
+            .await,
+        "the frozen server should be gone after stop"
+    );
+}


### PR DESCRIPTION
Closes #165.

## The bug

`stop` took `&self` and recorded nothing, so `Drop` ran the whole sequence
again on a handle already stopped explicitly. In between, the port can be taken
by an unrelated server, and every step of `stop` either addresses the process
by port or escalates past the recorded pid.

```rust
let first = RedisServer::new().auto_port().start().await?;
let port = first.port();
first.stop();

let second = RedisServer::new().port(port).start().await?;
drop(first);          // stopped `second`
```

Shipped in v0.5.0.

## The fix

**Record the stop.** A second call returns immediately, so `Drop` after an
explicit stop is a no-op. The `stop(); detach();` workaround the issue mentions
is no longer needed; requiring it was the surprising part.

**Stop calling `kill_by_port` unconditionally.** It kills whatever is
listening, which cannot be shown to be ours, and it ran on every clean
shutdown. It now runs only when the escalation above failed and the recorded
pid is still alive, which is the case it was added for: a wrapper script whose
child holds the listener.

Adds `is_stopped`.

## Testing

Three tests, the first being the report verbatim. It is a behavior test, not an
implementation one: removing the idempotence guard makes it fail with

```
dropping a stopped handle killed the port's new occupant
```

Full suite green, clippy `-D warnings`, fmt, docs clean.

## Note

This is the same ownership family as #145, #157, #160, and #164: a handle
acting on something it no longer owns. Worth considering whether the remaining
port-addressed paths deserve the same audit.