### PR TITLE
feat: add collision-aware automatic port allocation for cluster fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ just `redis-server` and `redis-cli` on PATH.
 - **Arbitrary config** -- pass any Redis directive via `.extra(key, value)`
 - **Fault injection** -- process-level chaos (freeze, kill, partition) via the `chaos` module,
   and byte-level TCP fault injection (delay, drop, chunking) via `FaultProxy`
-- **Parallel fixtures** -- `.auto_port()` picks a free port and retries a lost race
+- **Parallel fixtures** -- `.auto_port()` picks a free port, or a whole cluster range, and retries a lost race
 - **Module verification** -- assert a module actually loaded, not just that it was configured
 - **Safe by default** -- never stops a Redis process it did not start; reclaims only its own
 - **Tracing** -- spans and events across every lifecycle path, visible via `RUST_LOG`
@@ -178,6 +178,32 @@ rather than failing, and never stops whatever won the race.
 
 `port(0)` is unrelated: it keeps its Redis meaning of disabling the plaintext
 listener for a TLS-only server.
+
+Clusters take the same option:
+
+```rust
+use redis_server_wrapper::RedisCluster;
+
+async fn test_cluster_auto_port() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .auto_port()
+        .start()
+        .await
+        .unwrap();
+
+    // The chosen range starts here; nodes run on the ports above it.
+    println!("cluster range starts at {}", cluster.base_port());
+}
+```
+
+A cluster cannot use the same trick a single server does. It needs a run of
+consecutive client ports plus the bus port each one derives at client port +
+10000, and the OS will not hand out a contiguous range. So the range is chosen
+and probed instead, and the whole range is one decision: a cluster that can get
+only some of its ports is not started at all. Ranges are drawn from a window
+that keeps both the client ports and the bus ports out of the range the OS uses
+for outbound connections.
 
 ### Verifying Loaded Modules
 

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -50,6 +50,16 @@ impl NodeContext {
     }
 }
 
+/// How many port ranges [`RedisClusterBuilder::auto_port`] will try before
+/// giving up.
+///
+/// A range is only lost when another process claims one of its ports in the
+/// window between the probe and the bind, and candidates are drawn at random
+/// from a window the OS does not allocate from, so needing a second attempt
+/// is already unusual. The budget bounds a pathological machine rather than
+/// being reached in normal use.
+pub const MAX_RANGE_ATTEMPTS: usize = 8;
+
 /// Builder for a Redis Cluster.
 ///
 /// # Example
@@ -74,6 +84,7 @@ pub struct RedisClusterBuilder {
     masters: u16,
     replicas_per_master: u16,
     base_port: u16,
+    auto_port: bool,
     bind: String,
     password: Option<String>,
     logfile: Option<String>,
@@ -171,6 +182,39 @@ impl RedisClusterBuilder {
     /// Nodes are assigned consecutive ports starting at this value.
     pub fn base_port(mut self, port: u16) -> Self {
         self.base_port = port;
+        self
+    }
+
+    /// Let the wrapper pick the whole port range, for cluster fixtures that
+    /// run in parallel and cannot coordinate a fixed range between them.
+    ///
+    /// Read the chosen ports back from [`RedisClusterHandle::base_port`] or
+    /// from the node handles once started.
+    ///
+    /// A cluster cannot use the bind-to-port-zero trick that works for a
+    /// standalone server. It needs a run of consecutive client ports plus the
+    /// bus port each one derives, and the OS will not hand out a contiguous
+    /// range. So the range is chosen and probed rather than requested, and the
+    /// whole range is one decision: a cluster that can only get some of its
+    /// ports is not started at all.
+    ///
+    /// Ranges are drawn at random from a window that keeps both the client
+    /// ports and the bus ports clear of the pool the OS uses for outbound
+    /// connections, so the allocator is not competing with every connection
+    /// the machine makes.
+    ///
+    /// # Races
+    ///
+    /// Probing a range and having `redis-server` bind it are separate steps,
+    /// so another process can take a port in between. A lost range is
+    /// abandoned and a different one tried, up to [`MAX_RANGE_ATTEMPTS`]
+    /// times, after which [`Error::PortAllocation`] is returned.
+    ///
+    /// A lost race never disturbs the winner. Nothing here stops a process
+    /// holding a port the wrapper wanted, and the nodes of an abandoned
+    /// attempt stop themselves.
+    pub fn auto_port(mut self) -> Self {
+        self.auto_port = true;
         self
     }
 
@@ -710,6 +754,24 @@ impl RedisClusterBuilder {
             ));
         }
 
+        // Everything past here is about where the range sits, which in
+        // automatic mode is not decided yet. Check instead that a range this
+        // size can be placed at all, so an impossible topology is named as one
+        // rather than surfacing later as an exhausted attempt budget.
+        if self.auto_port {
+            if crate::preflight::candidate_base_ports(total as u16, 1)
+                .next()
+                .is_none()
+            {
+                return invalid(format!(
+                    "{total} nodes is more than automatic port allocation can place: \
+                     the client range and the bus range 10000 above it must both fit \
+                     below the ports the OS hands out. Use base_port to choose a range."
+                ));
+            }
+            return Ok(());
+        }
+
         // Every node needs a client port and a bus port, and neither range may
         // run off the end of the port space.
         let highest_client = (self.base_port as u32) + total - 1;
@@ -855,20 +917,151 @@ impl RedisClusterBuilder {
             .await
     }
 
-    async fn start_inner(mut self, total_nodes: u16) -> Result<RedisClusterHandle> {
-        let start_time = std::time::Instant::now();
-        self.validate_topology()?;
+    /// Pick a free client and bus range, then start the nodes on it.
+    ///
+    /// Retries on a different range when a port is lost between the probe and
+    /// the bind. Only that case retries: any other failure is a property of
+    /// the configuration rather than of the range, and would fail the same way
+    /// on different numbers.
+    async fn start_on_an_automatic_range(
+        &mut self,
+        total_nodes: u16,
+    ) -> Result<(PathBuf, Vec<RedisServerHandle>)> {
+        // An explicit `cluster-port` replaces the derived bus port, so there
+        // is no bus range to keep clear.
+        let check_bus = self.cluster_port.is_none();
+        let mut last: Option<Error> = None;
 
-        let cluster_base = self.base_dir();
+        for base in crate::preflight::candidate_base_ports(total_nodes, MAX_RANGE_ATTEMPTS) {
+            self.base_port = base;
 
-        // Reclaim before the preflight, not after: a leftover node of our own
-        // still holds its port, so the preflight would reject the topology on
-        // the strength of a process we are entitled to stop.
-        self.reclaim_owned_nodes(&cluster_base);
+            if !crate::preflight::port_range_available(&self.bind, base, total_nodes, check_bus) {
+                tracing::debug!(base_port = base, "cluster_auto_port_range_busy");
+                last = Some(Error::PortInUse {
+                    host: self.bind.clone(),
+                    port: base,
+                    role: crate::preflight::PortRole::ClusterNode.to_string(),
+                });
+                continue;
+            }
 
-        self.ensure_ports_free()?;
+            // Give every attempt its own directory.
+            //
+            // The node directories are derived from the ports, so two
+            // processes that draw the same range would otherwise share them,
+            // and with them the pidfiles. Both would then see the pidfile the
+            // winner wrote and both would report success, leaving two handles
+            // believing they own one set of servers. The loser's teardown
+            // would stop the winner's cluster.
+            let cluster_base = self.automatic_base_dir();
 
-        // Start each node.
+            match self.start_nodes(total_nodes, &cluster_base).await {
+                Ok(nodes) => {
+                    match Self::verify_nodes_are_ours(&self.bind, nodes, &cluster_base).await {
+                        Ok(nodes) => return Ok((cluster_base, nodes)),
+                        Err(e) => {
+                            tracing::debug!(base_port = base, "cluster_auto_port_lost_race");
+                            last = Some(e);
+                        }
+                    }
+                }
+                // Someone took one of the ports between the probe and the
+                // bind. Their processes are left alone; take a different
+                // range. The nodes this attempt did start stop themselves as
+                // the handles drop.
+                Err(e @ (Error::PortInUse { .. } | Error::ServerStart { .. })) => {
+                    tracing::debug!(base_port = base, "cluster_auto_port_retry");
+                    last = Some(e);
+                }
+                Err(other) => return Err(other),
+            }
+        }
+
+        Err(Error::PortAllocation {
+            attempts: MAX_RANGE_ATTEMPTS,
+            last: last.map(|e| e.to_string()),
+        })
+    }
+
+    /// A directory unique to this process and this attempt.
+    fn automatic_base_dir(&self) -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        /// Distinguishes concurrent automatic-range attempts within a process.
+        static ATTEMPT: AtomicU64 = AtomicU64::new(0);
+
+        self.base_dir().join(format!(
+            "auto-{}-{}",
+            std::process::id(),
+            ATTEMPT.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    /// Confirm every node is the one this attempt started.
+    ///
+    /// A successful start is not proof the server on a port is ours. The
+    /// daemonizing parent exits 0 whether or not the child binds, and the
+    /// readiness probe connects to whatever is listening, so a node that lost
+    /// its port can still look started. Ask each server which directory it is
+    /// running from, which is unique to this attempt.
+    ///
+    /// A node that answers with someone else's directory is detached rather
+    /// than stopped: it is not ours to stop. The rest stop themselves when the
+    /// returned error drops the handles.
+    ///
+    /// Takes `bind` rather than `&self` deliberately. Holding a shared
+    /// reference to the builder across an await would make the whole start
+    /// future non-`Send`, because `&T` is only `Send` when `T` is `Sync` and
+    /// the per-node config hook is a `dyn FnMut`. Callers spawn cluster
+    /// startups onto a runtime, so that matters.
+    async fn verify_nodes_are_ours(
+        bind: &str,
+        nodes: Vec<RedisServerHandle>,
+        cluster_base: &std::path::Path,
+    ) -> Result<Vec<RedisServerHandle>> {
+        let mut ours = Vec::with_capacity(nodes.len());
+        let mut foreign: Option<u16> = None;
+
+        for node in nodes {
+            let expected = cluster_base
+                .join(format!("node-{}", node.port()))
+                .display()
+                .to_string();
+            let is_ours = matches!(
+                node.run(&["CONFIG", "GET", "dir"]).await,
+                Ok(reply) if reply.contains(&expected)
+            );
+            if is_ours {
+                ours.push(node);
+            } else {
+                // Not ours, so not ours to stop. Detaching consumes the
+                // handle, which is what keeps it out of the teardown below.
+                foreign.get_or_insert(node.port());
+                node.detach();
+            }
+        }
+
+        match foreign {
+            None => Ok(ours),
+            // Dropping `ours` here stops the nodes this attempt really did
+            // start, which is correct: the attempt is being abandoned.
+            Some(port) => Err(Error::PortInUse {
+                host: bind.to_string(),
+                port,
+                role: crate::preflight::PortRole::ClusterNode.to_string(),
+            }),
+        }
+    }
+
+    /// Start every node of the topology, leaving them unclustered.
+    ///
+    /// Failing part way through drops the handles started so far, and each
+    /// one stops its own server, so a caller may retry on a different range
+    /// without leaking the nodes of the abandoned attempt.
+    async fn start_nodes(
+        &mut self,
+        total_nodes: u16,
+        cluster_base: &std::path::Path,
+    ) -> Result<Vec<RedisServerHandle>> {
         let ports: Vec<u16> = self.ports().collect();
         let mut nodes = Vec::new();
         for (index, port) in ports.into_iter().enumerate() {
@@ -1079,6 +1272,29 @@ impl RedisClusterBuilder {
             let handle = server.start().await?;
             nodes.push(handle);
         }
+        Ok(nodes)
+    }
+
+    async fn start_inner(mut self, total_nodes: u16) -> Result<RedisClusterHandle> {
+        let start_time = std::time::Instant::now();
+        self.validate_topology()?;
+
+        let (cluster_base, nodes) = if self.auto_port {
+            self.start_on_an_automatic_range(total_nodes).await?
+        } else {
+            let cluster_base = self.base_dir();
+
+            // Reclaim before the preflight, not after: a leftover node of our
+            // own still holds its port, so the preflight would reject the
+            // topology on the strength of a process we are entitled to stop.
+            self.reclaim_owned_nodes(&cluster_base);
+
+            self.ensure_ports_free()?;
+
+            // Start each node.
+            let nodes = self.start_nodes(total_nodes, &cluster_base).await?;
+            (cluster_base, nodes)
+        };
         tracing::debug!(
             elapsed_ms = start_time.elapsed().as_millis() as u64,
             nodes = nodes.len(),
@@ -1199,6 +1415,7 @@ impl RedisCluster {
             masters: 3,
             replicas_per_master: 0,
             base_port: 7000,
+            auto_port: false,
             bind: "127.0.0.1".into(),
             password: None,
             logfile: None,
@@ -1272,6 +1489,16 @@ impl RedisClusterHandle {
     /// The seed address (first node).
     pub fn addr(&self) -> String {
         format!("{}:{}", self.bind, self.base_port)
+    }
+
+    /// The first client port of the cluster's range.
+    ///
+    /// The nodes run on `base_port .. base_port + node count`, and each
+    /// derives its bus port as its client port + 10000 unless `cluster_port`
+    /// overrode that. With [`RedisClusterBuilder::auto_port`] this is the
+    /// range the wrapper chose, which the caller has no other way to learn.
+    pub fn base_port(&self) -> u16 {
+        self.base_port
     }
 
     /// All node addresses.
@@ -1725,6 +1952,62 @@ mod tests {
                 "unexpected message: {err}"
             );
         }
+    }
+
+    #[test]
+    fn automatic_mode_ignores_a_base_port_it_will_not_use() {
+        // A base port that would be rejected outright in explicit mode says
+        // nothing about a topology whose range has not been chosen yet.
+        let b = cluster(3, 1, 65000).auto_port();
+        assert!(
+            b.validate_topology().is_ok(),
+            "automatic mode should not validate a base port it discards"
+        );
+    }
+
+    #[test]
+    fn automatic_mode_still_rejects_a_topology_it_cannot_place() {
+        // More nodes than the automatic window can hold. Better to name it as
+        // a topology error than to spend the attempt budget and report an
+        // allocation failure, which would read as a busy machine.
+        let b = RedisCluster::builder()
+            .masters(6000)
+            .replicas_per_master(1)
+            .auto_port();
+        let err = b
+            .validate_topology()
+            .expect_err("12000 nodes should not be placeable automatically");
+        match err {
+            Error::InvalidTopology { message } => {
+                assert!(
+                    message.contains("automatic port allocation"),
+                    "expected the message to name the mode, got: {message}"
+                );
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn automatic_mode_still_rejects_too_few_masters() {
+        // Automatic ports change where a cluster runs, not what a cluster is.
+        assert!(cluster(2, 0, 7000).auto_port().validate_topology().is_err());
+    }
+
+    #[test]
+    fn each_automatic_attempt_gets_its_own_directory() {
+        // Two attempts sharing a directory would share the node pidfiles, and
+        // both would then read the winner's pidfile and report success.
+        let b = cluster(3, 0, 7000).auto_port();
+        let first = b.automatic_base_dir();
+        let second = b.automatic_base_dir();
+        assert_ne!(first, second);
+        assert!(
+            first
+                .to_string_lossy()
+                .contains(&std::process::id().to_string()),
+            "the directory should be unique to this process too: {first:?}"
+        );
     }
 
     #[test]

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -136,6 +136,126 @@ pub fn bus_port(client_port: u16) -> Option<u16> {
     client_port.checked_add(10000)
 }
 
+/// The gap Redis leaves between a client port and its bus port.
+const BUS_OFFSET: u16 = 10000;
+
+/// The lowest base port an automatic cluster range is drawn from.
+///
+/// Above the well-known range, and clear of the ports a person is likely to
+/// have picked by hand: 6379 for a standalone server and the 7000 block that
+/// every cluster tutorial uses.
+const AUTO_BASE_MIN: u16 = 10000;
+
+/// One past the highest port an automatic cluster range may touch.
+///
+/// A cluster needs two ranges, the client ports and the bus ports 10000
+/// above them, and neither may sit in the pool the OS hands out for outbound
+/// connections. Drawing from that pool would put the allocator in a race with
+/// every connection the machine makes, which is the race automatic allocation
+/// exists to avoid.
+///
+/// Linux's default pool starts at 32768 and macOS's at 49152, so keeping the
+/// whole bus range below 32768 stays clear on either without asking the OS
+/// what its pool is.
+const AUTO_CEILING: u16 = 32768;
+
+/// Candidate base ports for a cluster of `count` nodes, in random order.
+///
+/// A cluster cannot use the bind-to-zero trick a standalone server uses: it
+/// needs `count` consecutive client ports and the matching bus ports, and the
+/// OS will not hand out a contiguous run. So the range is chosen rather than
+/// requested, and the caller probes it.
+///
+/// Random rather than sequential so two processes starting at the same moment
+/// do not walk the same candidates in the same order and collide on every
+/// one. Each candidate is a base port whose client range
+/// `[base, base + count)` and bus range `[base + 10000, base + 10000 + count)`
+/// both fit under [`AUTO_CEILING`].
+///
+/// Yields nothing when `count` is too large to place: either the two ranges
+/// no longer fit under [`AUTO_CEILING`], or the run is long enough to overlap
+/// its own bus range at any base. [`crate::cluster::RedisClusterBuilder`]
+/// rejects both as topology errors before ever asking.
+pub fn candidate_base_ports(count: u16, attempts: usize) -> impl Iterator<Item = u16> {
+    // A run longer than the bus offset overlaps its own bus range wherever it
+    // is placed: the client ports reach past `base + 10000`, which is where
+    // the bus ports start. No base fixes that, so yield nothing.
+    let placeable = count <= BUS_OFFSET;
+
+    // The highest base whose bus range still ends below the ceiling.
+    let highest = AUTO_CEILING
+        .checked_sub(BUS_OFFSET)
+        .and_then(|p| p.checked_sub(count));
+
+    let span = if placeable {
+        highest
+            .and_then(|h| h.checked_sub(AUTO_BASE_MIN))
+            .unwrap_or(0)
+    } else {
+        0
+    };
+
+    let mut seed = entropy();
+    (0..attempts).filter_map(move |_| {
+        if span == 0 {
+            return None;
+        }
+        // xorshift, so successive candidates are unrelated. The quality bar
+        // here is "does not repeat itself", not cryptographic.
+        seed ^= seed << 13;
+        seed ^= seed >> 7;
+        seed ^= seed << 17;
+        Some(AUTO_BASE_MIN + (seed % span as u64) as u16)
+    })
+}
+
+/// A seed that differs between processes and between calls.
+///
+/// `RandomState` is seeded by the OS once per process and then perturbed per
+/// instance, which is enough to keep two concurrently starting test binaries
+/// from drawing the same sequence. Avoids a dependency on `rand` for a
+/// non-cryptographic use.
+fn entropy() -> u64 {
+    use std::hash::{BuildHasher, Hasher};
+    let mut hasher = std::collections::hash_map::RandomState::new().build_hasher();
+    hasher.write_u32(std::process::id());
+    let seed = hasher.finish();
+    // A zero seed is a fixed point for xorshift and would yield one number
+    // forever.
+    if seed == 0 {
+        0x9e37_79b9_7f4a_7c15
+    } else {
+        seed
+    }
+}
+
+/// Whether every client port in `[base, base + count)` and its bus port is
+/// free on `host`.
+///
+/// The whole range is one allocation decision: a cluster that gets most of
+/// its ports is not partially started, it is rejected. Bus ports are skipped
+/// when `check_bus` is false, which is the case when `cluster-port` overrides
+/// the derived bus port.
+pub fn port_range_available(host: &str, base: u16, count: u16, check_bus: bool) -> bool {
+    for offset in 0..count {
+        let Some(port) = base.checked_add(offset) else {
+            return false;
+        };
+        if !port_available(host, port) {
+            return false;
+        }
+        if check_bus {
+            let Some(bus) = bus_port(port) else {
+                return false;
+            };
+            if !port_available(host, bus) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -215,6 +335,133 @@ mod tests {
                  the kernel still holds socket remnants"
             );
         }
+    }
+
+    #[test]
+    fn candidates_keep_both_ranges_clear_of_the_ephemeral_pool() {
+        // The property that makes automatic allocation worth anything: if the
+        // bus range reached into the pool the OS draws outbound connections
+        // from, the allocator would be racing every connection on the machine.
+        for count in [3u16, 6, 30, 300] {
+            let mut yielded = 0;
+            for base in candidate_base_ports(count, 64) {
+                yielded += 1;
+                assert!(base >= AUTO_BASE_MIN, "base {base} below the floor");
+                let highest_client = base + count - 1;
+                let highest_bus = bus_port(highest_client)
+                    .unwrap_or_else(|| panic!("base {base} has no bus port"));
+                assert!(
+                    highest_bus < AUTO_CEILING,
+                    "count {count} at base {base} puts bus port {highest_bus} \
+                     in the ephemeral pool"
+                );
+            }
+            assert_eq!(yielded, 64, "every attempt should yield a candidate");
+        }
+    }
+
+    #[test]
+    fn candidates_do_not_repeat_in_order() {
+        // Sequential candidates would make two processes starting together
+        // walk the same numbers in the same order and collide on every one.
+        let candidates: Vec<u16> = candidate_base_ports(6, 32).collect();
+        let unique: std::collections::HashSet<u16> = candidates.iter().copied().collect();
+        assert!(
+            unique.len() > candidates.len() / 2,
+            "candidates should be spread out, got {candidates:?}"
+        );
+        assert!(
+            candidates.windows(2).any(|w| w[1] != w[0] + 1),
+            "candidates should not be a sequential walk"
+        );
+    }
+
+    #[test]
+    fn a_run_that_would_overlap_its_own_bus_range_yields_no_candidates() {
+        // Past the bus offset the client ports reach into where the bus ports
+        // start, and moving the base does not help.
+        assert_eq!(candidate_base_ports(BUS_OFFSET + 1, 8).count(), 0);
+    }
+
+    #[test]
+    fn every_candidate_range_is_disjoint_from_its_bus_range() {
+        for count in [1u16, 3, 500, BUS_OFFSET] {
+            for base in candidate_base_ports(count, 16) {
+                let last_client = base + count - 1;
+                let first_bus = base + BUS_OFFSET;
+                assert!(
+                    last_client < first_bus,
+                    "count {count} at base {base}: client range reaches {last_client}, \
+                     bus range starts at {first_bus}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_cluster_too_large_to_place_yields_no_candidates() {
+        // Larger than the window between the floor and the ceiling. Better to
+        // yield nothing than to hand back a range that runs into the
+        // ephemeral pool.
+        let count = AUTO_CEILING - BUS_OFFSET - AUTO_BASE_MIN + 1;
+        assert_eq!(candidate_base_ports(count, 8).count(), 0);
+    }
+
+    #[test]
+    fn an_occupied_port_anywhere_in_the_range_rejects_the_whole_range() {
+        // One allocation decision, not a partial start: a cluster that can
+        // only get some of its ports has not got its ports.
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let occupied = listener.local_addr().unwrap().port();
+
+        // The occupied port sits in the middle of the requested range.
+        let base = occupied - 2;
+        assert!(
+            !port_range_available("127.0.0.1", base, 5, false),
+            "a live listener at {occupied} must reject the range from {base}"
+        );
+        drop(listener);
+    }
+
+    #[test]
+    fn an_occupied_bus_port_rejects_the_range_too() {
+        // The failure that a client-only check would miss. The client ports
+        // are all free; the bus port one of them derives is not.
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let occupied_bus = listener.local_addr().unwrap().port();
+
+        let Some(base) = occupied_bus.checked_sub(BUS_OFFSET) else {
+            // No client port derives this bus port, so there is nothing to
+            // assert. Ephemeral ports are well above the offset in practice.
+            drop(listener);
+            return;
+        };
+
+        assert!(
+            !port_range_available("127.0.0.1", base, 1, true),
+            "a live listener on bus port {occupied_bus} must reject base {base}"
+        );
+
+        // The same range is fine when bus ports are not derived, which is what
+        // an explicit cluster-port means. Conditional because `base` is
+        // wherever the OS put the listener minus 10000, and this makes no
+        // claim about what else on the machine might be sitting there.
+        if port_available("127.0.0.1", base) {
+            assert!(
+                port_range_available("127.0.0.1", base, 1, false),
+                "with bus ports out of the picture, the free client port \
+                 {base} should read as available"
+            );
+        }
+        drop(listener);
+    }
+
+    #[test]
+    fn a_free_range_reads_as_available() {
+        with_free_port(
+            |port| port_range_available("127.0.0.1", port, 1, false),
+            "a range of one free port must read as available",
+        );
     }
 
     #[test]

--- a/tests/auto_port.rs
+++ b/tests/auto_port.rs
@@ -6,7 +6,7 @@
 //! it, and the caller has no way to recover. `auto_port` keeps the same
 //! reservation trick but owns the retry.
 
-use redis_server_wrapper::RedisServer;
+use redis_server_wrapper::{RedisCluster, RedisServer};
 
 #[tokio::test]
 async fn auto_port_starts_on_a_usable_port() {
@@ -200,4 +200,162 @@ async fn config_get_dir_identifies_the_server_behind_a_port() {
         reply.contains(&node_dir),
         "CONFIG GET dir returned {reply:?}, which does not contain {node_dir}"
     );
+}
+
+// -- cluster ranges (#166) --
+
+/// The window automatic cluster ranges are drawn from, mirrored from
+/// `preflight` so a change to either side has to be deliberate.
+const AUTO_BASE_MIN: u16 = 10000;
+const AUTO_CEILING: u16 = 32768;
+
+#[tokio::test]
+async fn a_cluster_can_take_a_wrapper_chosen_range() {
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .auto_port()
+        .start()
+        .await
+        .expect("a cluster with an automatic range should start");
+
+    let base = cluster.base_port();
+    assert!(
+        base >= AUTO_BASE_MIN,
+        "base {base} is below the automatic window"
+    );
+
+    // Every node sits in the chosen range, and every bus port it derives fits
+    // under the ceiling. A range that satisfied the client ports but ran the
+    // bus ports into the OS pool would look fine until the gossip failed.
+    let ports: Vec<u16> = cluster.nodes().iter().map(|n| n.port()).collect();
+    assert_eq!(ports.len(), 3);
+    for port in &ports {
+        assert!(
+            *port >= base && *port < base + 3,
+            "node port {port} is outside the range starting at {base}"
+        );
+        let bus = port + 10000;
+        assert!(
+            bus < AUTO_CEILING,
+            "bus port {bus} derived from {port} reaches the ephemeral pool"
+        );
+    }
+
+    assert!(cluster.is_healthy().await, "the cluster should have formed");
+}
+
+#[tokio::test]
+async fn an_automatic_cluster_really_owns_its_bus_ports() {
+    // The half of the allocation a client-port-only check would miss. Redis
+    // only opens a bus port when the node is cluster-enabled and it bound
+    // successfully, so a listener there is proof the derived port was free and
+    // is now ours.
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .auto_port()
+        .start()
+        .await
+        .expect("cluster should start");
+
+    for node in cluster.nodes() {
+        let bus = node.port() + 10000;
+        assert!(
+            !redis_server_wrapper::preflight::port_available("127.0.0.1", bus),
+            "nothing is listening on bus port {bus} for node {}",
+            node.port()
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_clusters_get_non_overlapping_ranges() {
+    // The case #166 was filed for: parallel cluster fixtures with no agreed
+    // range between them. Overlapping ranges would not merely collide on a
+    // client port, they would cross the two clusters' gossip.
+    const FIXTURES: usize = 3;
+    const NODES: u16 = 3;
+
+    let mut tasks = Vec::with_capacity(FIXTURES);
+    for _ in 0..FIXTURES {
+        tasks.push(tokio::spawn(async {
+            RedisCluster::builder()
+                .masters(NODES)
+                .auto_port()
+                .start()
+                .await
+                .expect("cluster fixture should start")
+        }));
+    }
+
+    let mut clusters = Vec::with_capacity(FIXTURES);
+    for task in tasks {
+        clusters.push(task.await.expect("cluster fixture panicked"));
+    }
+
+    // No client port is shared, and no client range reaches into another's.
+    let mut all_ports: Vec<u16> = clusters
+        .iter()
+        .flat_map(|c| c.nodes().iter().map(|n| n.port()))
+        .collect();
+    let total = all_ports.len();
+    assert_eq!(total, FIXTURES * NODES as usize);
+    all_ports.sort_unstable();
+    all_ports.dedup();
+    assert_eq!(all_ports.len(), total, "two clusters shared a client port");
+
+    // Nor a bus port, which is the collision that would let one cluster's
+    // gossip reach another's.
+    let mut buses: Vec<u16> = all_ports.iter().map(|p| p + 10000).collect();
+    let bus_total = buses.len();
+    buses.sort_unstable();
+    buses.dedup();
+    assert_eq!(buses.len(), bus_total, "two clusters shared a bus port");
+
+    // Every one still formed and is still up: allocating a range never
+    // disturbed a cluster that already had one.
+    for cluster in &clusters {
+        assert!(
+            cluster.is_healthy().await,
+            "cluster at {} did not survive its neighbours",
+            cluster.base_port()
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_range_is_all_or_nothing() {
+    // A partial-range collision. Stand a plain listener in the middle of a
+    // range and confirm the allocator steps over the whole range rather than
+    // starting the nodes that would have fitted around it.
+    //
+    // The candidate is whatever the allocator picks, so this cannot force the
+    // collision onto a chosen range. What it does pin is that a range holding
+    // an occupied port is rejected outright, which is the property a cluster
+    // depends on: three nodes minus one is not a cluster.
+    let squatter = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind failed");
+    let held = squatter.local_addr().unwrap().port();
+
+    assert!(
+        !redis_server_wrapper::preflight::port_range_available("127.0.0.1", held - 1, 3, false),
+        "a range containing the occupied port {held} must be rejected whole"
+    );
+
+    // And the allocator still finds the cluster a home despite it.
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .auto_port()
+        .start()
+        .await
+        .expect("allocation should step over the occupied port");
+
+    for node in cluster.nodes() {
+        assert_ne!(
+            node.port(),
+            held,
+            "allocation handed out a port that was already taken"
+        );
+    }
+
+    // Untouched: the allocator abandons a contested range, it never clears it.
+    drop(squatter);
 }

--- a/tests/auto_port.rs
+++ b/tests/auto_port.rs
@@ -359,3 +359,21 @@ async fn a_range_is_all_or_nothing() {
     // Untouched: the allocator abandons a contested range, it never clears it.
     drop(squatter);
 }
+
+#[tokio::test]
+async fn an_automatic_range_works_with_a_password() {
+    // The ownership check asks each node CONFIG GET dir, so it has to be able
+    // to authenticate. If it could not, every node would answer with an error,
+    // read as someone else's server, and allocation would abandon every range
+    // it tried and fail with the attempt budget exhausted.
+    let cluster = RedisCluster::builder()
+        .masters(3)
+        .password("clusterpass")
+        .auto_port()
+        .start()
+        .await
+        .expect("an authenticated cluster should still get a range");
+
+    assert!(cluster.base_port() >= AUTO_BASE_MIN);
+    assert!(cluster.is_healthy().await);
+}


### PR DESCRIPTION
Closes #166.

## Problem

`RedisClusterBuilder` required a caller-chosen `base_port`, so parallel cluster fixtures had to coordinate a fixed range between them or collide. The bind-to-port-zero trick a standalone server uses does not transfer: a cluster needs a run of consecutive client ports **plus** the bus port each one derives at client port + 10000, and the OS will not hand out a contiguous range.

Surfaced in `redis-developer/redis-database-mcp-rs`, which is currently working around it by scanning a candidate range immediately before `start()` and accepting the TOCTOU window.

## Approach

The range is chosen and probed rather than requested.

**`preflight::candidate_base_ports(count, attempts)`** yields randomized base ports. The window is bounded so both the client range and the bus range 10000 above it stay clear of the pool the OS allocates outbound connections from. Linux's default pool starts at 32768 and macOS's at 49152, so keeping the whole bus range below 32768 stays clear on either without interrogating the OS. Drawing from that pool would put the allocator in a race with every connection the machine makes, which is the race automatic allocation exists to avoid.

Randomized rather than sequential so two processes starting at the same moment do not walk the same candidates in the same order and collide on every one.

**`preflight::port_range_available`** treats the range as a single decision. A cluster that can get only some of its ports is not partially started; it is rejected. Three nodes minus one is not a cluster.

**`RedisClusterBuilder::auto_port()`** probes a range, starts the nodes, then asks each one which directory it is running from. This is the #164 lesson: a successful start is not proof the server on a port is ours, because the daemonizing parent exits 0 whether or not the child binds and the readiness probe connects to whatever is listening. A node answering with a directory this attempt did not create is **detached, not stopped** - it is not ours to stop - and the attempt retries on a different range. Nodes the attempt really did start stop themselves as their handles drop.

Each attempt gets a directory keyed by pid and attempt number, so two processes drawing the same range cannot share node pidfiles and both conclude they own the cluster.

`base_port()` remains the explicit deterministic mode, unchanged.

## Also

`RedisClusterHandle::base_port()`, because with an automatic range the caller has no other way to learn what it got.

`validate_topology` skips the base-port checks in automatic mode, where the base is not chosen yet, and instead rejects a topology too large to place. A run longer than the 10000-port bus offset overlaps its own bus range at *any* base, so the allocator refuses to emit one.

`verify_nodes_are_ours` takes the bind address rather than `&self`. Holding a shared reference to the builder across an await made the whole cluster start future non-`Send`, because `&T` is `Send` only when `T` is `Sync` and the per-node config hook is a `dyn FnMut`. Callers spawn cluster startups onto a runtime, so that matters, and the concurrency test below needs it.

## Tests

Unit, in `preflight`:

- every candidate keeps both ranges clear of the ephemeral pool, across several cluster sizes
- candidates are spread rather than a sequential walk
- a run that would overlap its own bus range yields no candidates
- an occupied port anywhere in a range rejects the whole range
- an occupied **bus** port rejects the range too, which a client-only check would miss

Integration, in `tests/auto_port.rs`:

- a cluster takes a wrapper-chosen range, and every derived bus port fits under the ceiling
- the cluster really owns its bus ports: Redis only opens one when the node bound successfully, so a listener there is proof
- three concurrent cluster fixtures get non-overlapping client **and** bus ranges, and all stay healthy. Overlapping ranges would not merely collide on a port, they would cross the two clusters' gossip
- a partial-range collision is rejected whole, and allocation still finds the cluster a home

## Validation

`cargo test --all-features`: 314 passed, 0 failed, exit 0. `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo doc --no-deps --all-features` all exit 0.

Existing cluster tests pass unchanged, including `cluster_with_node_config`, which exercises the per-node hook the `start_nodes` extraction refactored around.

Draft because CI on this repository is currently unreliable for reasons unrelated to this change, tracked in #170 and #171.