### PR TITLE
ci: fix the apt-get hang and reshape the test job around the one that works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,8 +203,24 @@ jobs:
         timeout-minutes: 15
         run: |
           set -o pipefail
-          timeout --signal=TERM --kill-after=60 600 \
+          # timeout(1) is GNU coreutils and is not on the macOS image, so this
+          # has to degrade rather than assume it. The hang being bounded here
+          # has only ever happened on Linux, and the step-level cap above
+          # still applies on both platforms either way.
+          if command -v timeout >/dev/null 2>&1; then
+            bound="timeout"
+          elif command -v gtimeout >/dev/null 2>&1; then
+            bound="gtimeout"
+          else
+            bound=""
+            echo "no timeout(1) on this image, relying on the step-level cap"
+          fi
+          if [ -n "$bound" ]; then
+            "$bound" --signal=TERM --kill-after=60 600 \
+              cargo test --all-features --verbose 2>&1 | tee "$RUNNER_TEMP/test-output.log"
+          else
             cargo test --all-features --verbose 2>&1 | tee "$RUNNER_TEMP/test-output.log"
+          fi
           status=$?
           if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
             echo "::error::cargo test did not finish within 600s"
@@ -235,7 +251,7 @@ jobs:
           uptime
           df -h / "$RUNNER_TEMP" 2>/dev/null
           free -m 2>/dev/null
-          nproc
+          getconf _NPROCESSORS_ONLN 2>/dev/null
           exit 0
 
       - name: Build documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,23 @@ jobs:
         timeout-minutes: 15
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config libssl-dev
+          # The runner image already ships build-essential, pkg-config and
+          # libssl-dev. Calling apt-get unconditionally is what wedged this
+          # job for weeks: `apt-get update` hung for 14m34s against a failing
+          # azure.archive.ubuntu.com mirror, with no output and no timeout of
+          # its own. Only reach for apt when something is genuinely missing,
+          # and bound it when we do.
+          missing=""
+          command -v cc >/dev/null 2>&1 || missing="$missing build-essential"
+          command -v pkg-config >/dev/null 2>&1 || missing="$missing pkg-config"
+          [ -f /usr/include/openssl/ssl.h ] || missing="$missing libssl-dev"
+          if [ -n "$missing" ]; then
+            echo "installing:$missing"
+            sudo timeout 300 apt-get update
+            sudo timeout 300 apt-get install -y $missing
+          else
+            echo "build prerequisites already present, skipping apt-get"
+          fi
           # --max-time and --retry because a bare curl waits forever on a
           # stalled connection, and this step has been observed hanging.
           curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ env:
 jobs:
   test:
     name: Test Suite
+    # A backstop under the per-step timeouts below. Without one, a hung step
+    # runs to the six-hour default, and a job the runner kills that way
+    # uploads no log at all, which is what made three separate hangs in this
+    # workflow undiagnosable.
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
       # Report every cell. Cancelling the rest on the first failure hides
@@ -64,11 +69,16 @@ jobs:
 
       - name: Build Redis ${{ env.UBUNTU_REDIS_VERSION }} (Ubuntu)
         if: runner.os == 'Linux' && steps.redis-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 15
         run: |
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y build-essential pkg-config libssl-dev
-          curl -fsSL -o /tmp/redis.tar.gz \
+          # --max-time and --retry because a bare curl waits forever on a
+          # stalled connection, and this step has been observed hanging.
+          curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused \
+            --connect-timeout 30 --max-time 300 \
+            -o /tmp/redis.tar.gz \
             "https://download.redis.io/releases/redis-${UBUNTU_REDIS_VERSION}.tar.gz"
           mkdir -p /tmp/redis-src
           tar xzf /tmp/redis.tar.gz -C /tmp/redis-src --strip-components=1
@@ -110,6 +120,7 @@ jobs:
       # where module coverage is authoritative.
       - name: Build Redis test module
         continue-on-error: true
+        timeout-minutes: 10
         run: |
           set -euo pipefail
           version="$(redis-server --version | sed -n 's/.*v=\([0-9][0-9.]*\).*/\1/p')"
@@ -119,7 +130,9 @@ jobs:
             include="$HOME/redis-dist"
           else
             include="${RUNNER_TEMP}"
-            curl -fsSL -o "${include}/redismodule.h" \
+            curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused \
+              --connect-timeout 30 --max-time 120 \
+              -o "${include}/redismodule.h" \
               "https://raw.githubusercontent.com/redis/redis/${version}/src/redismodule.h"
           fi
           cc -fPIC -shared -I "${include}" \
@@ -158,8 +171,27 @@ jobs:
       - name: Build
         run: cargo build --verbose --all-targets
 
+      # A green run finishes this in a little over two minutes. The cap is
+      # deliberately many times that: it exists to convert a hang into a
+      # failure with a log, not to police how long the suite takes.
       - name: Run tests
+        timeout-minutes: 12
         run: cargo test --all-features --verbose
+
+      # Runs after a timed-out test step, which is the only way this workflow
+      # has produced any evidence about a hang. Orphaned redis-server
+      # processes here mean the suite hung in teardown rather than in a test.
+      - name: Diagnose a failed test run
+        if: failure()
+        run: |
+          set +e +o pipefail
+          echo "--- redis processes still running ---"
+          ps -eo pid,ppid,etime,stat,args | grep -E '[r]edis-(server|cli)' || echo "none"
+          echo "--- listening sockets ---"
+          { ss -lntp || netstat -an; } 2>/dev/null | head -40
+          echo "--- load average ---"
+          uptime
+          exit 0
 
       - name: Build documentation
         run: cargo doc --no-deps --all-features
@@ -167,6 +199,7 @@ jobs:
 
   security:
     name: Security Audit
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -187,6 +220,7 @@ jobs:
 
   msrv:
     name: Minimum Supported Rust Version
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -207,4 +241,5 @@ jobs:
           shared-key: "msrv"
 
       - name: Test MSRV compatibility
+        timeout-minutes: 12
         run: cargo test --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,8 +183,22 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
         if: matrix.rust == 'stable'
 
-      - name: Build
-        run: cargo build --verbose --all-targets
+      # Deliberately not `cargo build --all-targets` first. That builds the
+      # whole dependency graph with default features, and the test step then
+      # rebuilds it with --all-features, so the job carried two complete
+      # target directories. The compatibility workflow builds one feature set
+      # and passes; this job builds two and wedges its runner hard enough that
+      # neither timeout(1) nor the step cap nor an always() step runs again.
+      # A full disk would produce exactly that, since the agent cannot write
+      # its own logs either.
+      #
+      # Nothing is lost by dropping it: the test step builds what it needs,
+      # and clippy already type-checks every target on stable.
+      - name: Report disk and memory before the suite
+        run: |
+          df -h / "$RUNNER_TEMP" || true
+          free -m 2>/dev/null || true
+          du -sh target 2>/dev/null || true
 
       # A green run finishes this in a little over two minutes. The cap is
       # deliberately many times that: it exists to convert a hang into a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,15 +263,54 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # This one genuinely needs apt, since redis-server is not on the image.
-      # Bounded because apt has no timeout of its own and has been observed
-      # hanging indefinitely on a stalled mirror.
-      - name: Install Redis
-        timeout-minutes: 10
+      # Was `apt-get install redis-server`, which failed here on the same
+      # stalled azure.archive.ubuntu.com mirror that wedged the test job: the
+      # bound fired at 300s with the identical Ign/fallback/silence signature.
+      #
+      # Use the same pinned build the test job uses instead. That drops the
+      # last apt dependency in this workflow, and it corrects an
+      # inconsistency: the runner image ships Redis 7.0.15, which is below the
+      # floor the README declares, so the MSRV job was testing against a
+      # version the crate does not claim to support.
+      - name: Cache Redis ${{ env.UBUNTU_REDIS_VERSION }} build
+        id: redis-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/redis-dist
+          key: redis-${{ env.UBUNTU_REDIS_VERSION }}-${{ runner.os }}-v2
+
+      - name: Build Redis ${{ env.UBUNTU_REDIS_VERSION }}
+        if: steps.redis-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 15
         run: |
           set -euo pipefail
-          sudo timeout 300 apt-get update
-          sudo timeout 300 apt-get install -y redis-server
+          missing=""
+          command -v cc >/dev/null 2>&1 || missing="$missing build-essential"
+          command -v pkg-config >/dev/null 2>&1 || missing="$missing pkg-config"
+          [ -f /usr/include/openssl/ssl.h ] || missing="$missing libssl-dev"
+          if [ -n "$missing" ]; then
+            echo "installing:$missing"
+            sudo timeout 300 apt-get update
+            sudo timeout 300 apt-get install -y $missing
+          else
+            echo "build prerequisites already present, skipping apt-get"
+          fi
+          curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused \
+            --connect-timeout 30 --max-time 300 \
+            -o /tmp/redis.tar.gz \
+            "https://download.redis.io/releases/redis-${UBUNTU_REDIS_VERSION}.tar.gz"
+          mkdir -p /tmp/redis-src
+          tar xzf /tmp/redis.tar.gz -C /tmp/redis-src --strip-components=1
+          make -C /tmp/redis-src -j"$(nproc)" BUILD_TLS=yes
+          mkdir -p ~/redis-dist
+          cp /tmp/redis-src/src/redis-server /tmp/redis-src/src/redis-cli ~/redis-dist/
+          cp /tmp/redis-src/src/redismodule.h ~/redis-dist/
+
+      - name: Put Redis on PATH
+        run: |
+          set -euo pipefail
+          chmod +x ~/redis-dist/redis-server ~/redis-dist/redis-cli
+          echo "$HOME/redis-dist" >> "$GITHUB_PATH"
 
       - name: Install Rust MSRV
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,50 @@ env:
   UBUNTU_REDIS_VERSION: "7.2.14"
 
 jobs:
+  # Formatting, lints and docs. Split out of the test job so that job can be a
+  # straight mirror of the one in redis-compat.yml, which runs the same suite
+  # on the same image and does not have these steps. None of this needs a
+  # running Redis: clippy and rustdoc compile the test targets without
+  # executing them.
+  lint:
+    name: Lint
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "lint"
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Build documentation
+        run: cargo doc --no-deps --all-features
+
+  # Deliberately shaped like the `compat` job in redis-compat.yml, step for
+  # step. That job runs this same suite, with these same features, against a
+  # source build of the same Redis, on the same runner image, and passes in
+  # about two and a half minutes. This one wedged its runner so completely
+  # that neither a step timeout, nor timeout(1) in the step's own shell, nor a
+  # step guarded with always() ran again once the suite started, and no log
+  # was ever uploaded. The cause was never found; see #170. Matching the shape
+  # of the job that works is the way out that does not depend on knowing why.
+  #
+  # macOS keeps its own path: brew Redis, and a module header fetched over the
+  # network because there is no source tree to take one from.
   test:
     name: Test Suite
-    # A backstop under the per-step timeouts below. Without one, a hung step
-    # runs to the six-hour default, and a job the runner kills that way
-    # uploads no log at all, which is what made three separate hangs in this
-    # workflow undiagnosable.
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
@@ -51,21 +89,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Ubuntu pins the oldest supported line so the fast signal matches the
-      # floor the README declares. The runner image ships 7.0.15, which is
-      # below that floor, so `apt-get install redis-server` was gating every
-      # pull request on a version the crate does not claim to support.
-      #
-      # macOS is left on brew, which tracks the newest line. Between them
-      # every pull request sees both ends of the supported range; the lines in
-      # between are covered by the compatibility workflow.
+      # Same cache key as the 7.2.14 cell of the compatibility matrix, on
+      # purpose. That workflow's jobs finish and therefore save the cache;
+      # this one's did not, so it rebuilt Redis on every run and re-lost it.
+      # Sharing the key means this job restores what that one saved.
       - name: Cache Redis ${{ env.UBUNTU_REDIS_VERSION }} build
         if: runner.os == 'Linux'
         id: redis-cache
         uses: actions/cache@v4
         with:
           path: ~/redis-dist
-          key: ci-redis-${{ env.UBUNTU_REDIS_VERSION }}-${{ runner.os }}
+          key: redis-${{ env.UBUNTU_REDIS_VERSION }}-${{ runner.os }}-v2
 
       - name: Build Redis ${{ env.UBUNTU_REDIS_VERSION }} (Ubuntu)
         if: runner.os == 'Linux' && steps.redis-cache.outputs.cache-hit != 'true'
@@ -73,11 +107,10 @@ jobs:
         run: |
           set -euo pipefail
           # The runner image already ships build-essential, pkg-config and
-          # libssl-dev. Calling apt-get unconditionally is what wedged this
-          # job for weeks: `apt-get update` hung for 14m34s against a failing
-          # azure.archive.ubuntu.com mirror, with no output and no timeout of
-          # its own. Only reach for apt when something is genuinely missing,
-          # and bound it when we do.
+          # libssl-dev. Calling apt-get unconditionally hung this job for
+          # 14m34s against a failing azure.archive.ubuntu.com mirror, with no
+          # output and no timeout of its own. Only reach for apt when
+          # something is genuinely missing, and bound it when we do.
           missing=""
           command -v cc >/dev/null 2>&1 || missing="$missing build-essential"
           command -v pkg-config >/dev/null 2>&1 || missing="$missing pkg-config"
@@ -90,13 +123,15 @@ jobs:
             echo "build prerequisites already present, skipping apt-get"
           fi
           # --max-time and --retry because a bare curl waits forever on a
-          # stalled connection, and this step has been observed hanging.
+          # stalled connection.
           curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused \
             --connect-timeout 30 --max-time 300 \
             -o /tmp/redis.tar.gz \
             "https://download.redis.io/releases/redis-${UBUNTU_REDIS_VERSION}.tar.gz"
           mkdir -p /tmp/redis-src
           tar xzf /tmp/redis.tar.gz -C /tmp/redis-src --strip-components=1
+          # BUILD_TLS=yes so the TLS-gated tests exercise a real TLS build,
+          # matching the compatibility workflow.
           make -C /tmp/redis-src -j"$(nproc)" BUILD_TLS=yes
           mkdir -p ~/redis-dist
           cp /tmp/redis-src/src/redis-server /tmp/redis-src/src/redis-cli ~/redis-dist/
@@ -124,153 +159,81 @@ jobs:
             redis-server --version | grep -q "v=${UBUNTU_REDIS_VERSION}"
           fi
 
-      # tests/module_loading.rs skips itself unless REDIS_TEST_MODULE points at
-      # a compiled module. Building the fixture needs redismodule.h, which the
-      # distro Redis packages do not ship, so fetch the one matching the
-      # version actually installed.
-      #
-      # Best effort: a fetch or compile failure leaves the variable unset and
-      # the module tests skip rather than failing the run. The compatibility
-      # workflow builds Redis from source and has the real header, which is
-      # where module coverage is authoritative.
-      - name: Build Redis test module
+      # On Linux this mirrors the compatibility workflow: build against the
+      # header from the very source tree that produced the redis-server under
+      # test, and treat a failure as fatal. A test that skips by returning
+      # early reports "ok", so a missing fixture would otherwise look like a
+      # pass.
+      - name: Build Redis test module (Ubuntu)
+        if: runner.os == 'Linux'
+        timeout-minutes: 10
+        run: |
+          set -euo pipefail
+          cc -fPIC -shared -I "$HOME/redis-dist" \
+            tests/support/rsw_test_module.c \
+            -o "${RUNNER_TEMP}/rsw_test_module.so"
+          echo "REDIS_TEST_MODULE=${RUNNER_TEMP}/rsw_test_module.so" >> "$GITHUB_ENV"
+
+      # macOS has no source tree to take a header from, so it fetches one
+      # matching the brew Redis. Best effort: a failure here leaves the
+      # variable unset and the module tests skip. Linux above is where module
+      # coverage is enforced.
+      - name: Build Redis test module (macOS)
+        if: runner.os == 'macOS'
         continue-on-error: true
         timeout-minutes: 10
         run: |
           set -euo pipefail
           version="$(redis-server --version | sed -n 's/.*v=\([0-9][0-9.]*\).*/\1/p')"
           echo "detected Redis $version"
-          if [ -f "$HOME/redis-dist/redismodule.h" ]; then
-            # Linux builds Redis from source, so the matching header is local.
-            include="$HOME/redis-dist"
-          else
-            include="${RUNNER_TEMP}"
-            curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused \
-              --connect-timeout 30 --max-time 120 \
-              -o "${include}/redismodule.h" \
-              "https://raw.githubusercontent.com/redis/redis/${version}/src/redismodule.h"
-          fi
-          cc -fPIC -shared -I "${include}" \
+          curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused \
+            --connect-timeout 30 --max-time 120 \
+            -o "${RUNNER_TEMP}/redismodule.h" \
+            "https://raw.githubusercontent.com/redis/redis/${version}/src/redismodule.h"
+          cc -fPIC -shared -I "${RUNNER_TEMP}" \
             tests/support/rsw_test_module.c \
             -o "${RUNNER_TEMP}/rsw_test_module.so"
           echo "REDIS_TEST_MODULE=${RUNNER_TEMP}/rsw_test_module.so" >> "$GITHUB_ENV"
           echo "module fixture built for Redis $version"
 
-      - name: Report module test coverage
-        run: |
-          if [ -n "${REDIS_TEST_MODULE:-}" ]; then
-            echo "module tests will run against ${REDIS_TEST_MODULE}"
-          else
-            echo "::warning::module fixture unavailable, module tests will skip"
-          fi
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.rust }}
+          shared-key: "test-suite"
 
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-        if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest'
-
-      - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
-        if: matrix.rust == 'stable'
-
-      # Deliberately not `cargo build --all-targets` first. That builds the
-      # whole dependency graph with default features, and the test step then
-      # rebuilds it with --all-features, so the job carried two complete
-      # target directories. The compatibility workflow builds one feature set
-      # and passes; this job builds two and wedges its runner hard enough that
-      # neither timeout(1) nor the step cap nor an always() step runs again.
-      # A full disk would produce exactly that, since the agent cannot write
-      # its own logs either.
-      #
-      # Nothing is lost by dropping it: the test step builds what it needs,
-      # and clippy already type-checks every target on stable.
-      - name: Report disk and memory before the suite
-        run: |
-          df -h / "$RUNNER_TEMP" || true
-          free -m 2>/dev/null || true
-          du -sh target 2>/dev/null || true
-
-      # A green run finishes this in a little over two minutes. The cap is
-      # deliberately many times that: it exists to convert a hang into a
-      # failure with a log, not to police how long the suite takes.
-      # Bounded twice, deliberately. The step-level timeout above is enforced
-      # by the runner agent, and on the job that hangs here the agent did not
-      # enforce it: the step ran 17 minutes past a 12 minute cap and the job
-      # died with no log, while a sibling job's 15 minute cap on a different
-      # step fired on schedule. timeout(1) is enforced by this shell instead,
-      # so the bound holds as long as bash is alive even if the agent is not.
-      #
-      # Output is teed so the tail survives for the post-mortem step below.
-      # libtest prints a line per test as it finishes, so whatever is missing
-      # from that list is where the suite stopped.
       - name: Run tests
         timeout-minutes: 15
         run: |
-          set -o pipefail
-          # timeout(1) is GNU coreutils and is not on the macOS image, so this
-          # has to degrade rather than assume it. The hang being bounded here
-          # has only ever happened on Linux, and the step-level cap above
-          # still applies on both platforms either way.
-          if command -v timeout >/dev/null 2>&1; then
-            bound="timeout"
-          elif command -v gtimeout >/dev/null 2>&1; then
-            bound="gtimeout"
-          else
-            bound=""
-            echo "no timeout(1) on this image, relying on the step-level cap"
+          set -euo pipefail
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            # Enforced on Linux only, where the fixture is built from the
+            # matching source tree and a failure to produce it is a real
+            # break rather than a missing header.
+            test -n "${REDIS_TEST_MODULE:-}"
+            test -f "${REDIS_TEST_MODULE}"
           fi
-          if [ -n "$bound" ]; then
-            "$bound" --signal=TERM --kill-after=60 600 \
-              cargo test --all-features --verbose 2>&1 | tee "$RUNNER_TEMP/test-output.log"
-          else
-            cargo test --all-features --verbose 2>&1 | tee "$RUNNER_TEMP/test-output.log"
-          fi
-          status=$?
-          if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
-            echo "::error::cargo test did not finish within 600s"
-          fi
-          exit "$status"
+          cargo test --all-features --verbose
 
-      # Runs after a timed-out test step, which is the only way this workflow
-      # has produced any evidence about a hang. Orphaned redis-server
-      # processes here mean the suite hung in teardown rather than in a test.
-      # always() rather than failure() so this also runs when the job is
-      # cancelled by its own timeout, which is how the test hang has ended
-      # every time so far. It reports nothing only if the runner itself is
-      # gone, which is itself the answer.
-      - name: Diagnose the test run
-        if: always()
+      # Cheap, and the one time this workflow produced any evidence about a
+      # hang it came from a step that failed rather than a job that was
+      # cancelled. Orphaned redis-server processes here would mean the suite
+      # stopped in teardown rather than in a test.
+      - name: Diagnose a failed test run
+        if: failure()
         run: |
           set +e +o pipefail
-          echo "--- how far the suite got ---"
-          tail -40 "$RUNNER_TEMP/test-output.log" 2>/dev/null || echo "no test output captured"
-          echo "--- tests that never reported ---"
-          grep -cE '^test .* \.\.\. ok$' "$RUNNER_TEMP/test-output.log" 2>/dev/null \
-            || echo "0 completions recorded"
           echo "--- redis processes still running ---"
           ps -eo pid,ppid,pgid,etime,stat,args | grep -E '[r]edis-(server|cli)' || echo "none"
-          echo "--- listening sockets ---"
-          { ss -lntp || netstat -an; } 2>/dev/null | head -40
           echo "--- resources ---"
           uptime
           df -h / "$RUNNER_TEMP" 2>/dev/null
           free -m 2>/dev/null
-          getconf _NPROCESSORS_ONLN 2>/dev/null
           exit 0
-
-      - name: Build documentation
-        run: cargo doc --no-deps --all-features
-        if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest'
 
   security:
     name: Security Audit
@@ -300,10 +263,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # This one genuinely needs apt, since redis-server is not on the image.
+      # Bounded because apt has no timeout of its own and has been observed
+      # hanging indefinitely on a stalled mirror.
       - name: Install Redis
+        timeout-minutes: 10
         run: |
-          sudo apt-get update
-          sudo apt-get install -y redis-server
+          set -euo pipefail
+          sudo timeout 300 apt-get update
+          sudo timeout 300 apt-get install -y redis-server
 
       - name: Install Rust MSRV
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,23 +189,53 @@ jobs:
       # A green run finishes this in a little over two minutes. The cap is
       # deliberately many times that: it exists to convert a hang into a
       # failure with a log, not to police how long the suite takes.
+      # Bounded twice, deliberately. The step-level timeout above is enforced
+      # by the runner agent, and on the job that hangs here the agent did not
+      # enforce it: the step ran 17 minutes past a 12 minute cap and the job
+      # died with no log, while a sibling job's 15 minute cap on a different
+      # step fired on schedule. timeout(1) is enforced by this shell instead,
+      # so the bound holds as long as bash is alive even if the agent is not.
+      #
+      # Output is teed so the tail survives for the post-mortem step below.
+      # libtest prints a line per test as it finishes, so whatever is missing
+      # from that list is where the suite stopped.
       - name: Run tests
-        timeout-minutes: 12
-        run: cargo test --all-features --verbose
+        timeout-minutes: 15
+        run: |
+          set -o pipefail
+          timeout --signal=TERM --kill-after=60 600 \
+            cargo test --all-features --verbose 2>&1 | tee "$RUNNER_TEMP/test-output.log"
+          status=$?
+          if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
+            echo "::error::cargo test did not finish within 600s"
+          fi
+          exit "$status"
 
       # Runs after a timed-out test step, which is the only way this workflow
       # has produced any evidence about a hang. Orphaned redis-server
       # processes here mean the suite hung in teardown rather than in a test.
-      - name: Diagnose a failed test run
-        if: failure()
+      # always() rather than failure() so this also runs when the job is
+      # cancelled by its own timeout, which is how the test hang has ended
+      # every time so far. It reports nothing only if the runner itself is
+      # gone, which is itself the answer.
+      - name: Diagnose the test run
+        if: always()
         run: |
           set +e +o pipefail
+          echo "--- how far the suite got ---"
+          tail -40 "$RUNNER_TEMP/test-output.log" 2>/dev/null || echo "no test output captured"
+          echo "--- tests that never reported ---"
+          grep -cE '^test .* \.\.\. ok$' "$RUNNER_TEMP/test-output.log" 2>/dev/null \
+            || echo "0 completions recorded"
           echo "--- redis processes still running ---"
-          ps -eo pid,ppid,etime,stat,args | grep -E '[r]edis-(server|cli)' || echo "none"
+          ps -eo pid,ppid,pgid,etime,stat,args | grep -E '[r]edis-(server|cli)' || echo "none"
           echo "--- listening sockets ---"
           { ss -lntp || netstat -an; } 2>/dev/null | head -40
-          echo "--- load average ---"
+          echo "--- resources ---"
           uptime
+          df -h / "$RUNNER_TEMP" 2>/dev/null
+          free -m 2>/dev/null
+          nproc
           exit 0
 
       - name: Build documentation

--- a/.github/workflows/redis-compat.yml
+++ b/.github/workflows/redis-compat.yml
@@ -74,8 +74,23 @@ jobs:
         timeout-minutes: 15
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config libssl-dev
+          # The runner image already ships build-essential, pkg-config and
+          # libssl-dev. Calling apt-get unconditionally is what wedged this
+          # job for weeks: `apt-get update` hung for 14m34s against a failing
+          # azure.archive.ubuntu.com mirror, with no output and no timeout of
+          # its own. Only reach for apt when something is genuinely missing,
+          # and bound it when we do.
+          missing=""
+          command -v cc >/dev/null 2>&1 || missing="$missing build-essential"
+          command -v pkg-config >/dev/null 2>&1 || missing="$missing pkg-config"
+          [ -f /usr/include/openssl/ssl.h ] || missing="$missing libssl-dev"
+          if [ -n "$missing" ]; then
+            echo "installing:$missing"
+            sudo timeout 300 apt-get update
+            sudo timeout 300 apt-get install -y $missing
+          else
+            echo "build prerequisites already present, skipping apt-get"
+          fi
           # Bounded: a bare curl waits forever on a stalled connection.
           curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused \
             --connect-timeout 30 --max-time 300 \

--- a/.github/workflows/redis-compat.yml
+++ b/.github/workflows/redis-compat.yml
@@ -41,6 +41,9 @@ env:
 jobs:
   compat:
     name: Redis ${{ matrix.redis }}
+    # Matches the backstop in ci.yml. A job the runner kills for exceeding the
+    # six-hour default uploads no log, so the timeout has to land first.
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       # Report every line's result. A break on 7.2 should not hide the state
@@ -68,11 +71,15 @@ jobs:
 
       - name: Build Redis ${{ matrix.redis }}
         if: steps.redis-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 15
         run: |
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y build-essential pkg-config libssl-dev
-          curl -fsSL -o /tmp/redis.tar.gz \
+          # Bounded: a bare curl waits forever on a stalled connection.
+          curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused \
+            --connect-timeout 30 --max-time 300 \
+            -o /tmp/redis.tar.gz \
             "https://download.redis.io/releases/redis-${{ matrix.redis }}.tar.gz"
           mkdir -p /tmp/redis-src
           tar xzf /tmp/redis.tar.gz -C /tmp/redis-src --strip-components=1
@@ -124,6 +131,7 @@ jobs:
           shared-key: "redis-compat"
 
       - name: Run test suite against Redis ${{ matrix.redis }}
+        timeout-minutes: 12
         run: |
           set -euo pipefail
           # A test that skips by returning early reports "ok", so an unset


### PR DESCRIPTION
Addresses #170. CI is green again: run [32302511413](https://github.com/joshrotenberg/redis-server-wrapper/actions/runs/32302511413) passes all six jobs, the first all-green run since 2026-08-06.

This fixes one confirmed cause and mitigates a second that is still unexplained. It does not claim to fix the second.

## 1. `apt-get update` hanging. Confirmed and fixed.

The first step-level timeout produced the only usable log of the whole investigation:

```
16:44:48  Ign:2  http://azure.archive.ubuntu.com/ubuntu noble InRelease
16:44:49  Get:5  https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
16:59:23  ##[error]The action 'Build Redis 7.2.14 (Ubuntu)' has timed out after 15 minutes.
```

14m34s of silence. apt fails over from the Azure mirror, falls back to `archive.ubuntu.com`, and wedges. It has no timeout of its own.

The MSRV job then reproduced it independently, failing at exactly 300s with exit 124 and the same Ign/fallback/silence pattern, once its apt call was bounded.

This also explains why it persisted: `ci.yml`'s Redis cache never saved, because the job was always killed first, so it rebuilt Redis and called apt on every single run and re-lost the cache each time.

**Fix:** `build-essential`, `pkg-config` and `libssl-dev` already ship on the runner image, so check for `cc`, `pkg-config` and `openssl/ssl.h` and only reach for apt if something is genuinely missing, bounded with `timeout(1)`. The MSRV job stops using `apt-get install redis-server` and takes the same pinned 7.2.14 build, which also corrects a pre-existing inconsistency: the image ships 7.0.15, below the floor the README declares.

## 2. The `Run tests` wedge. Mitigated, not explained.

The runner stops executing entirely. A step timeout does not fire, `timeout(1)` in the step's own shell does not fire, an `always()` step does not run, and no log is uploaded. Only GitHub's service-side job timeout ends it.

It is intermittent: in one run stable passed and 1.88.0 wedged; in the next, 1.88.0 passed with no change to the job.

**Mitigation:** shape the test job like the `compat` job in `redis-compat.yml`, which runs the same 297 tests with the same features against the same Redis on the same image and has never wedged.

- lint moves to its own job. clippy and rustdoc compile the test targets without running them, so they need no Redis, and compat has no such steps
- the Redis cache uses the same key as the compatibility matrix's 7.2.14 cell, so this job restores a binary that workflow already built instead of rebuilding on every run
- the module fixture is built on Linux from the header in the source tree that produced the `redis-server` under test, and a failure is fatal rather than a silent skip, matching compat. macOS keeps the best-effort network fetch, having no source tree
- the test step is plain `cargo test` again

## Timeouts

Step and job timeouts stay. They produced the single usable log in this investigation and turned the MSRV apt hang from a silent wedge into a five minute failure. The `timeout(1)` wrapper is gone: it never fired on the job it was meant to bound, and it broke the macOS job, which does not ship coreutils.

## What is not claimed

The wedge is not root-caused. A green run is not proof it is gone, and it may recur. #170 stays open with the full evidence, including the five hypotheses tested and rejected.