### PR TITLE
test: CI baseline probe (do not merge)

### DIFF
--- a/tests/server.rs
+++ b/tests/server.rs
@@ -306,3 +306,5 @@ async fn start_failure_surfaces_log_tail_in_error() {
         "expected the log tail in the error message, got: {message}"
     );
 }
+
+// CI baseline probe: does unmodified main hang today?


### PR DESCRIPTION
Throwaway probe. Unmodified `main` plus a comment, to find out whether CI hangs today independently of #168.

If this hangs the same way, the hang is not from #168's changes.

Delete once it reports.