### PR TITLE
test: correct the password_auth comment and assert an authenticated command

### DIFF
--- a/tests/server.rs
+++ b/tests/server.rs
@@ -40,11 +40,35 @@ async fn password_auth() {
         .await
         .expect("failed to start redis-server");
 
-    // The handle's cli is already configured without the password,
-    // but the server was started with wait_for_ready which uses the
-    // cli without auth. Since redis-server with requirepass still
-    // responds to PING, the handle should be alive.
+    // `start` applies the password to the handle's cli before it waits for
+    // readiness, so wait_for_ready, is_alive, and run all speak to the server
+    // over an authenticated connection. An unauthenticated cli would not get
+    // this far: redis-server under requirepass answers PING with NOAUTH rather
+    // than PONG, which `ping_is_false_when_unauthenticated` in tests/cli.rs
+    // asserts directly.
     assert!(server.is_alive().await);
+
+    server
+        .run(&["SET", "auth-key", "auth-value"])
+        .await
+        .expect("an authenticated SET should succeed");
+    let value = server
+        .run(&["GET", "auth-key"])
+        .await
+        .expect("an authenticated GET should succeed");
+    assert_eq!(value.trim(), "auth-value");
+
+    // The round trip above would pass just as well against a server with no
+    // password at all, so confirm requirepass is what the connection
+    // authenticated against.
+    let requirepass = server
+        .run(&["CONFIG", "GET", "requirepass"])
+        .await
+        .expect("CONFIG GET requirepass should succeed");
+    assert!(
+        requirepass.contains("testpass"),
+        "requirepass is not set on the server: {requirepass:?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

The comment in the `password_auth` test in `tests/server.rs` described the
opposite of what the code does, and the test asserted less than it could.

## What was wrong

The comment read:

```
// The handle's cli is already configured without the password,
// but the server was started with wait_for_ready which uses the
// cli without auth. Since redis-server with requirepass still
// responds to PING, the handle should be alive.
```

Both claims are false.

- `src/server.rs:3037` applies the password to the handle's `RedisCli` before
  `wait_for_ready` is called, so the handle's CLI is configured **with** the
  password, and `wait_for_ready` authenticates as well.
- redis-server under `requirepass` does **not** answer an unauthenticated PING.
  It replies `NOAUTH Authentication required.`, so `ping()` returns false, which
  `tests/cli.rs::ping_is_false_when_unauthenticated` already asserts.

`is_alive()` passes here because the CLI authenticates, not in spite of a
missing password.

## Changes

- The comment now states what happens: `start` applies the password to the
  handle's cli before waiting for readiness, so `wait_for_ready`, `is_alive`,
  and `run` all use an authenticated connection, and an unauthenticated cli
  would not get past readiness.
- A SET/GET round trip through `server.run`, which needs a real authenticated
  connection.
- `CONFIG GET requirepass` returning `testpass`, which distinguishes an
  authenticated connection from a server that never required auth at all.

## Verification

Two mutations of `src/server.rs`, applied locally and reverted:

| Mutation | Result |
|---|---|
| Drop `cli = cli.password(pw)` (server.rs:3037) | `start` fails: `127.0.0.1:16402 did not respond within 10s`. The unauthenticated cli never sees a PONG, so readiness never arrives. This is the direct disproof of the old comment. |
| Drop `requirepass` from the generated config (server.rs:2519) | `is_alive`, SET, and GET all pass; only the new assertion fails, with `requirepass is not set on the server: "requirepass\n\n"`. |

The second is the case the added assertion exists for: liveness and a round trip
cannot tell an authenticated connection from a server with no password.

## Gates

Run locally on macOS, redis-server 8.10.0:

- `cargo fmt --all -- --check`: pass
- `cargo clippy --all-targets --all-features -- -D warnings`: pass
- `cargo test`: pass, 244 tests across 17 targets, 0 failures

CI on this repo hangs in the Ubuntu `Run tests` step on unmodified `main` (#170),
so the local run is the gate of record here.

## Out of scope

- No change to `src/`. The library behavior is correct; only the test's comment
  and assertions changed. The two mutations above were reverted.
- No new coverage of the unauthenticated path. `tests/cli.rs` already covers
  `NOAUTH` as an error reply and `ping()` returning false without a password.
